### PR TITLE
keeping intervals param deafult for all cases in GetPileupSummaries

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -2580,7 +2580,7 @@ process PileupSummariesForMutect2 {
     when: 'mutect2' in tools
 
     script:
-    intervalsOptions = params.no_intervals ? "" : "-L ${intervalBed}"
+    intervalsOptions = params.no_intervals ? "-L ${germlineResource}" : "-L ${intervalBed}"
     """
     gatk --java-options "-Xmx${task.memory.toGiga()}g" \
         GetPileupSummaries \


### PR DESCRIPTION
# nf-core/sarek pull request

This PR address issue #299 

if no interval is provided, all the variants will be used in the same interval param.

Based on, this [doc](https://gatk.broadinstitute.org/hc/en-us/articles/360037593451-GetPileupSummaries) -
> Although the sites (-L) and variants (-V) resources will often be identical, this need not be the case.

If a subset of variants is being used then the interval bed file can come into the picture.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)