### PR TITLE
AWS test trigger only on push to master

### DIFF
--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - dev
   release:
     types: [published]
 

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -1,4 +1,4 @@
-name: AWS Megatests
+name: nf-core AWS test
 # This workflow is triggered on PRs to the master branch.
 # It runs the -profile 'test' on AWS batch
 


### PR DESCRIPTION
# nf-core/sarek pull request

Set the aws trigger back to only on push to master

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/sarek branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/sarek)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)