### PR TITLE
changed string to number for vep_cache_version in nextflow_schema.json

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -563,7 +563,7 @@
                     "help_text": "If you use AWS iGenomes or a local resource with genomes.conf, this has already been set for you appropriately."
                 },
                 "vep_cache_version": {
-                    "type": "string",
+                    "type": "number",
                     "fa_icon": "fas fa-tag",
                     "description": "VEP cache version"
                 },


### PR DESCRIPTION
I am sorry that I haven't run any test suits, but the change from string to number for one config option should be quite safe. See issue #446

I don't know how you do with versioning. How this change would bump your version number. Let me know and I can add anything else missing. This would also be helpful for when I make the new dev branch PR of issue #441.