### PR TITLE
add bcftools sort step before tabix index

### DIFF
--- a/bin/concatenateVCFs.sh
+++ b/bin/concatenateVCFs.sh
@@ -103,5 +103,5 @@ if [ ! -z ${targetBED+x} ]; then
     tabix ${outputFile}.gz
 else
     # Rename the raw calls as WGS results
-    for f in rawcalls*; do mv -v $f ${outputFile}${f#rawcalls.vcf}; done
+    for f in rawcalls.vcf*; do mv -v $f ${outputFile}${f#rawcalls.vcf}; done
 fi

--- a/bin/concatenateVCFs.sh
+++ b/bin/concatenateVCFs.sh
@@ -84,14 +84,15 @@ then
                 tail -n +$((L+1)) ${vcf}
             done
         done
-    ) | bgzip -@${cpus} > rawcalls.vcf.gz
-    tabix rawcalls.vcf.gz
+    ) | bgzip -@${cpus} > rawcalls.unsorted.vcf.gz
 else
     VCF=$(ls no_intervals*.vcf)
-    cp $VCF rawcalls.vcf
-    bgzip -@${cpus} rawcalls.vcf
-    tabix rawcalls.vcf.gz
+    cp $VCF rawcalls.unsorted.vcf
+    bgzip -@${cpus} rawcalls.unsorted.vcf
 fi
+
+bcftools sort rawcalls.unsorted.vcf.gz | bgzip > rawcalls.vcf.gz
+tabix -p vcf rawcalls.vcf.gz
 
 set +u
 


### PR DESCRIPTION
Add `bcftools sort` step before tabix index to deal with different Unix sort versions in the `Concatenate_VCFs.sh` script.

The motivation for this PR was making Sarek work in my system using a conda environment, not docker. My system is GNU core utils version 8.22. Tabix was complaining about the order of chromosomes after concatenation, sorting the VCF before calling tabix fixes the issue. 

This is the particular command I used:
```
nextflow run tron-bioinformatics/sarek -r $SAREK_VERSION --input $input --outdir $output \
--step variant_calling --tools HaplotypeCaller \
--genome custom \
--fasta $REFERENCE_GENOME_FASTA --fasta_fai $REFERENCE_GENOME_FASTA_INDEX \
--dict $REFERENCE_GENOME_DICT \
--intervals $BED \
--dbsnp $DBSNP --dbsnp_tbi $DBSNP_TABIX \
--germline_resource $GNOMAD \
--igenomes_ignore \
 -profile conda,standard,finish
```

