### PR TITLE
No req input.csv

### DIFF
--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -71,12 +71,6 @@ class WorkflowMain {
 
         // Check the hostnames against configured profiles
         NfcoreTemplate.hostName(workflow, params, log)
-
-        // Check input has been provided
-        if (!params.input) {
-            log.error "Please provide an input samplesheet to the pipeline e.g. '--input samplesheet.csv'"
-            System.exit(1)
-        }
     }
 
     //

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -11,20 +11,9 @@
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
             "required": [
-                "input",
                 "step"
             ],
             "properties": {
-                "input": {
-                    "type": "string",
-                    "format": "file-path",
-                    "mimetype": "text/csv",
-                    "pattern": "\\.csv$",
-                    "schema": "assets/schema_input.json",
-                    "description": "Path to comma-separated file containing information about the samples in the experiment.",
-                    "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with a header row. See [usage docs](https://nf-co.re/sarek/usage#input).",
-                    "fa_icon": "fas fa-file-csv"
-                },
                 "step": {
                     "type": "string",
                     "default": "mapping",
@@ -39,6 +28,16 @@
                         "annotate",
                         "controlfreec"
                     ]
+                },
+                "input": {
+                    "type": "string",
+                    "format": "file-path",
+                    "mimetype": "text/csv",
+                    "pattern": "\\.csv$",
+                    "schema": "assets/schema_input.json",
+                    "description": "Path to comma-separated file containing information about the samples in the experiment.",
+                    "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with a header row. See [usage docs](https://nf-co.re/sarek/usage#input).",
+                    "fa_icon": "fas fa-file-csv"
                 },
                 "outdir": {
                     "type": "string",


### PR DESCRIPTION
# nf-core/sarek pull request

This is to address the issue #451. @maxulysse did a good job at pointing out the expected style for the `params.step` options. During this confusion, I realized that for `sarek/dev` both `nextflow_schema.json` and `lib/WorkflowMain.groovy` there is an explicit requirement to include `params.input `

However `workflows/sarek.nf` includes a case finding step (lines 48-60) designed to handle the different steps and their corresponding pre-built csv files. In order to recapture the utility of the `params.step` functionality, I have removed these explicit requirements.

In the lines 48-60 of `workflows/sarek.nf` covers the following cases

- input.csv designated
  - valid input.csv
    - nothing's changed. uses step to only do steps 
  - invalid input.csv
    - nothing's changed. will throw errors as any bad input.csv will
- no input.csv
  - valid step: mapping
    - throw error. mapping step must have a designated input.csv (desired)
  - valid step: prepare_recalibration -> annotate
    - try to find the prebuilt csv file to restart the job
  - invalid step: 
    - throw an error detailing an unknown step (desired)

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core lint .`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
    - Usage documentation is way out of date

