### PR TITLE
Replace tmp_dir directory in BaseRecalibration

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1571,7 +1571,7 @@ process BaseRecalibrator {
         BaseRecalibrator \
         -I ${bam} \
         -O ${prefix}${idSample}.recal.table \
-        --tmp-dir /tmp \
+        --tmp-dir . \
         -R ${fasta} \
         ${intervalsOptions} \
         ${dbsnpOptions} \


### PR DESCRIPTION
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/sarek branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/sarek)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)

I  experienced issues with the option `--tmp_dir` in the process `BaseRecalibration` being hardcoded to `/tmp` since in our setup this directory is not big enough. We use the setting `scratch=true` or `scratch = /my/directory/` instead, which writes the intermediate files there. In an initial discussion, we agreed on using `${TMPDIR:-/tmp}`, however I still experienced issues: when testing with  `scratch = /my/directory/`, intermediate files were still written to tmp.

For the process `MarkDuplicates` the setting is `--TMP_DIR = .` . I tested the same for `BaseRecalibration`. This results in:

`scratch = true` : Intermediate files are written to /scratch
`scratch = /my/dir`: Intermediate files are written to the directory
`scratch = false`: Intermediate files are written to a tmp directory within the work-dir

This behaviour appears desirable to me and is somewhat in line with Harshil's proposal to always specify the work directory.