### PR TITLE
Fix automated VEP builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     environment:
       GENOME: GRCh37
       SPECIES: homo_sapiens
-      VEP_VERSION: "95"
+      VEP_VERSION: "98"
     steps:
       - checkout
       - setup_remote_docker
@@ -55,21 +55,21 @@ jobs:
     environment:
       GENOME: GRCh38
       SPECIES: homo_sapiens
-      VEP_VERSION: "95"
+      VEP_VERSION: "98"
 
   vepgrcm38:
     << : *buildvep
     environment:
       GENOME: GRCm38
       SPECIES: mus_musculus
-      VEP_VERSION: "95"
+      VEP_VERSION: "98"
 
   vepcanfam3_1:
     << : *buildvep
     environment:
       GENOME: CanFam3.1
       SPECIES: canis_familiaris
-      VEP_VERSION: "95"
+      VEP_VERSION: "98"
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [#40](https://github.com/nf-core/sarek/pull/40) - Fix issue with `publishDirMode` within `test` profile
 - [#42](https://github.com/nf-core/sarek/pull/42) - Fix typos, and minor updates in `README.md`
+- [#43](https://github.com/nf-core/sarek/pull/43) - Fix automated `VEP` builds with circleCI
 
 ## [2.5] - Ålkatj
 


### PR DESCRIPTION
- Fix automated VEP builds
(when updating VEP, I forgot to update the cache version in the circleCI yaml file)

Many thanks to contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/sarek branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/sarek)
 - [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [X] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [X] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** [guidelines](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)