### PR TITLE
Avoid collision in MultiQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Initial release of `nf-core/sarek`, created with the [nf-core](http://nf-co.re/)
 - [#35](https://github.com/nf-core/sarek/pull/35) - Refactor references handling
 - [#35](https://github.com/nf-core/sarek/pull/35) - use Channel values instead of `referenceMap`
 - [#37](https://github.com/nf-core/sarek/pull/37) - Bump version for Release
+- [#38](https://github.com/nf-core/sarek/pull/38) - File names before merge is based on `${idSample}_${idRun}` instead of `${idRun}`
 
 ### `Removed`
 
@@ -123,6 +124,7 @@ Initial release of `nf-core/sarek`, created with the [nf-core](http://nf-co.re/)
 - [#31](https://github.com/nf-core/sarek/pull/31) - Fix badges according to nf-core lint
 - [#31](https://github.com/nf-core/sarek/pull/31) - Fix rcolorbrewer version according to nf-core lint
 - [#33](https://github.com/nf-core/sarek/pull/33) - Fix MD Linting
+- [#38](https://github.com/nf-core/sarek/pull/38) - Avoid collision in MultiQC
 
 ### `Deprecated`
 

--- a/main.nf
+++ b/main.nf
@@ -594,7 +594,7 @@ process FastQCFQ {
 
     tag {idPatient + "-" + idRun}
 
-    publishDir "${params.outdir}/Reports/${idSample}/FastQC/${idRun}", mode: params.publishDirMode
+    publishDir "${params.outdir}/Reports/${idSample}/FastQC/${idSample}_${idRun}", mode: params.publishDirMode
 
     input:
         set idPatient, idSample, idRun, file("${idSample}_${idRun}_R1.fastq.gz"), file("${idSample}_${idRun}_R2.fastq.gz") from inputPairReadsFastQC
@@ -615,7 +615,7 @@ process FastQCBAM {
 
     tag {idPatient + "-" + idRun}
 
-    publishDir "${params.outdir}/Reports/${idSample}/FastQC/${idRun}", mode: params.publishDirMode
+    publishDir "${params.outdir}/Reports/${idSample}/FastQC/${idSample}_${idRun}", mode: params.publishDirMode
 
     input:
         set idPatient, idSample, idRun, file("${idSample}_${idRun}.bam") from inputBAMFastQC

--- a/main.nf
+++ b/main.nf
@@ -597,7 +597,7 @@ process FastQCFQ {
     publishDir "${params.outdir}/Reports/", mode: params.publishDirMode
 
     input:
-        set idPatient, idSample, idRun, file("${idRun}_R1.fastq.gz"), file("${idRun}_R2.fastq.gz") from inputPairReadsFastQC
+        set idPatient, idSample, idRun, file("${idSample}_${idRun}_R1.fastq.gz"), file("${idSample}_${idRun}_R2.fastq.gz") from inputPairReadsFastQC
 
     output:
         file("${idSample}/FastQC/${idRun}") into fastQCFQReport
@@ -606,7 +606,7 @@ process FastQCFQ {
     
     script:
     """
-    fastqc -t 2 -q ${idRun}_R1.fastq.gz ${idRun}_R2.fastq.gz
+    fastqc -t 2 -q ${idSample}_${idRun}_R1.fastq.gz ${idSample}_${idRun}_R2.fastq.gz
     mkdir -p ${idSample}/FastQC/${idRun}
     mv *_fastqc.zip *_fastqc.html ${idSample}/FastQC/${idRun}
     """
@@ -620,7 +620,7 @@ process FastQCBAM {
     publishDir "${params.outdir}/Reports/", mode: params.publishDirMode
 
     input:
-        set idPatient, idSample, idRun, file("${idRun}.bam") from inputBAMFastQC
+        set idPatient, idSample, idRun, file("${idSample}_${idRun}.bam") from inputBAMFastQC
 
     output:
         file("${idSample}/FastQC/${idRun}") into fastQCBAMReport
@@ -629,7 +629,7 @@ process FastQCBAM {
 
     script:
     """
-    fastqc -t 2 -q ${idRun}.bam
+    fastqc -t 2 -q ${idSample}_${idRun}.bam
     mkdir -p ${idSample}/FastQC/${idRun}
     mv *_fastqc.zip *_fastqc.html ${idSample}/FastQC/${idRun}
     """
@@ -652,8 +652,8 @@ process MapReads {
         file(fasta) from ch_fasta
 
     output:
-        set idPatient, idSample, idRun, file("${idRun}.bam") into bamMapped
-        set idPatient, idSample, file("${idRun}.bam") into bamMappedBamQC
+        set idPatient, idSample, idRun, file("${idSample}_${idRun}.bam") into bamMapped
+        set idPatient, idSample, file("${idSample}_${idRun}.bam") into bamMappedBamQC
 
     when: step == 'mapping'
 
@@ -674,7 +674,7 @@ process MapReads {
         ${convertToFastq}
         bwa mem -K 100000000 -R \"${readGroup}\" ${extra} -t ${task.cpus} -M ${fasta} \
         ${input} | \
-        samtools sort --threads ${task.cpus} -m 2G - > ${idRun}.bam
+        samtools sort --threads ${task.cpus} -m 2G - > ${idSample}_${idRun}.bam
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -594,21 +594,19 @@ process FastQCFQ {
 
     tag {idPatient + "-" + idRun}
 
-    publishDir "${params.outdir}/Reports/", mode: params.publishDirMode
+    publishDir "${params.outdir}/Reports/${idSample}/FastQC/${idRun}", mode: params.publishDirMode
 
     input:
         set idPatient, idSample, idRun, file("${idSample}_${idRun}_R1.fastq.gz"), file("${idSample}_${idRun}_R2.fastq.gz") from inputPairReadsFastQC
 
     output:
-        file("${idSample}/FastQC/${idRun}") into fastQCFQReport
+        file("*.{html.zip}") into fastQCFQReport
 
     when: step == 'mapping' && !('fastqc' in skipQC)
     
     script:
     """
     fastqc -t 2 -q ${idSample}_${idRun}_R1.fastq.gz ${idSample}_${idRun}_R2.fastq.gz
-    mkdir -p ${idSample}/FastQC/${idRun}
-    mv *_fastqc.zip *_fastqc.html ${idSample}/FastQC/${idRun}
     """
 }
 
@@ -617,21 +615,19 @@ process FastQCBAM {
 
     tag {idPatient + "-" + idRun}
 
-    publishDir "${params.outdir}/Reports/", mode: params.publishDirMode
+    publishDir "${params.outdir}/Reports/${idSample}/FastQC/${idRun}", mode: params.publishDirMode
 
     input:
         set idPatient, idSample, idRun, file("${idSample}_${idRun}.bam") from inputBAMFastQC
 
     output:
-        file("${idSample}/FastQC/${idRun}") into fastQCBAMReport
+        file("*.{html.zip}") into fastQCBAMReport
 
     when: step == 'mapping' && !('fastqc' in skipQC)
 
     script:
     """
     fastqc -t 2 -q ${idSample}_${idRun}.bam
-    mkdir -p ${idSample}/FastQC/${idRun}
-    mv *_fastqc.zip *_fastqc.html ${idSample}/FastQC/${idRun}
     """
 }
 
@@ -964,14 +960,14 @@ process BamQC {
 
     tag {idPatient + "-" + idSample}
 
-    publishDir "${params.outdir}/Reports/", mode: params.publishDirMode
+    publishDir "${params.outdir}/Reports/${idSample}/bamQC", mode: params.publishDirMode
 
     input:
         set idPatient, idSample, file(bam) from bamBamQC
         file(targetBED) from ch_targetBED
 
     output:
-        file("${idSample}/bamQC/${bam.baseName}") into bamQCReport
+        file("${bam.baseName}") into bamQCReport
 
     when: !('bamqc' in skipQC)
 
@@ -987,7 +983,7 @@ process BamQC {
         -nt ${task.cpus} \
         -skip-duplicated \
         --skip-dup-mode 0 \
-        -outdir ${idSample}/bamQC/${bam.baseName} \
+        -outdir ${bam.baseName} \
         -outformat HTML
     """
 }
@@ -2371,9 +2367,9 @@ process MultiQC {
     input:
         file (multiqcConfig) from Channel.value(params.multiqc_config ? file(params.multiqc_config) : "")
         file (versions) from yamlSoftwareVersion
-        file ('*/bamQC/*') from bamQCReport.collect().ifEmpty([])
+        file ('bamQC/*') from bamQCReport.collect().ifEmpty([])
         file ('BCFToolsStats/*') from bcftoolsReport.collect().ifEmpty([])
-        file ('*/FastQC/*') from fastQCReport.collect().ifEmpty([])
+        file ('FastQC/*') from fastQCReport.collect().ifEmpty([])
         file ('MarkDuplicates/*') from markDuplicatesReport.collect().ifEmpty([])
         file ('SamToolsStats/*') from samtoolsStatsReport.collect().ifEmpty([])
         file ('snpEff/*') from snpeffReport.collect().ifEmpty([])

--- a/main.nf
+++ b/main.nf
@@ -600,7 +600,7 @@ process FastQCFQ {
         set idPatient, idSample, idRun, file("${idSample}_${idRun}_R1.fastq.gz"), file("${idSample}_${idRun}_R2.fastq.gz") from inputPairReadsFastQC
 
     output:
-        file("*.{html.zip}") into fastQCFQReport
+        file("*.{html,zip}") into fastQCFQReport
 
     when: step == 'mapping' && !('fastqc' in skipQC)
     
@@ -621,7 +621,7 @@ process FastQCBAM {
         set idPatient, idSample, idRun, file("${idSample}_${idRun}.bam") from inputBAMFastQC
 
     output:
-        file("*.{html.zip}") into fastQCBAMReport
+        file("*.{html,zip}") into fastQCBAMReport
 
     when: step == 'mapping' && !('fastqc' in skipQC)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -115,6 +115,7 @@ profiles {
     singularity.enabled = false
   }
   singularity {
+    autoMounts = true
     docker.enabled = false
     singularity.enabled = true
   }


### PR DESCRIPTION
- File names before merge is based on `${idSample}_${idRun}` instead of `${idRun}`

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/sarek branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/sarek)
 - [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [X] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [X] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md
