### PR TITLE
added cluster config files and comments to main.nf

### DIFF
--- a/conf/nygc.config
+++ b/conf/nygc.config
@@ -1,0 +1,38 @@
+singularityDir = "/gpfs/commons/home/adoane/.singularity/singularity_images_nextflow/"
+
+trace.fields = 'process,task_id,hash,name,native_id,attempt,status,exit,realtime,cpus,memory,%cpu,vmem,rss,submit,start,complete,duration,realtime,rchar,wchar'
+
+params {
+    config_profile_description = """
+                                 New York Genome Center Univa cluster profile provided by nf-core/configs.
+                                 Please run the pipeline on a compute node.
+                                 """.stripIndent()
+    config_profile_contact = 'Ashley S Doane'
+    //config_profile_url = 'https://github.com/nf-core/configs/blob/master/docs/wcm_panda.md'
+  igenomes_base = '/gpfs/commons/groups/imielinski_lab/DB/references/'
+}
+
+singularity {
+      enabled = true
+      cacheDir = singularityDir
+      autoMounts = true
+}
+
+docker.enabled = false
+
+process {
+ // beforeScript = """
+ //                   module load singularity
+ //                """
+ //                .stripIndent()
+  cpus = 16
+  executor = 'sge'
+  penv = 'smp'
+  clusterOptions = '-V'
+  memory = 90.GB
+  //scratch = true
+  time = 96.h
+  errorStrategy = {task.exitStatus in [140, 143] ? 'retry' : 'terminate'}
+  maxErrors = '-1'
+  maxRetries = 3
+}

--- a/conf/panda.config
+++ b/conf/panda.config
@@ -1,0 +1,40 @@
+singularityDir = "/athena/elementolab/scratch/asd2007/.singularity/singularity_images_nextflow"
+moduleScript = "/athena/elementolab/scratch/reference/.spackloads.sh"
+
+trace.fields = 'process,task_id,hash,name,native_id,attempt,status,exit,realtime,cpus,memory,%cpu,vmem,rss,submit,start,complete,duration,realtime,rchar,wchar'
+
+params {
+    config_profile_description = """
+                                 Weill Cornell Medicine SCU panda cluster profile provided by nf-core/configs.
+                                 Please do  not run the pipeline on a login node.
+                                 """.stripIndent()
+    config_profile_contact = 'Ashley S Doane asd2007@med.cornell.edu'
+    //config_profile_url = 'https://github.com/nf-core/configs/blob/master/docs/wcm_panda.md'
+    genomes_base = '/athena/elementolab/scratch/reference/igenomes/'
+}
+
+singularity {
+      enabled = true
+      cacheDir = singularityDir
+      autoMounts = true
+}
+
+
+
+process {
+//  beforeScript = """
+//                    source $moduleScript
+//                 """
+//                 .stripIndent()
+  clusterOptions = {"-A $params.project"}
+  cpus = 16
+  executor = 'slurm'
+  memory = 210.GB
+  queue = 'panda'
+  scratch = true
+  time = 48.h
+
+  errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
+  maxErrors = '-1'
+  maxRetries = 3
+}

