### PR TITLE
Add possibility to run HaplotypeCaller without dbsnp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Piellorieppe is one of the main massif in the Sarek National Park.
 - [#176](https://github.com/nf-core/sarek/pull/176) - Add empty `custom` genome in `genomes.config` to allow genomes that are not in `AWS iGenomes`
 - [#179](https://github.com/nf-core/sarek/pull/179) - Add `FreeBayes` germline variant calling
 - [#180](https://github.com/nf-core/sarek/pull/180) - Now saving Mapped Bams (and creating TSV) in minimal setting
+- [#182](https://github.com/nf-core/sarek/pull/182) - Add possibility to run `HaplotypeCaller` without `dbsnp` so it can be used to actually generate vcfs to build a set of known sites (cf [gatkforums](https://gatkforums.broadinstitute.org/gatk/discussion/1247/what-should-i-use-as-known-variants-sites-for-running-tool-x))
 
 ### Changed - [2.6dev]
 

--- a/main.nf
+++ b/main.nf
@@ -1223,7 +1223,7 @@ process IndexBamFile {
 
     tag {idPatient + "-" + idSample}
 
-    publishDir "${params.outdir}/Preprocessing/${idSample}/Mapped/${it}", mode: params.publish_dir_mode
+    publishDir "${params.outdir}/Preprocessing/${idSample}/Mapped", mode: params.publish_dir_mode
 
     input:
         set idPatient, idSample, file(bam) from bam_mapped_merged_to_index
@@ -1819,13 +1819,14 @@ process HaplotypeCaller {
 
     script:
     intervalsOptions = params.no_intervals ? "" : "-L ${intervalBed}"
+    dbsnpOptions = params.dbsnp ? "--D ${dbsnp}" : ""
     """
     gatk --java-options "-Xmx${task.memory.toGiga()}g -Xms6000m -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10" \
         HaplotypeCaller \
         -R ${fasta} \
         -I ${bam} \
         ${intervalsOptions} \
-        -D ${dbsnp} \
+        ${dbsnpOptions} \
         -O ${intervalBed.baseName}_${idSample}.g.vcf \
         -ERC GVCF
     """
@@ -1857,6 +1858,7 @@ process GenotypeGVCFs {
     script:
     // Using -L is important for speed and we have to index the interval files also
     intervalsOptions = params.no_intervals ? "" : "-L ${intervalBed}"
+    dbsnpOptions = params.dbsnp ? "--D ${dbsnp}" : ""
     """
     gatk --java-options -Xmx${task.memory.toGiga()}g \
         IndexFeatureFile \
@@ -1866,7 +1868,7 @@ process GenotypeGVCFs {
         GenotypeGVCFs \
         -R ${fasta} \
         ${intervalsOptions} \
-        -D ${dbsnp} \
+        ${dbsnpOptions} \
         -V ${gvcf} \
         -O ${intervalBed.baseName}_${idSample}.vcf
     """


### PR DESCRIPTION
# nf-core/sarek pull request

- Add possibility to run HaplotypeCaller without dbsnp to build a set of known sites
- cf https://gatkforums.broadinstitute.org/gatk/discussion/1247/what-should-i-use-as-known-variants-sites-for-running-tool-x

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/sarek branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/sarek)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)