### PR TITLE
Updated MultiQC to v1.8 to solve problem with FastQC heatmaps 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - genesplicer=1.0
   - htslib=1.9
   - manta=1.5.0
-  - multiqc=1.7
+  - multiqc=1.8
   - qualimap=2.2.2b
   - samtools=1.9
   - snpeff=4.3.1t


### PR DESCRIPTION
With MultiQC 1.7 there are problems when running FastQC multiple times, i.e. the heat map for "per base sequence content" is missing for the second time. The problem was solved in v1.8. See also https://github.com/ewels/MultiQC/issues/777

This will be useful when adding FastQC after the adapter trimming in https://github.com/nf-core/sarek/pull/117. 


# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/sarek branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/sarek)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)