--- a/main.nf
+++ b/main.nf
@@ -791,6 +791,8 @@ process MapReads {
     // adjust mismatch penalty for tumor samples
     status = statusMap[idPatient, idSample]
     extra = status == 1 ? "-B 3" : ""
+    // TODO: this command can use all requested memory and fails when piped to bwa.
+    // TODO: the bwa and samtools pipe below uses 2x the number of requested CPUs.
     convertToFastq = hasExtension(inputFile1, "bam") ? "gatk --java-options -Xmx${task.memory.toGiga()}g SamToFastq --INPUT=${inputFile1} --FASTQ=/dev/stdout --INTERLEAVE=true --NON_PF=true | \\" : ""
     input = hasExtension(inputFile1, "bam") ? "-p /dev/stdin - 2> >(tee ${inputFile1}.bwa.stderr.log >&2)" : "${inputFile1} ${inputFile2}"
     """

--- a/revisions_Doane.md
+++ b/revisions_Doane.md
@@ -1,0 +1,15 @@
+# Notes
+    - I made changes to main.nf in a private branch to deal with issues below, as my solutions may break on other systems. I added comments to main.nf, but otherwise this PR should only be adding the cluster config files, conf/panda.config and conf/nygc.config.  See comments below for changes I made on my private branch.
+    
+# Suggested revisions
+
+    - Some processes that use pipes are using more than the requested resources.  See comments in main.nf for `process MapReads`.  Commands that are piped together will run concurrently, and the resources used will be the sum of the resources for each piped command. So `bwa mem -t 2 ... | samtools sort -@2 ...` will use 4 cpus, not 2.  The sample applies for memory.  I made a private branch with specific cpu and memory values as needed for my use case (WGS), but you likely need a more generalizeable solution. 
+
+    - Feature request: option to set temp directory path or environment variable. Several processes make use of a temp directory using `/tmp`.  The compute nodes at Weill Cornell and New York Genome Center (NYGC) have limited space in `/tmp` and use the env variable `$TMPDIR`, which specifies a local scratch disc.
+    
+    - BaseRecalibrator: reduce memory resource request.  The bam files are spllit up for parallel processing, so using max memory was way overkill on my system and caused jobs to delay in queue. Something like  10G is probably more than enough.  In a private branch, I changed it to "memory_singleCPU_2_task" and this worked well for WGS data."
+    
+    - Exit code 140 for Univa grid engine could be added to base.config to resubmit job.
+    
+    - Issue: some ApplyBQSR jobs are failing with exit code 141.  Cause: In `base.config`, setting pipefail option causes jobs to sometimes fail with exit code 141.  Known issue with pipefail and exit 141.  See https://gitter.im/nextflow-io/nextflow/archives/2016/04/12 
+    Solution for now, is changing `process.shell = ['/bin/bash', '-euo', 'pipefail']` to `process.shell = ['/bin/bash', '-eu']`


### PR DESCRIPTION
# Notes
- I made changes to main.nf in a private branch to deal with issues below, as my solutions may break on other systems. I added comments to main.nf in this PR, but otherwise this PR is only adding the cluster config files, conf/panda.config and conf/nygc.config.  See comments below for changes I made on my private branch.
    
# Comments and suggestions for revision
- Some processes that use pipes are using more than the requested resources.  See comments in main.nf for `process MapReads`.  Commands that are piped together will run concurrently, and the resources used will be the sum of the resources for each piped command. So `bwa mem -t 2 ... | samtools sort -@2 ...` will use 4 cpus, not 2.  The same applies for memory.  I made a private branch with specific cpu and memory values as needed for my use case (WGS), but you likely need a more generalizable solution. 
- Feature request: option to set temp directory path or environment variable. Several processes make use of a temp directory using `/tmp`.  The compute nodes at Weill Cornell and New York Genome Center (NYGC) have very limited space in `/tmp`.  For temp directory, we use the env variable `$TMPDIR`, which specifies a local scratch disc.
- BaseRecalibrator: reduce memory resource request.  The bam files are spllit up for parallel processing, so using max memory was way overkill on my system and caused jobs to delay in queue. Something like 10G was more than enough for WGS data with ~1 billion reads/sample.  In a private branch, I changed it to "memory_singleCPU_2_task" and this worked well for WGS data.
- Exit code 140 for Univa grid engine could be added to base.config to resubmit job.
- Issue: some ApplyBQSR jobs are failing with exit code 141.  Cause: In `base.config`, setting pipefail option causes jobs to sometimes fail with exit code 141.  Known issue with pipefail and exit 141.  See https://gitter.im/nextflow-io/nextflow/archives/2016/04/12 
   - Solution I found was changing `process.shell = ['/bin/bash', '-euo', 'pipefail']` to `process.shell = ['/bin/bash', '-eu']`.  This change is not in PR.

Many thanks to the nf-core team for nf-core/sarek!
