### PR TITLE
Remove label memory_max from BaseRecalibrator process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#43](https://github.com/nf-core/sarek/pull/43) - Fix automated `VEP` builds with circleCI
 - [#54](https://github.com/nf-core/sarek/pull/54) - Apply fixes from release `2.5.1`
 - [#58](https://github.com/nf-core/sarek/pull/58) - Fix issue with `.interval_list` file from the GATK bundle [#56](https://github.com/nf-core/sarek/issues/56) that was not recognized in the `CreateIntervalsBed` process
+- [#73](https://github.com/nf-core/sarek/pull/73) - Fix issue with label `memory_max` for `BaseRecalibrator` process [#72](https://github.com/nf-core/sarek/issues/72)
 
 ## [2.5.1] - Årjep-Ålkatjjekna
 

--- a/main.nf
+++ b/main.nf
@@ -801,7 +801,6 @@ bamBaseRecalibrator = bamBaseRecalibrator.dump(tag:'BAM FOR BASERECALIBRATOR')
 // STEP 3: CREATING RECALIBRATION TABLES
 
 process BaseRecalibrator {
-    label 'memory_max'
     label 'cpus_1'
 
     tag {idPatient + "-" + idSample + "-" + intervalBed}


### PR DESCRIPTION
-  Remove label `memory_max` from `BaseRecalibrator` process to fix #72

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/sarek branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/sarek)
 - [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [X] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [X] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** [guidelines](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)