### PR TITLE
Retry tasks with exit code 247 for added memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dev](https://github.com/nf-core/sarek/tree/dev)
+
+### Added
+
+- [#353](https://github.com/nf-core/sarek/pull/353) - Add support for task retries with exit code 247 (exhibited by Picard MarkDuplicates)
+
 ## [2.7](https://github.com/nf-core/sarek/releases/tag/2.7) - Pårte
 
 Pårte is one of the main massif in the Sarek National Park.

--- a/conf/base.config
+++ b/conf/base.config
@@ -15,7 +15,7 @@ process {
   time = {check_resource(24.h * task.attempt)}
   shell = ['/bin/bash', '-euo', 'pipefail']
 
-  errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+  errorStrategy = { task.exitStatus in [143,137,104,134,139,247] ? 'retry' : 'finish' }
   maxErrors = '-1'
   maxRetries = 3
 


### PR DESCRIPTION
## Description

I've noticed that Picard MarkDuplicates can fail with the exit code 247 because of insufficient memory. I can confirm that increasing the memory allocation from the default of 7 GB to 16 GB resolved the issue. Indeed, the `peakVmem` after this adjustment was 13.6 GB. I figured that it would be nice if the workflow auto-retried the task with double and then triple the default memory allocation (in this case, doubling would have sufficed). 

```
process {
  withName:MarkDuplicates {
    memory = '16.GB'
  }
}
```