### PR TITLE
modules config update - preprocessing refactor

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -286,7 +286,6 @@ process {
     withName: 'GATK4_MARKDUPLICATES' {
         ext.args         = '-REMOVE_DUPLICATES false -VALIDATION_STRINGENCY LENIENT'
         ext.prefix       = {"${meta.id}.md"}
-        ext.when         = { !params.use_gatk_spark || (params.use_gatk_spark && !params.use_gatk_spark.contains('markduplicates')) }
         //publishDir       = [
         //    enabled: false
         //    mode: "${params.publish_dir_mode}",
@@ -331,10 +330,10 @@ process {
         ]
     }
     withName: 'SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES' {
-        ext.when         = { !(params.skip_tools && params.skip_tools.contains('markduplicates')) }
+        ext.when         = { params.skip_tools && params.skip_tools.contains('markduplicates') }
     }
     withName: 'GATK4_MARKDUPLICATES|SAMTOOLS_BAM_TO_CRAM_DUPLICATES' {
-        ext.when         = { !(params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates')) }
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('markduplicates')) && !(params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates')) }
     }
     withName: 'SAMTOOLS_BAM_TO_CRAM_SPARK' {
         ext.when         = { !(params.skip_tools && (params.skip_tools.contains('bamqc') || params.skip_tools.contains('deeptools'))) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -646,7 +646,7 @@ process {
 
 }
 
-if ((params.tools) && (params.tools.contains('snpeff') || params.tools.contains('merge'))) {
+if (params.tools && (params.tools.contains('snpeff') || params.tools.contains('merge'))) {
     process {
         withName: 'NFCORE_SAREK:SAREK:ANNOTATE:ANNOTATION_SNPEFF:ANNOTATION_BGZIPTABIX' {
             ext.prefix = {"${meta.id}_snpEff.ann.vcf"}
@@ -654,7 +654,7 @@ if ((params.tools) && (params.tools.contains('snpeff') || params.tools.contains(
     }
 }
 
-if ((params.tools) && (params.tools.contains('vep'))) {
+if (params.tools && (params.tools.contains('vep'))) {
     process {
         withName: 'NFCORE_SAREK:SAREK:ANNOTATE:ANNOTATION_ENSEMBLVEP:ANNOTATION_BGZIPTABIX' {
             ext.prefix = {"${meta.id}_VEP.ann.vcf"}
@@ -662,7 +662,7 @@ if ((params.tools) && (params.tools.contains('vep'))) {
     }
 }
 
-if ((params.tools) && (params.tools.contains('merge'))) {
+if (params.tools && (params.tools.contains('merge'))) {
     process {
         withName: 'NFCORE_SAREK:SAREK:ANNOTATE:MERGE_ANNOTATE:ANNOTATION_BGZIPTABIX' {
             ext.prefix = {"${meta.id}_snpEff_VEP.ann.vcf"}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -222,27 +222,40 @@ process {
 // MAPPING
 process {
 
-    withName: "BWA.*MEM" {
-        ext.args         = { meta.status == 1 ? '-K 100000000 -M -B 3' : '-K 100000000 -M' }
-        ext.prefix       = { params.split_fastq > 1 ?  "${meta.id}".concat('.').concat(reads.get(0).name.findAll(/part_([0-9]+)?/).last()) : "" }
-    }
-
-    withName: 'INDEX_MAPPING' {
-        publishDir       = [
-            enabled: true,
-            mode: "${params.publish_dir_mode}",
-            path: { "${params.outdir}/preprocessing/${meta.id}/mapped" },
-            pattern: "*{bam,bai}"
-        ]
-    }
-
     withName: "SEQKIT_SPLIT2" {
         ext.args         = { "--by-size ${params.split_fastq}" }
+        ext.when         = { params.split_fastq > 1 }
         publishDir       = [
             enabled: "${params.save_split_fastqs}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: "BWAMEM1_MEM" {
+        ext.when         = { params.aligner == "bwa-mem" }
+    }
+    withName: "BWAMEM2_MEM" {
+        ext.when         = { params.aligner == "bwa-mem2" }
+    }
+
+    withName: "BWA.*MEM" {
+        ext.args         = { meta.status == 1 ? '-K 100000000 -M -B 3' : '-K 100000000 -M' }
+        ext.prefix       = { params.split_fastq > 1 ?  "${meta.id}".concat('.').concat(reads.get(0).name.findAll(/part_([0-9]+)?/).last()) : "" }
+    }
+
+    withName: 'MERGE_MAPPING' {
+        ext.when         = { params.save_bam_mapped || (params.skip_tools && params.skip_tools.contains('markduplicates')) }
+    }
+
+    withName: 'INDEX_MAPPING' {
+        ext.when         = { params.save_bam_mapped || (params.skip_tools && params.skip_tools.contains('markduplicates')) }
+        publishDir       = [
+            enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/mapped" },
+            pattern: "*{bam,bai}"
         ]
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -15,15 +15,15 @@
 process {
 
     publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         mode: "${params.publish_dir_mode}",
+        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
-            path: { "${params.outdir}/pipeline_info" },
             mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/pipeline_info" },
             pattern: '*_versions.yml'
         ]
     }
@@ -35,9 +35,9 @@ process {
     withName: 'BWAMEM1_INDEX' {
         ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem" }
         publishDir = [
-            path: { "${params.outdir}/reference/bwa" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/bwa" },
             pattern: "bwa"
         ]
     }
@@ -45,18 +45,18 @@ process {
     withName: 'BWAMEM2_INDEX' {
         ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem2" }
         publishDir = [
-            path: { "${params.outdir}/reference/bwamem2" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/bwamem2" },
             pattern: "bwa"
         ]
 
     }
     withName: 'CREATE_INTERVALS_BED' {
         publishDir = [
-            path: { "${params.outdir}/reference/intervals" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/intervals" },
             pattern: "*bed"
         ]
     }
@@ -64,19 +64,19 @@ process {
     withName: 'GATK4_CREATESEQUENCEDICTIONARY' {
         ext.when   = { !params.dict && params.step != "annotate" && params.step != "controlfreec" }
         publishDir = [
-            path: { "${params.outdir}/reference/gatk4" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/gatk4" },
             pattern: "*dict"
         ]
     }
 
     withName: 'MSISENSORPRO_SCAN' {
-    ext.when   = { params.tools && params.tools.contains('msisensorpro') }
+        ext.when   = { params.tools && params.tools.contains('msisensorpro') }
         publishDir = [
-            path: { "${params.outdir}/reference/msi" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/msi" },
             pattern: "*list"
         ]
     }
@@ -84,30 +84,29 @@ process {
     withName: 'SAMTOOLS_FAIDX' {
         ext.when   = { !params.fasta_fai && params.step != "annotate" }
         publishDir = [
-            path: { "${params.outdir}/reference/fai" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/fai" },
             pattern: "*fai"
         ]
     }
 
     withName: 'TABIX_BGZIPTABIX' {
+        ext.prefix = {"${meta.id}.bed"}
         publishDir = [
-            path: { "${params.outdir}/reference/target" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/target" },
             pattern: "*bed.gz"
         ]
-        ext.prefix = {"${meta.id}.bed"}
-
     }
 
     withName: 'TABIX_DBSNP' {
         ext.when   = { !params.dbsnp_tbi && params.dbsnp && (params.step == "mapping" || params.step == "prepare_recalibration") || params.tools && (params.tools.contains('controlfreec') || params.tools.contains('haplotypecaller') || params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
         publishDir = [
-            path: { "${params.outdir}/reference/dbsnp" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/dbsnp" },
             pattern: "*vcf.gz.tbi"
         ]
     }
@@ -115,9 +114,9 @@ process {
     withName: 'TABIX_GERMLINE_RESOURCE' {
         ext.when   = { !params.germline_resource_tbi && params.germline_resource && params.tools && params.tools.contains('mutect2') }
         publishDir = [
-            path: { "${params.outdir}/reference/germline_resource" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/germline_resource" },
             pattern: "*vcf.gz.tbi"
         ]
     }
@@ -125,19 +124,19 @@ process {
     withName: 'TABIX_KNOWN_INDELS' {
         ext.when   = { !params.known_indels_tbi && params.known_indels && (params.step == 'mapping' || params.step == 'prepare_recalibration') }
         publishDir = [
-            path: { "${params.outdir}/reference/known_indels" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/known_indels" },
             pattern: "*vcf.gz.tbi"
         ]
     }
 
     withName: 'TABIX_PON' {
-    ext.when   = { !params.pon_tbi && params.pon && params.tools && (params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
+        ext.when   = { !params.pon_tbi && params.pon && params.tools && (params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
         publishDir = [
-            path: { "${params.outdir}/reference/pon" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/reference/pon" },
             pattern: "*vcf.gz.tbi"
         ]
     }
@@ -150,8 +149,8 @@ process{
     }
 
     withName: 'SAMBLASTER' {
-        ext.prefix       = {"${meta.id}_unsorted_tagged"}
         ext.args         = '-M --addMateTags'
+        ext.prefix       = {"${meta.id}_unsorted_tagged"}
     }
 
     withName: 'CALLUMICONSENSUS' {
@@ -164,8 +163,8 @@ if(params.umi_read_structure){
     process {
         withName: "NFCORE_SAREK:SAREK:CREATE_UMI_CONSENSUS:BWA.*_MEM" {
             ext.args = '-p -C -M'
-            ext.prefix = {"${meta.id}.umi_unsorted"}
             ext.args2 = '-bS'
+            ext.prefix = {"${meta.id}.umi_unsorted"}
         }
     }
 }
@@ -203,17 +202,17 @@ process {
     withName: 'FASTQC' {
         ext.args         = '--quiet'
         publishDir       = [
-            path: { "${params.outdir}/reports/fastqc/${meta.id}" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/reports/fastqc/${meta.id}" }
         ]
     }
     withName: 'TRIMGALORE' {
         ext.args         = '--fastqc'
         publishDir       = [
-            path: { "${params.outdir}/trimgalore/${meta.id}" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/trimgalore/${meta.id}" }
         ]
     }
     // withName: 'MULTIQC' {
@@ -226,15 +225,15 @@ process {
 process {
 
     withName: "BWA.*MEM" {
-        ext.args         = { meta.status == 1 ? '-K 100000000 -M -B 3' : '-K 100000000 -M' }
-        ext.prefix       = { params.split_fastq > 1 ?  "${meta.id}".concat('.').concat(reads.get(0).name.findAll(/part_([0-9]+)?/).last()) : "" }
+        ext.args   = { meta.status == 1 ? '-K 100000000 -M -B 3' : '-K 100000000 -M' }
+        ext.prefix = { params.split_fastq > 1 ?  "${meta.id}".concat('.').concat(reads.get(0).name.findAll(/part_([0-9]+)?/).last()) : "" }
     }
 
     withName: 'INDEX_MAPPING' {
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/mapped" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/mapped" },
             pattern: "*{bam,bai}"
         ]
     }
@@ -242,9 +241,9 @@ process {
     withName: "SEQKIT_SPLIT2" {
         ext.args         = { "--by-size ${params.split_fastq}" }
         publishDir = [
-            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_split_fastqs}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -265,9 +264,9 @@ process {
     withName: 'GATK4_ESTIMATELIBRARYCOMPLEXITY' {
         ext.prefix       = {"${meta.id}.md"}
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             pattern: "*{metrics}"
         ]
     }
@@ -275,18 +274,18 @@ process {
         ext.args         = '-REMOVE_DUPLICATES false -VALIDATION_STRINGENCY LENIENT'
         ext.prefix       = {"${meta.id}.md"}
         //publishDir       = [
-        //    path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
-        //    mode: "${params.publish_dir_mode}",
         //    enabled: false
+        //    mode: "${params.publish_dir_mode}",
+        //    path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
         //]
     }
     withName: 'GATK4_MARKDUPLICATES_SPARK' {
         ext.args         = '--remove-sequencing-duplicates false -VS LENIENT'
         ext.suffix       = '.md'
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             pattern: "*{cram,crai}"
         ]
     }
@@ -294,39 +293,39 @@ process {
         ext.args         = '--paint-chromosome-limits --genome-gc-distr HUMAN -skip-duplicated --skip-dup-mode 0 -outformat HTML'
         ext.suffix       = '.mapped'
         publishDir       = [
-            path: { "${params.outdir}/reports/qualimap/${meta.id}" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/reports/qualimap/${meta.id}" }
         ]
     }
     withName: 'SAMTOOLS_STATS' {
         publishDir       = [
-            path: { "${params.outdir}/reports/samtools_stats/${meta.id}" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/reports/samtools_stats/${meta.id}" }
         ]
     }
     withName: 'DEEPTOOLS_BAMCOVERAGE' {
         publishDir       = [
-            path: { "${params.outdir}/reports/deeptools/${meta.id}" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/reports/deeptools/${meta.id}" }
         ]
     }
     withName: 'SAMTOOLS_BAM_TO_CRAM|SAMTOOLS_BAM_TO_CRAM_SPARK' {
         ext.suffix       = '.md'
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             pattern: "*{cram,crai}"
         ]
     }
     withName: 'INDEX_MARKDUPLICATES' {
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             pattern: "*{cram,crai}"
         ]
     }
@@ -335,13 +334,13 @@ process {
 // PREPARE_RECALIBRATION
 process {
     withName: 'BASERECALIBRATOR|BASERECALIBRATOR_SPARK|GATHERBQSRREPORTS' {
+        ext.prefix = {"${meta.id}.recal"}
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/recal_table" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/recal_table" },
             pattern: "*.table"
         ]
-        ext.prefix = {"${meta.id}.recal"}
     }
 }
 
@@ -353,9 +352,9 @@ process {
     withName: 'SAMTOOLS_MERGE_CRAM' {
         ext.suffix       = '.recal'
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/recalibrated" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/recalibrated" },
             pattern: "*cram"
         ]
     }
@@ -363,25 +362,25 @@ process {
         ext.args         = '--paint-chromosome-limits --genome-gc-distr HUMAN -skip-duplicated --skip-dup-mode 0 -outformat HTML'
         ext.suffix       = '.recal'
         publishDir       = [
-            path: { "${params.outdir}/reports/qualimap/${meta.id}" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/reports/qualimap/${meta.id}" }
         ]
     }
     withName: 'INDEX_RECALIBRATE' {
         ext.suffix       = 'recal'
         publishDir       = [
-            path: { "${params.outdir}/preprocessing/${meta.id}/recalibrated" },
-            mode: "${params.publish_dir_mode}",
             enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/preprocessing/${meta.id}/recalibrated" },
             pattern: "*{recal.cram,recal.cram.crai}"
         ]
     }
     withName: 'SAMTOOLS_STATS' {
         publishDir       = [
-            path: { "${params.outdir}/reports/samtools_stats/${meta.id}" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/reports/samtools_stats/${meta.id}" }
         ]
     }
 }
@@ -389,107 +388,107 @@ process {
 // GERMLINE & TUMOR ONLY Variant_Calling
 process{
     withName: 'CONCAT_VCF_DEEPVARIANT' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" }
+        ]
     }
     withName: 'CONCAT_GVCF_DEEPVARIANT' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}.g"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" }
+        ]
     }
 
     withName: 'CONCAT_VCF_FREEBAYES' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" }
+        ]
 
     }
     withName: 'CONCAT_VCF_HAPLOTYPECALLER' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}.g"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" }
+        ]
     }
     withName: 'CONCAT_VCF_MANTA_.*' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/manta" }
+        ]
     }
     withName: 'CONCAT_VCF_MUTECT2' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" }
+        ]
     }
     withName: 'CONCAT_VCF_STRELKA' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" }
+        ]
     }
     withName: 'DEEPVARIANT' {
         ext.args         = { params.wes ?  "--model_type WES" : "--model_type WGS" }
     }
     withName: 'FREEBAYES' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "${params.no_intervals}"
-        ]
         ext.args         = '--min-alternate-fraction 0.1 --min-mapping-quality 1'
+        publishDir       = [
+            enabled: "${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/manta" }
+        ]
     }
     // withName: 'GATK4_CALCULATECONTAMINATION'{
-    //     publishDir        = [
-    //         mode: "${params.publish_dir_mode}",
-    //         enabled: false
-    //     ]
     //    ext.args          = ''
+    //     publishDir        = [
+    //         enabled: false,
+    //         mode: "${params.publish_dir_mode}"
+    //     ]
     //}
     //withName: 'GATK4_FILTERMUTECTCALLS'{
-    //     publishDir        = [
-    //         mode: "${params.publish_dir_mode}",
-    //         enabled: false
-    //     ]
     //    ext.args          = ''
+    //     publishDir        = [
+    //         enabled: false,
+    //         mode: "${params.publish_dir_mode}"
+    //     ]
     //}
     //withName: 'GATK4_GETPILEUPSUMMARIES'{
-    //     publishDir        = [
-    //         mode: "${params.publish_dir_mode}",
-    //         enabled: false
-    //     ]
     //    ext.args          = ''
+    //     publishDir        = [
+    //         enabled: false,
+    //         mode: "${params.publish_dir_mode}"
+    //     ]
     //}
     withName: 'GATK4_MUTECT2'{
         publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" },
+            enabled: "${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
-            enabled: "${params.no_intervals}"
+            path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" }
         ]
     }
     //withName: 'GENOMICSDBIMPORT' {
@@ -499,50 +498,50 @@ process{
         ext.args         = '-ERC GVCF'
     }
     withName: 'MANTA_GERMLINE|MANTA_TUMORONLY|MANTA_SOMATIC' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "${params.no_intervals}"
-        ]
         ext.args         = { params.wes ? "--exome" : "" }
+        publishDir       = [
+            enabled: "${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/manta" }
+        ]
     }
     withName: 'STRELKA_GERMLINE|STRELKA_TUMORONLY|STRELKA_SOMATIC|STRELKA_BP' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "${params.no_intervals}"
-        ]
         ext.args         = { params.wes ? "--exome" : "" }
+        publishDir       = [
+            enabled: "${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" }
+        ]
     }
     withName : 'TABIX_DEEPVARIANT_VCF|TABIX_DEEPVARIANT_GVCF' {
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" }
         ]
-        ext.prefix        = {"${meta.sample}"}
     }
     withName : 'TABIX_FREEBAYES' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" },
-            mode: "${params.publish_dir_mode}",
-            enabled: true
-        ]
         ext.prefix        = {"${meta.sample}"}
+        publishDir       = [
+            enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" }
+        ]
     }
     withName : 'TABIX_HAPLOTYPECALLER' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" },
-            mode: "${params.publish_dir_mode}",
-            enabled: true
-        ]
         ext.prefix        = {"${meta.sample}"}
+        publishDir       = [
+            enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" }
+        ]
     }
     //withName: 'TIDDIT_SV' {
     //    publishDir       = [
-    //            path: { "${params.outdir}/variant_calling/${meta.sample}/tiddit" },
+    //            enabled: true,
     //            mode: "${params.publish_dir_mode}",
-    //            enabled: true
+    //            path: { "${params.outdir}/variant_calling/${meta.sample}/tiddit" }
     //            ]
     //}
 
@@ -565,34 +564,34 @@ process{
 
     withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:GATK_TUMOR_NORMAL_SOMATIC_VARIANT_CALLING:MUTECT2'{
         publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
+            enabled: "${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
-            enabled: "${params.no_intervals}"
+            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" }
         ]
     }
     withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:GATK_TUMOR_NORMAL_SOMATIC_VARIANT_CALLING:CONCAT_VCF_MUTECT2' {
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
-            mode: "${params.publish_dir_mode}",
-            enabled: "!${params.no_intervals}"
-        ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.id}"}
+        publishDir       = [
+            enabled: "!${params.no_intervals}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" }
+        ]
     }
     withName: 'GATK4_MERGEMUTECTSTATS' {
         publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
+            enabled: true,
             mode: "${params.publish_dir_mode}",
-            enabled: true
+            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" }
         ]
     }
     withName: 'GATK4_FILTERMUTECTCALLS'{
-        publishDir       = [
-            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
-            mode: "${params.publish_dir_mode}",
-            enabled: true
-        ]
         ext.prefix        = {"${meta.id}.filtered."}
+        publishDir       = [
+            enabled: true,
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" }
+        ]
     }
 }
 
@@ -637,13 +636,12 @@ process {
 
     withName: 'ANNOTATION_BGZIPTABIX' {
         publishDir       = [
-                path: { "${params.outdir}/annotation/${meta.id}" },
-                mode: "${params.publish_dir_mode}",
                 enabled: true,
+                mode: "${params.publish_dir_mode}",
+                path: { "${params.outdir}/annotation/${meta.id}" },
                 pattern: "*{gz,gz.tbi}"
         ]
     }
-
 }
 
 if (params.tools && (params.tools.contains('snpeff') || params.tools.contains('merge'))) {
@@ -668,5 +666,4 @@ if (params.tools && (params.tools.contains('merge'))) {
             ext.prefix = {"${meta.id}_snpEff_VEP.ann.vcf"}
         }
     }
-
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -14,17 +14,16 @@
 
 process {
 
-    withName: '.*' {
-        publishDir = [
-            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            mode: "${params.publish_dir_mode}",
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
+    publishDir = [
+        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+        mode: "${params.publish_dir_mode}",
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+    ]
 
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
+            mode: "${params.publish_dir_mode}",
             pattern: '*_versions.yml'
         ]
     }
@@ -37,6 +36,7 @@ process {
         ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem" }
         publishDir = [
             path: { "${params.outdir}/reference/bwa" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "bwa"
         ]
@@ -46,6 +46,7 @@ process {
         ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem2" }
         publishDir = [
             path: { "${params.outdir}/reference/bwamem2" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "bwa"
         ]
@@ -54,6 +55,7 @@ process {
     withName: 'CREATE_INTERVALS_BED' {
         publishDir = [
             path: { "${params.outdir}/reference/intervals" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*bed"
         ]
@@ -63,6 +65,7 @@ process {
         ext.when   = { !params.dict && params.step != "annotate" && params.step != "controlfreec" }
         publishDir = [
             path: { "${params.outdir}/reference/gatk4" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*dict"
         ]
@@ -72,6 +75,7 @@ process {
     ext.when   = { params.tools && params.tools.contains('msisensorpro') }
         publishDir = [
             path: { "${params.outdir}/reference/msi" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*list"
         ]
@@ -81,6 +85,7 @@ process {
         ext.when   = { !params.fasta_fai && params.step != "annotate" }
         publishDir = [
             path: { "${params.outdir}/reference/fai" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*fai"
         ]
@@ -89,6 +94,7 @@ process {
     withName: 'TABIX_BGZIPTABIX' {
         publishDir = [
             path: { "${params.outdir}/reference/target" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*bed.gz"
         ]
@@ -100,6 +106,7 @@ process {
         ext.when   = { !params.dbsnp_tbi && params.dbsnp && (params.step == "mapping" || params.step == "prepare_recalibration") || params.tools && (params.tools.contains('controlfreec') || params.tools.contains('haplotypecaller') || params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
         publishDir = [
             path: { "${params.outdir}/reference/dbsnp" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*vcf.gz.tbi"
         ]
@@ -109,6 +116,7 @@ process {
         ext.when   = { !params.germline_resource_tbi && params.germline_resource && params.tools && params.tools.contains('mutect2') }
         publishDir = [
             path: { "${params.outdir}/reference/germline_resource" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*vcf.gz.tbi"
         ]
@@ -118,6 +126,7 @@ process {
         ext.when   = { !params.known_indels_tbi && params.known_indels && (params.step == 'mapping' || params.step == 'prepare_recalibration') }
         publishDir = [
             path: { "${params.outdir}/reference/known_indels" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*vcf.gz.tbi"
         ]
@@ -127,6 +136,7 @@ process {
     ext.when   = { !params.pon_tbi && params.pon && params.tools && (params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
         publishDir = [
             path: { "${params.outdir}/reference/pon" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_reference}",
             pattern: "*vcf.gz.tbi"
         ]
@@ -194,6 +204,7 @@ process {
         ext.args         = '--quiet'
         publishDir       = [
             path: { "${params.outdir}/reports/fastqc/${meta.id}" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
@@ -201,6 +212,7 @@ process {
         ext.args         = '--fastqc'
         publishDir       = [
             path: { "${params.outdir}/trimgalore/${meta.id}" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
@@ -221,6 +233,7 @@ process {
     withName: 'INDEX_MAPPING' {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/mapped" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*{bam,bai}"
         ]
@@ -230,6 +243,7 @@ process {
         ext.args         = { "--by-size ${params.split_fastq}" }
         publishDir = [
             path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.save_split_fastqs}",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -252,6 +266,7 @@ process {
         ext.prefix       = {"${meta.id}.md"}
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*{metrics}"
         ]
@@ -261,7 +276,8 @@ process {
         ext.prefix       = {"${meta.id}.md"}
         //publishDir       = [
         //    path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
-        //    enabled: false
+        //    mode: "${params.publish_dir_mode}",
+        enabled: false
         //]
     }
     withName: 'GATK4_MARKDUPLICATES_SPARK' {
@@ -269,6 +285,7 @@ process {
         ext.suffix       = '.md'
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*{cram,crai}"
         ]
@@ -278,18 +295,21 @@ process {
         ext.suffix       = '.mapped'
         publishDir       = [
             path: { "${params.outdir}/reports/qualimap/${meta.id}" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
     withName: 'SAMTOOLS_STATS' {
         publishDir       = [
             path: { "${params.outdir}/reports/samtools_stats/${meta.id}" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
     withName: 'DEEPTOOLS_BAMCOVERAGE' {
         publishDir       = [
             path: { "${params.outdir}/reports/deeptools/${meta.id}" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
@@ -297,6 +317,7 @@ process {
         ext.suffix       = '.md'
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*{cram,crai}"
         ]
@@ -304,6 +325,7 @@ process {
     withName: 'INDEX_MARKDUPLICATES' {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*{cram,crai}"
         ]
@@ -315,6 +337,7 @@ process {
     withName: 'BASERECALIBRATOR|BASERECALIBRATOR_SPARK|GATHERBQSRREPORTS' {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/recal_table" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*.table"
         ]
@@ -331,6 +354,7 @@ process {
         ext.suffix       = '.recal'
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/recalibrated" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*cram"
         ]
@@ -340,6 +364,7 @@ process {
         ext.suffix       = '.recal'
         publishDir       = [
             path: { "${params.outdir}/reports/qualimap/${meta.id}" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
@@ -347,6 +372,7 @@ process {
         ext.suffix       = 'recal'
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/recalibrated" },
+            mode: "${params.publish_dir_mode}",
             enabled: true,
             pattern: "*{recal.cram,recal.cram.crai}"
         ]
@@ -354,6 +380,7 @@ process {
     withName: 'SAMTOOLS_STATS' {
         publishDir       = [
             path: { "${params.outdir}/reports/samtools_stats/${meta.id}" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
@@ -364,6 +391,7 @@ process{
     withName: 'CONCAT_VCF_DEEPVARIANT' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -372,6 +400,7 @@ process{
     withName: 'CONCAT_GVCF_DEEPVARIANT' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -381,6 +410,7 @@ process{
     withName: 'CONCAT_VCF_FREEBAYES' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -390,6 +420,7 @@ process{
     withName: 'CONCAT_VCF_HAPLOTYPECALLER' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -398,6 +429,7 @@ process{
     withName: 'CONCAT_VCF_MANTA_.*' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -406,6 +438,7 @@ process{
     withName: 'CONCAT_VCF_MUTECT2' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -414,6 +447,7 @@ process{
     withName: 'CONCAT_VCF_STRELKA' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -425,25 +459,30 @@ process{
     withName: 'FREEBAYES' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.no_intervals}"
         ]
         ext.args         = '--min-alternate-fraction 0.1 --min-mapping-quality 1'
     }
     //withName: 'GATK4_CALCULATECONTAMINATION'{
-    //    publishDir        = [ enabled: false ]
+    //    publishDir        = [ mode: "${params.publish_dir_mode}",
+    enabled: false ]
     //    ext.args          = ''
     //}
     //withName: 'GATK4_FILTERMUTECTCALLS'{
-    //    publishDir        = [ enabled: false ]
+    //    publishDir        = [ mode: "${params.publish_dir_mode}",
+    enabled: false ]
     //    ext.args          = ''
     //}
     //withName: 'GATK4_GETPILEUPSUMMARIES'{
-    //    publishDir        = [ enabled: false ]
+    //    publishDir        = [ mode: "${params.publish_dir_mode}",
+    enabled: false ]
     //    ext.args          = ''
     //}
     withName: 'GATK4_MUTECT2'{
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.no_intervals}"
         ]
     }
@@ -456,6 +495,7 @@ process{
     withName: 'MANTA_GERMLINE|MANTA_TUMORONLY|MANTA_SOMATIC' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.no_intervals}"
         ]
         ext.args         = { params.wes ? "--exome" : "" }
@@ -463,6 +503,7 @@ process{
     withName: 'STRELKA_GERMLINE|STRELKA_TUMORONLY|STRELKA_SOMATIC|STRELKA_BP' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.no_intervals}"
         ]
         ext.args         = { params.wes ? "--exome" : "" }
@@ -470,6 +511,7 @@ process{
     withName : 'TABIX_DEEPVARIANT_VCF|TABIX_DEEPVARIANT_GVCF' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
         ext.prefix        = {"${meta.sample}"}
@@ -477,6 +519,7 @@ process{
     withName : 'TABIX_FREEBAYES' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
         ext.prefix        = {"${meta.sample}"}
@@ -484,6 +527,7 @@ process{
     withName : 'TABIX_HAPLOTYPECALLER' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
         ext.prefix        = {"${meta.sample}"}
@@ -491,7 +535,8 @@ process{
     //withName: 'TIDDIT_SV' {
     //    publishDir       = [
     //            path: { "${params.outdir}/variant_calling/${meta.sample}/tiddit" },
-    //            enabled: true
+    //            mode: "${params.publish_dir_mode}",
+    enabled: true
     //            ]
     //}
 
@@ -515,12 +560,14 @@ process{
     withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:GATK_TUMOR_NORMAL_SOMATIC_VARIANT_CALLING:MUTECT2'{
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
+            mode: "${params.publish_dir_mode}",
             enabled: "${params.no_intervals}"
         ]
     }
     withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:GATK_TUMOR_NORMAL_SOMATIC_VARIANT_CALLING:CONCAT_VCF_MUTECT2' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
+            mode: "${params.publish_dir_mode}",
             enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
@@ -529,12 +576,14 @@ process{
     withName: 'GATK4_MERGEMUTECTSTATS' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
     }
     withName: 'GATK4_FILTERMUTECTCALLS'{
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
+            mode: "${params.publish_dir_mode}",
             enabled: true
         ]
         ext.prefix        = {"${meta.id}.filtered."}
@@ -583,6 +632,7 @@ process {
     withName: 'ANNOTATION_BGZIPTABIX' {
         publishDir       = [
                 path: { "${params.outdir}/annotation/${meta.id}" },
+                mode: "${params.publish_dir_mode}",
                 enabled: true,
                     pattern: "*{gz,gz.tbi}"
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -277,7 +277,7 @@ process {
         //publishDir       = [
         //    path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
         //    mode: "${params.publish_dir_mode}",
-        enabled: false
+        //    enabled: false
         //]
     }
     withName: 'GATK4_MARKDUPLICATES_SPARK' {
@@ -464,19 +464,25 @@ process{
         ]
         ext.args         = '--min-alternate-fraction 0.1 --min-mapping-quality 1'
     }
-    //withName: 'GATK4_CALCULATECONTAMINATION'{
-    //    publishDir        = [ mode: "${params.publish_dir_mode}",
-    enabled: false ]
+    // withName: 'GATK4_CALCULATECONTAMINATION'{
+    //     publishDir        = [
+    //         mode: "${params.publish_dir_mode}",
+    //         enabled: false
+    //     ]
     //    ext.args          = ''
     //}
     //withName: 'GATK4_FILTERMUTECTCALLS'{
-    //    publishDir        = [ mode: "${params.publish_dir_mode}",
-    enabled: false ]
+    //     publishDir        = [
+    //         mode: "${params.publish_dir_mode}",
+    //         enabled: false
+    //     ]
     //    ext.args          = ''
     //}
     //withName: 'GATK4_GETPILEUPSUMMARIES'{
-    //    publishDir        = [ mode: "${params.publish_dir_mode}",
-    enabled: false ]
+    //     publishDir        = [
+    //         mode: "${params.publish_dir_mode}",
+    //         enabled: false
+    //     ]
     //    ext.args          = ''
     //}
     withName: 'GATK4_MUTECT2'{
@@ -536,7 +542,7 @@ process{
     //    publishDir       = [
     //            path: { "${params.outdir}/variant_calling/${meta.sample}/tiddit" },
     //            mode: "${params.publish_dir_mode}",
-    enabled: true
+    //            enabled: true
     //            ]
     //}
 
@@ -634,7 +640,7 @@ process {
                 path: { "${params.outdir}/annotation/${meta.id}" },
                 mode: "${params.publish_dir_mode}",
                 enabled: true,
-                    pattern: "*{gz,gz.tbi}"
+                pattern: "*{gz,gz.tbi}"
         ]
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -262,9 +262,8 @@ process {
 
 // Markduplicates Spark NEEDS name-sorted reads or runtime goes through the roof
 // However if it's skipped, reads need to be coordinate-sorted
-// Spark can be used also for BQSR, therefore check for both
 // Only name sort if Spark for Markduplicates + duplicate marking is not skipped
-if (('markduplicates' in params.use_gatk_spark) && (!params.skip_markduplicates)) {
+if ( params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates') && (!params.skip_markduplicates)) {
     process {
         withName: "BWA.*_MEM" {
             ext.args2    = '-n'
@@ -287,6 +286,7 @@ process {
     withName: 'GATK4_MARKDUPLICATES' {
         ext.args         = '-REMOVE_DUPLICATES false -VALIDATION_STRINGENCY LENIENT'
         ext.prefix       = {"${meta.id}.md"}
+        ext.when         = { !params.use_gatk_spark || (params.use_gatk_spark && !params.use_gatk_spark.contains('markduplicates')) }
         //publishDir       = [
         //    enabled: false
         //    mode: "${params.publish_dir_mode}",
@@ -369,7 +369,21 @@ process {
             pattern: "*.table"
         ]
     }
+
+    withName: 'BASERECALIBRATOR' {
+        ext.when         = { !params.use_gatk_spark || (params.use_gatk_spark && !params.use_gatk_spark.contains('baserecalibrator')) }
+    }
+    withName: 'BASERECALIBRATOR_SPARK' {
+        ext.when         = { params.use_gatk_spark && params.use_gatk_spark.contains('baserecalibrator') }
+    }
+    withName: 'GATHERBQSRREPORTS' {
+        ext.when         = { !params.no_intervals }
+    }
+
 }
+
+params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates')
+
 
 // RECALIBRATE
 process {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -276,6 +276,7 @@ if (('markduplicates' in params.use_gatk_spark) && (!params.skip_markduplicates)
 process {
     withName: 'GATK4_ESTIMATELIBRARYCOMPLEXITY' {
         ext.prefix       = {"${meta.id}.md"}
+        ext.when         = { (params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates')) && (!(params.skip_tools && params.skip_tools.contains('markduplicates_report'))) }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -294,7 +295,8 @@ process {
     }
     withName: 'GATK4_MARKDUPLICATES_SPARK' {
         ext.args         = '--remove-sequencing-duplicates false -VS LENIENT'
-        ext.suffix       = '.md'
+        ext.suffix       = { !(params.skip_tools && (params.skip_tools.contains('bamqc') || params.skip_tools.contains('deeptools'))) ? '.md.bam' : '.md.cram' }
+        ext.when         = { params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates') }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -305,6 +307,7 @@ process {
     withName: 'QUALIMAP_BAMQC' {
         ext.args         = '--paint-chromosome-limits --genome-gc-distr HUMAN -skip-duplicated --skip-dup-mode 0 -outformat HTML'
         ext.suffix       = '.mapped'
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('bamqc')) }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -312,6 +315,7 @@ process {
         ]
     }
     withName: 'SAMTOOLS_STATS' {
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('samtools')) }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -319,13 +323,23 @@ process {
         ]
     }
     withName: 'DEEPTOOLS_BAMCOVERAGE' {
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('deeptools')) }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reports/deeptools/${meta.id}" }
         ]
     }
-    withName: 'SAMTOOLS_BAM_TO_CRAM|SAMTOOLS_BAM_TO_CRAM_SPARK' {
+    withName: 'SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES' {
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('markduplicates')) }
+    }
+    withName: 'GATK4_MARKDUPLICATES|SAMTOOLS_BAM_TO_CRAM_DUPLICATES' {
+        ext.when         = { !(params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates')) }
+    }
+    withName: 'SAMTOOLS_BAM_TO_CRAM_SPARK' {
+        ext.when         = { !(params.skip_tools && (params.skip_tools.contains('bamqc') || params.skip_tools.contains('deeptools'))) }
+    }
+    withName: 'SAMTOOLS_BAM_TO_CRAM_DUPLICATES|SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES|SAMTOOLS_BAM_TO_CRAM_SPARK' {
         ext.suffix       = '.md'
         publishDir       = [
             enabled: true,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -8,7 +8,7 @@
         ext.args3           = Third set of arguments appended to command in module (multi-tool modules).
         ext.suffix          = File name ext.suffix output files. Not available for nf-core modules
         ext.prefix          = File name prefix for output files.
-        ext.when                  = When to run the module.
+        ext.when            = When to run the module.
 ----------------------------------------------------------------------------------------
 */
 
@@ -159,7 +159,7 @@ process{
     }
 }
 
-if(params.umi_read_structure){
+if (params.umi_read_structure) {
     process {
         withName: "NFCORE_SAREK:SAREK:CREATE_UMI_CONSENSUS:BWA.*_MEM" {
             ext.args         = '-p -C -M'
@@ -197,10 +197,11 @@ process {
     }
 }
 
-// QC_TRIM
+// FASTQ_QC_TRIM
 process {
     withName: 'FASTQC' {
         ext.args         = '--quiet'
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('fastqc')) }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -209,17 +210,14 @@ process {
     }
     withName: 'TRIMGALORE' {
         ext.args         = '--fastqc'
+        ext.when         = { params.trim_fastq }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/trimgalore/${meta.id}" }
         ]
     }
-    // withName: 'MULTIQC' {
-    //     ext.args         = ''
-    // }
 }
-
 
 // MAPPING
 process {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -387,11 +387,18 @@ params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates')
 
 // RECALIBRATE
 process {
+    withName: 'APPLYBQSR' {
+        ext.when         = { !params.use_gatk_spark || (params.use_gatk_spark && !params.use_gatk_spark.contains('baserecalibrator')) }
+    }
+    withName: 'APPLYBQSR_SPARK' {
+        ext.when         = { params.use_gatk_spark && params.use_gatk_spark.contains('baserecalibrator') }
+    }
     withName: 'APPLYBQSR|APPLYBQSR_SPARK' {
         ext.prefix       = {"${meta.id}.recal"}
     }
     withName: 'SAMTOOLS_MERGE_CRAM' {
         ext.suffix       = '.recal'
+        ext.when         = { !params.no_intervals }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -402,6 +409,7 @@ process {
     withName: 'QUALIMAP_BAMQC_CRAM' {
         ext.args         = '--paint-chromosome-limits --genome-gc-distr HUMAN -skip-duplicated --skip-dup-mode 0 -outformat HTML'
         ext.suffix       = '.recal'
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('bamqc')) }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -418,6 +426,7 @@ process {
         ]
     }
     withName: 'SAMTOOLS_STATS' {
+        ext.when         = { !(params.skip_tools && params.skip_tools.contains('samtools')) }
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -34,7 +34,7 @@ process {
 process {
 
     withName: 'BWAMEM1_INDEX' {
-        ext.when   = { params.aligner == "bwa-mem" }
+        ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem" }
         publishDir = [
             path: { "${params.outdir}/reference/bwa" },
             enabled: "${params.save_reference}",
@@ -43,7 +43,7 @@ process {
     }
 
     withName: 'BWAMEM2_INDEX' {
-        ext.when   = { params.aligner == "bwa-mem2" }
+        ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem2" }
         publishDir = [
             path: { "${params.outdir}/reference/bwamem2" },
             enabled: "${params.save_reference}",
@@ -60,6 +60,7 @@ process {
     }
 
     withName: 'GATK4_CREATESEQUENCEDICTIONARY' {
+        ext.when   = { !params.dict && params.step != "annotate" && params.step != "controlfreec" }
         publishDir = [
             path: { "${params.outdir}/reference/gatk4" },
             enabled: "${params.save_reference}",
@@ -68,6 +69,7 @@ process {
     }
 
     withName: 'MSISENSORPRO_SCAN' {
+    ext.when   = { params.tools && params.tools.contains('msisensorpro') }
         publishDir = [
             path: { "${params.outdir}/reference/msi" },
             enabled: "${params.save_reference}",
@@ -76,6 +78,7 @@ process {
     }
 
     withName: 'SAMTOOLS_FAIDX' {
+        ext.when   = { !params.fasta_fai && params.step != "annotate" }
         publishDir = [
             path: { "${params.outdir}/reference/fai" },
             enabled: "${params.save_reference}",
@@ -94,6 +97,7 @@ process {
     }
 
     withName: 'TABIX_DBSNP' {
+        ext.when   = { !params.dbsnp_tbi && params.dbsnp && (params.step == "mapping" || params.step == "prepare_recalibration") || params.tools && (params.tools.contains('controlfreec') || params.tools.contains('haplotypecaller') || params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
         publishDir = [
             path: { "${params.outdir}/reference/dbsnp" },
             enabled: "${params.save_reference}",
@@ -102,6 +106,7 @@ process {
     }
 
     withName: 'TABIX_GERMLINE_RESOURCE' {
+        ext.when   = { !params.germline_resource_tbi && params.germline_resource && params.tools && params.tools.contains('mutect2') }
         publishDir = [
             path: { "${params.outdir}/reference/germline_resource" },
             enabled: "${params.save_reference}",
@@ -110,6 +115,7 @@ process {
     }
 
     withName: 'TABIX_KNOWN_INDELS' {
+        ext.when   = { !params.known_indels_tbi && params.known_indels && (params.step == 'mapping' || params.step == 'prepare_recalibration') }
         publishDir = [
             path: { "${params.outdir}/reference/known_indels" },
             enabled: "${params.save_reference}",
@@ -118,6 +124,7 @@ process {
     }
 
     withName: 'TABIX_PON' {
+    ext.when   = { !params.pon_tbi && params.pon && params.tools && (params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
         publishDir = [
             path: { "${params.outdir}/reference/pon" },
             enabled: "${params.save_reference}",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -8,20 +8,20 @@
         ext.args3           = Third set of arguments appended to command in module (multi-tool modules).
         ext.suffix          = File name ext.suffix output files. Not available for nf-core modules
         ext.prefix          = File name prefix for output files.
-        ext.when            = When to run the module.
+        ext.when                  = When to run the module.
 ----------------------------------------------------------------------------------------
 */
 
 process {
 
-    publishDir = [
+    publishDir           = [
         mode: "${params.publish_dir_mode}",
         path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
-        publishDir = [
+        publishDir       = [
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/pipeline_info" },
             pattern: '*_versions.yml'
@@ -33,8 +33,8 @@ process {
 process {
 
     withName: 'BWAMEM1_INDEX' {
-        ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem" }
-        publishDir = [
+        ext.when         = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem" }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/bwa" },
@@ -43,8 +43,8 @@ process {
     }
 
     withName: 'BWAMEM2_INDEX' {
-        ext.when   = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem2" }
-        publishDir = [
+        ext.when         = { !params.bwa && params.step == "mapping" && params.aligner == "bwa-mem2" }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/bwamem2" },
@@ -53,7 +53,7 @@ process {
 
     }
     withName: 'CREATE_INTERVALS_BED' {
-        publishDir = [
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/intervals" },
@@ -62,8 +62,8 @@ process {
     }
 
     withName: 'GATK4_CREATESEQUENCEDICTIONARY' {
-        ext.when   = { !params.dict && params.step != "annotate" && params.step != "controlfreec" }
-        publishDir = [
+        ext.when         = { !params.dict && params.step != "annotate" && params.step != "controlfreec" }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/gatk4" },
@@ -72,8 +72,8 @@ process {
     }
 
     withName: 'MSISENSORPRO_SCAN' {
-        ext.when   = { params.tools && params.tools.contains('msisensorpro') }
-        publishDir = [
+        ext.when         = { params.tools && params.tools.contains('msisensorpro') }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/msi" },
@@ -82,8 +82,8 @@ process {
     }
 
     withName: 'SAMTOOLS_FAIDX' {
-        ext.when   = { !params.fasta_fai && params.step != "annotate" }
-        publishDir = [
+        ext.when         = { !params.fasta_fai && params.step != "annotate" }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/fai" },
@@ -92,8 +92,8 @@ process {
     }
 
     withName: 'TABIX_BGZIPTABIX' {
-        ext.prefix = {"${meta.id}.bed"}
-        publishDir = [
+        ext.prefix       = {"${meta.id}.bed"}
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/target" },
@@ -102,8 +102,8 @@ process {
     }
 
     withName: 'TABIX_DBSNP' {
-        ext.when   = { !params.dbsnp_tbi && params.dbsnp && (params.step == "mapping" || params.step == "prepare_recalibration") || params.tools && (params.tools.contains('controlfreec') || params.tools.contains('haplotypecaller') || params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
-        publishDir = [
+        ext.when         = { !params.dbsnp_tbi && params.dbsnp && (params.step == "mapping" || params.step == "prepare_recalibration") || params.tools && (params.tools.contains('controlfreec') || params.tools.contains('haplotypecaller') || params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/dbsnp" },
@@ -112,8 +112,8 @@ process {
     }
 
     withName: 'TABIX_GERMLINE_RESOURCE' {
-        ext.when   = { !params.germline_resource_tbi && params.germline_resource && params.tools && params.tools.contains('mutect2') }
-        publishDir = [
+        ext.when         = { !params.germline_resource_tbi && params.germline_resource && params.tools && params.tools.contains('mutect2') }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/germline_resource" },
@@ -122,8 +122,8 @@ process {
     }
 
     withName: 'TABIX_KNOWN_INDELS' {
-        ext.when   = { !params.known_indels_tbi && params.known_indels && (params.step == 'mapping' || params.step == 'prepare_recalibration') }
-        publishDir = [
+        ext.when         = { !params.known_indels_tbi && params.known_indels && (params.step == 'mapping' || params.step == 'prepare_recalibration') }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/known_indels" },
@@ -132,8 +132,8 @@ process {
     }
 
     withName: 'TABIX_PON' {
-        ext.when   = { !params.pon_tbi && params.pon && params.tools && (params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
-        publishDir = [
+        ext.when         = { !params.pon_tbi && params.pon && params.tools && (params.tools.contains('mutect2') || params.tools.contains('tnscope')) }
+        publishDir       = [
             enabled: "${params.save_reference}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/reference/pon" },
@@ -145,7 +145,7 @@ process {
 // UMI Subworkflow
 process{
     withName: 'BAM2FASTQ' {
-        ext.args  = '-T RX'
+        ext.args         = '-T RX'
     }
 
     withName: 'SAMBLASTER' {
@@ -162,9 +162,9 @@ process{
 if(params.umi_read_structure){
     process {
         withName: "NFCORE_SAREK:SAREK:CREATE_UMI_CONSENSUS:BWA.*_MEM" {
-            ext.args = '-p -C -M'
-            ext.args2 = '-bS'
-            ext.prefix = {"${meta.id}.umi_unsorted"}
+            ext.args         = '-p -C -M'
+            ext.args2        = '-bS'
+            ext.prefix       = {"${meta.id}.umi_unsorted"}
         }
     }
 }
@@ -173,27 +173,27 @@ if(params.umi_read_structure){
 process {
     withName: 'SAMTOOLS_VIEW_MAP_MAP' {
         ext.args = '-b -f1 -F12'
-        ext.prefix = {"${meta.id}.map_map"}
+        ext.prefix       = {"${meta.id}.map_map"}
     }
     withName: 'SAMTOOLS_VIEW_UNMAP_UNMAP' {
         ext.args = '-b -f12 -F256'
-        ext.prefix = {"${meta.id}.unmap_unmap"}
+        ext.prefix       = {"${meta.id}.unmap_unmap"}
     }
     withName: 'SAMTOOLS_VIEW_UNMAP_MAP' {
         ext.args = '-b -f4 -F264'
-        ext.prefix = {"${meta.id}.unmap_map"}
+        ext.prefix       = {"${meta.id}.unmap_map"}
     }
     withName: 'SAMTOOLS_VIEW_MAP_UNMAP' {
         ext.args = '-b -f8 -F260'
-        ext.prefix = {"${meta.id}.map_unmap"}
+        ext.prefix       = {"${meta.id}.map_unmap"}
     }
     withName: 'SAMTOOLS_FASTQ_UNMAPPED'{
         ext.args2 = '-N'
-        ext.prefix = {"${meta.id}.unmapped"}
+        ext.prefix       = {"${meta.id}.unmapped"}
     }
     withName: 'SAMTOOLS_FASTQ_MAPPED'{
         ext.args2 = '-N'
-        ext.prefix = {"${meta.id}.mapped"}
+        ext.prefix       = {"${meta.id}.mapped"}
     }
 }
 
@@ -225,8 +225,8 @@ process {
 process {
 
     withName: "BWA.*MEM" {
-        ext.args   = { meta.status == 1 ? '-K 100000000 -M -B 3' : '-K 100000000 -M' }
-        ext.prefix = { params.split_fastq > 1 ?  "${meta.id}".concat('.').concat(reads.get(0).name.findAll(/part_([0-9]+)?/).last()) : "" }
+        ext.args         = { meta.status == 1 ? '-K 100000000 -M -B 3' : '-K 100000000 -M' }
+        ext.prefix       = { params.split_fastq > 1 ?  "${meta.id}".concat('.').concat(reads.get(0).name.findAll(/part_([0-9]+)?/).last()) : "" }
     }
 
     withName: 'INDEX_MAPPING' {
@@ -240,7 +240,7 @@ process {
 
     withName: "SEQKIT_SPLIT2" {
         ext.args         = { "--by-size ${params.split_fastq}" }
-        publishDir = [
+        publishDir       = [
             enabled: "${params.save_split_fastqs}",
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
@@ -255,7 +255,9 @@ process {
 // Only name sort if Spark for Markduplicates + duplicate marking is not skipped
 if (('markduplicates' in params.use_gatk_spark) && (!params.skip_markduplicates)) {
     process {
-        withName: "BWA.*_MEM" { ext.args2 = '-n' }
+        withName: "BWA.*_MEM" {
+            ext.args2    = '-n'
+        }
     }
 }
 
@@ -334,7 +336,7 @@ process {
 // PREPARE_RECALIBRATION
 process {
     withName: 'BASERECALIBRATOR|BASERECALIBRATOR_SPARK|GATHERBQSRREPORTS' {
-        ext.prefix = {"${meta.id}.recal"}
+        ext.prefix       = {"${meta.id}.recal"}
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -347,7 +349,7 @@ process {
 // RECALIBRATE
 process {
     withName: 'APPLYBQSR|APPLYBQSR_SPARK' {
-        ext.prefix = {"${meta.id}.recal"}
+        ext.prefix       = {"${meta.id}.recal"}
     }
     withName: 'SAMTOOLS_MERGE_CRAM' {
         ext.suffix       = '.recal'
@@ -389,7 +391,7 @@ process {
 process{
     withName: 'CONCAT_VCF_DEEPVARIANT' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.sample}"}
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -398,7 +400,7 @@ process{
     }
     withName: 'CONCAT_GVCF_DEEPVARIANT' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.sample}.g"}
+        ext.prefix       = {"${meta.sample}.g"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -408,7 +410,7 @@ process{
 
     withName: 'CONCAT_VCF_FREEBAYES' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.sample}"}
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -418,7 +420,7 @@ process{
     }
     withName: 'CONCAT_VCF_HAPLOTYPECALLER' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.sample}.g"}
+        ext.prefix       = {"${meta.sample}.g"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -427,7 +429,7 @@ process{
     }
     withName: 'CONCAT_VCF_MANTA_.*' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.sample}"}
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -436,7 +438,7 @@ process{
     }
     withName: 'CONCAT_VCF_MUTECT2' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.sample}"}
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -445,7 +447,7 @@ process{
     }
     withName: 'CONCAT_VCF_STRELKA' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.sample}"}
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -522,7 +524,7 @@ process{
         ]
     }
     withName : 'TABIX_FREEBAYES' {
-        ext.prefix        = {"${meta.sample}"}
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -530,7 +532,7 @@ process{
         ]
     }
     withName : 'TABIX_HAPLOTYPECALLER' {
-        ext.prefix        = {"${meta.sample}"}
+        ext.prefix       = {"${meta.sample}"}
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -551,10 +553,10 @@ process{
 process{
 
     withName: 'MERGEMUTECTSTATS' {
-        ext.prefix = { "${meta.sample}.vcf.gz" }
+        ext.prefix       = { "${meta.sample}.vcf.gz" }
     }
     withName: 'GATHERPILEUPSUMMARIES' {
-        ext.prefix = { "${meta.sample}.table" }
+        ext.prefix       = { "${meta.sample}.table" }
     }
 }
 
@@ -571,7 +573,7 @@ process{
     }
     withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:GATK_TUMOR_NORMAL_SOMATIC_VARIANT_CALLING:CONCAT_VCF_MUTECT2' {
         ext.args         = { params.no_intervals ?  "-n" : "" }
-        ext.prefix        = {"${meta.id}"}
+        ext.prefix       = {"${meta.id}"}
         publishDir       = [
             enabled: "!${params.no_intervals}",
             mode: "${params.publish_dir_mode}",
@@ -586,7 +588,7 @@ process{
         ]
     }
     withName: 'GATK4_FILTERMUTECTCALLS'{
-        ext.prefix        = {"${meta.id}.filtered."}
+        ext.prefix       = {"${meta.id}.filtered."}
         publishDir       = [
             enabled: true,
             mode: "${params.publish_dir_mode}",
@@ -647,7 +649,7 @@ process {
 if (params.tools && (params.tools.contains('snpeff') || params.tools.contains('merge'))) {
     process {
         withName: 'NFCORE_SAREK:SAREK:ANNOTATE:ANNOTATION_SNPEFF:ANNOTATION_BGZIPTABIX' {
-            ext.prefix = {"${meta.id}_snpEff.ann.vcf"}
+            ext.prefix       = {"${meta.id}_snpEff.ann.vcf"}
         }
     }
 }
@@ -655,7 +657,7 @@ if (params.tools && (params.tools.contains('snpeff') || params.tools.contains('m
 if (params.tools && (params.tools.contains('vep'))) {
     process {
         withName: 'NFCORE_SAREK:SAREK:ANNOTATE:ANNOTATION_ENSEMBLVEP:ANNOTATION_BGZIPTABIX' {
-            ext.prefix = {"${meta.id}_VEP.ann.vcf"}
+            ext.prefix       = {"${meta.id}_VEP.ann.vcf"}
         }
     }
 }
@@ -663,7 +665,7 @@ if (params.tools && (params.tools.contains('vep'))) {
 if (params.tools && (params.tools.contains('merge'))) {
     process {
         withName: 'NFCORE_SAREK:SAREK:ANNOTATE:MERGE_ANNOTATE:ANNOTATION_BGZIPTABIX' {
-            ext.prefix = {"${meta.id}_snpEff_VEP.ann.vcf"}
+            ext.prefix       = {"${meta.id}_snpEff_VEP.ann.vcf"}
         }
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -263,7 +263,7 @@ process {
 // Markduplicates Spark NEEDS name-sorted reads or runtime goes through the roof
 // However if it's skipped, reads need to be coordinate-sorted
 // Only name sort if Spark for Markduplicates + duplicate marking is not skipped
-if ( params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates') && (!params.skip_markduplicates)) {
+if ( params.use_gatk_spark && params.use_gatk_spark.contains('markduplicates') && (!params.skip_tools || (params.skip_tools && !params.skip_tools.contains('markduplicates')))) {
     process {
         withName: "BWA.*_MEM" {
             ext.args2    = '-n'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -8,21 +8,23 @@
         ext.args3           = Third set of arguments appended to command in module (multi-tool modules).
         ext.suffix          = File name ext.suffix output files. Not available for nf-core modules
         ext.prefix          = File name prefix for output files.
+        ext.when            = When to run the module.
 ----------------------------------------------------------------------------------------
 */
 
 process {
 
-    publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-        mode: 'copy',
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-    ]
+    withName: '.*' {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: "${params.publish_dir_mode}",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
 
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
-            mode: 'copy',
             pattern: '*_versions.yml'
         ]
     }
@@ -32,20 +34,20 @@ process {
 process {
 
     withName: 'BWAMEM1_INDEX' {
+        ext.when   = { params.aligner == "bwa-mem" }
         publishDir = [
             path: { "${params.outdir}/reference/bwa" },
             enabled: "${params.save_reference}",
-            pattern: "bwa",
-            mode: 'copy'
+            pattern: "bwa"
         ]
     }
 
     withName: 'BWAMEM2_INDEX' {
+        ext.when   = { params.aligner == "bwa-mem2" }
         publishDir = [
             path: { "${params.outdir}/reference/bwamem2" },
             enabled: "${params.save_reference}",
-            pattern: "bwa",
-            mode: 'copy'
+            pattern: "bwa"
         ]
 
     }
@@ -53,8 +55,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/intervals" },
             enabled: "${params.save_reference}",
-            pattern: "*bed",
-            mode: 'copy'
+            pattern: "*bed"
         ]
     }
 
@@ -62,8 +63,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/gatk4" },
             enabled: "${params.save_reference}",
-            pattern: "*dict",
-            mode: 'copy'
+            pattern: "*dict"
         ]
     }
 
@@ -71,8 +71,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/msi" },
             enabled: "${params.save_reference}",
-            pattern: "*list",
-            mode: 'copy'
+            pattern: "*list"
         ]
     }
 
@@ -80,8 +79,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/fai" },
             enabled: "${params.save_reference}",
-            pattern: "*fai",
-            mode: 'copy'
+            pattern: "*fai"
         ]
     }
 
@@ -89,8 +87,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/target" },
             enabled: "${params.save_reference}",
-            pattern: "*bed.gz",
-            mode: 'copy'
+            pattern: "*bed.gz"
         ]
         ext.prefix = {"${meta.id}.bed"}
 
@@ -100,8 +97,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/dbsnp" },
             enabled: "${params.save_reference}",
-            pattern: "*vcf.gz.tbi",
-            mode: 'copy'
+            pattern: "*vcf.gz.tbi"
         ]
     }
 
@@ -109,8 +105,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/germline_resource" },
             enabled: "${params.save_reference}",
-            pattern: "*vcf.gz.tbi",
-            mode: 'copy'
+            pattern: "*vcf.gz.tbi"
         ]
     }
 
@@ -118,8 +113,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/known_indels" },
             enabled: "${params.save_reference}",
-            pattern: "*vcf.gz.tbi",
-            mode: 'copy'
+            pattern: "*vcf.gz.tbi"
         ]
     }
 
@@ -127,8 +121,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/reference/pon" },
             enabled: "${params.save_reference}",
-            pattern: "*vcf.gz.tbi",
-            mode: 'copy'
+            pattern: "*vcf.gz.tbi"
         ]
     }
 }
@@ -194,7 +187,6 @@ process {
         ext.args         = '--quiet'
         publishDir       = [
             path: { "${params.outdir}/reports/fastqc/${meta.id}" },
-            mode: 'copy',
             enabled: true
         ]
     }
@@ -202,7 +194,6 @@ process {
         ext.args         = '--fastqc'
         publishDir       = [
             path: { "${params.outdir}/trimgalore/${meta.id}" },
-            mode: 'copy',
             enabled: true
         ]
     }
@@ -224,7 +215,6 @@ process {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/mapped" },
             enabled: true,
-            mode: 'copy',
             pattern: "*{bam,bai}"
         ]
     }
@@ -233,7 +223,6 @@ process {
         ext.args         = { "--by-size ${params.split_fastq}" }
         publishDir = [
             path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            mode: 'copy',
             enabled: "${params.save_split_fastqs}",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -257,7 +246,6 @@ process {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             enabled: true,
-            mode: 'copy',
             pattern: "*{metrics}"
         ]
     }
@@ -275,7 +263,6 @@ process {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             enabled: true,
-            mode: 'copy',
             pattern: "*{cram,crai}"
         ]
     }
@@ -284,22 +271,19 @@ process {
         ext.suffix       = '.mapped'
         publishDir       = [
             path: { "${params.outdir}/reports/qualimap/${meta.id}" },
-            mode: 'copy',
             enabled: true
         ]
     }
     withName: 'SAMTOOLS_STATS' {
         publishDir       = [
             path: { "${params.outdir}/reports/samtools_stats/${meta.id}" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
     }
     withName: 'DEEPTOOLS_BAMCOVERAGE' {
         publishDir       = [
             path: { "${params.outdir}/reports/deeptools/${meta.id}" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
     }
     withName: 'SAMTOOLS_BAM_TO_CRAM|SAMTOOLS_BAM_TO_CRAM_SPARK' {
@@ -307,7 +291,6 @@ process {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             enabled: true,
-            mode: 'copy',
             pattern: "*{cram,crai}"
         ]
     }
@@ -315,7 +298,6 @@ process {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/markduplicates" },
             enabled: true,
-            mode: 'copy',
             pattern: "*{cram,crai}"
         ]
     }
@@ -327,7 +309,6 @@ process {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/recal_table" },
             enabled: true,
-            mode: 'copy',
             pattern: "*.table"
         ]
         ext.prefix = {"${meta.id}.recal"}
@@ -344,7 +325,6 @@ process {
         publishDir       = [
             path: { "${params.outdir}/preprocessing/${meta.id}/recalibrated" },
             enabled: true,
-            mode: 'copy',
             pattern: "*cram"
         ]
     }
@@ -353,8 +333,7 @@ process {
         ext.suffix       = '.recal'
         publishDir       = [
             path: { "${params.outdir}/reports/qualimap/${meta.id}" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
     }
     withName: 'INDEX_RECALIBRATE' {
@@ -368,8 +347,7 @@ process {
     withName: 'SAMTOOLS_STATS' {
         publishDir       = [
             path: { "${params.outdir}/reports/samtools_stats/${meta.id}" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
     }
 }
@@ -379,8 +357,7 @@ process{
     withName: 'CONCAT_VCF_DEEPVARIANT' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
@@ -388,8 +365,7 @@ process{
     withName: 'CONCAT_GVCF_DEEPVARIANT' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}.g"}
@@ -398,8 +374,7 @@ process{
     withName: 'CONCAT_VCF_FREEBAYES' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
@@ -408,8 +383,7 @@ process{
     withName: 'CONCAT_VCF_HAPLOTYPECALLER' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}.g"}
@@ -417,8 +391,7 @@ process{
     withName: 'CONCAT_VCF_MANTA_.*' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
@@ -426,8 +399,7 @@ process{
     withName: 'CONCAT_VCF_MUTECT2' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
@@ -435,8 +407,7 @@ process{
     withName: 'CONCAT_VCF_STRELKA' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.sample}"}
@@ -447,8 +418,7 @@ process{
     withName: 'FREEBAYES' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
-            enabled: "${params.no_intervals}",
-            mode: 'copy'
+            enabled: "${params.no_intervals}"
         ]
         ext.args         = '--min-alternate-fraction 0.1 --min-mapping-quality 1'
     }
@@ -467,8 +437,7 @@ process{
     withName: 'GATK4_MUTECT2'{
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/mutect2" },
-            enabled: "${params.no_intervals}",
-            mode: 'copy'
+            enabled: "${params.no_intervals}"
         ]
     }
     //withName: 'GENOMICSDBIMPORT' {
@@ -480,39 +449,35 @@ process{
     withName: 'MANTA_GERMLINE|MANTA_TUMORONLY|MANTA_SOMATIC' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/manta" },
-            enabled: "${params.no_intervals}",
-            mode: 'copy'
+            enabled: "${params.no_intervals}"
         ]
         ext.args         = { params.wes ? "--exome" : "" }
     }
     withName: 'STRELKA_GERMLINE|STRELKA_TUMORONLY|STRELKA_SOMATIC|STRELKA_BP' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/strelka" },
-            enabled: "${params.no_intervals}",
-            mode: 'copy'
+            enabled: "${params.no_intervals}"
         ]
         ext.args         = { params.wes ? "--exome" : "" }
     }
     withName : 'TABIX_DEEPVARIANT_VCF|TABIX_DEEPVARIANT_GVCF' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/deepvariant" },
-            enabled: true,
+            enabled: true
         ]
         ext.prefix        = {"${meta.sample}"}
     }
     withName : 'TABIX_FREEBAYES' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/freebayes" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
         ext.prefix        = {"${meta.sample}"}
     }
     withName : 'TABIX_HAPLOTYPECALLER' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.sample}/haplotypecaller" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
         ext.prefix        = {"${meta.sample}"}
     }
@@ -543,15 +508,13 @@ process{
     withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:GATK_TUMOR_NORMAL_SOMATIC_VARIANT_CALLING:MUTECT2'{
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
-            enabled: "${params.no_intervals}",
-            mode: 'copy'
+            enabled: "${params.no_intervals}"
         ]
     }
     withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:GATK_TUMOR_NORMAL_SOMATIC_VARIANT_CALLING:CONCAT_VCF_MUTECT2' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
-            enabled: "!${params.no_intervals}",
-            mode: 'copy'
+            enabled: "!${params.no_intervals}"
         ]
         ext.args         = { params.no_intervals ?  "-n" : "" }
         ext.prefix        = {"${meta.id}"}
@@ -559,15 +522,13 @@ process{
     withName: 'GATK4_MERGEMUTECTSTATS' {
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
     }
     withName: 'GATK4_FILTERMUTECTCALLS'{
         publishDir       = [
             path: { "${params.outdir}/variant_calling/${meta.id}/mutect2" },
-            enabled: true,
-            mode: 'copy'
+            enabled: true
         ]
         ext.prefix        = {"${meta.id}.filtered."}
     }
@@ -616,8 +577,7 @@ process {
         publishDir       = [
                 path: { "${params.outdir}/annotation/${meta.id}" },
                 enabled: true,
-                mode: 'copy',
-                pattern: "*{gz,gz.tbi}"
+                    pattern: "*{gz,gz.tbi}"
         ]
     }
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -61,14 +61,14 @@ profiles {
         params.save_bam_mapped     = true
     }
     skip_markduplicates {
-        params.skip_markduplicates = true
+        params.skip_tools          = "markduplicates"
     }
     split_fastq {
         params.split_fastq         = 150000
         params.save_split_fastqs   = true
     }
     no_intervals {
-        params.no_intervals          = true
+        params.no_intervals        = true
     }
     targeted {
         params.intervals           = "${params.genomes_base}/data/genomics/homo_sapiens/genome/multi_intervals.bed"
@@ -97,7 +97,7 @@ profiles {
         params.trim_fastq          = true
     }
     use_gatk_spark {
-        params.use_gatk_spark      = 'bqsr,markduplicates'
+        params.use_gatk_spark      = 'baserecalibrator,markduplicates'
     }
     umi {
         params.input               = "${baseDir}/tests/csv/3.0/fastq_umi.csv"

--- a/conf/test.config
+++ b/conf/test.config
@@ -50,6 +50,9 @@ profiles {
         params.input               = 'https://raw.githubusercontent.com/nf-core/test-datasets/sarek/testdata/csv/tiny-vcf-https.csv'
         params.step                = 'annotate'
     }
+    no_intervals {
+        params.no_intervals        = true
+    }
     pair {
         params.input               = "${baseDir}/tests/csv/3.0/fastq_pair.csv"
     }
@@ -66,9 +69,6 @@ profiles {
     split_fastq {
         params.split_fastq         = 150000
         params.save_split_fastqs   = true
-    }
-    no_intervals {
-        params.no_intervals        = true
     }
     targeted {
         params.intervals           = "${params.genomes_base}/data/genomics/homo_sapiens/genome/multi_intervals.bed"
@@ -96,21 +96,21 @@ profiles {
         params.three_prime_clip_r2 = 1
         params.trim_fastq          = true
     }
-    use_gatk_spark {
-        params.use_gatk_spark      = 'baserecalibrator,markduplicates'
-    }
     umi {
         params.input               = "${baseDir}/tests/csv/3.0/fastq_umi.csv"
         params.umi_read_structure  = '7M1S+T'
+    }
+    use_gatk_spark {
+        params.use_gatk_spark      = 'baserecalibrator,markduplicates'
     }
 }
 
 //This is apparently useless as it won't overwrite things in the modules.config
 process {
-    withName:SNPEFF {
+    withName:ENSEMBLVEP {
         maxForks = 1
     }
-    withName:ENSEMBLVEP {
+    withName:SNPEFF {
         maxForks = 1
     }
 }

--- a/modules.json
+++ b/modules.json
@@ -4,106 +4,106 @@
     "repos": {
         "nf-core/modules": {
             "bcftools/stats": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "bwa/index": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "bwa/mem": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "bwamem2/index": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "bwamem2/mem": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "cat/fastq": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "cnvkit/batch": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "custom/dumpsoftwareversions": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "deepvariant": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "ensemblvep": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "fastqc": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "fgbio/callmolecularconsensusreads": {
-                "git_sha": "9d0cad583b9a71a6509b754fdf589cbfbed08961"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "fgbio/fastqtobam": {
-                "git_sha": "e3285528aca2733ff2d544cb5e5fcc34599226f3"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "fgbio/groupreadsbyumi": {
-                "git_sha": "9d0cad583b9a71a6509b754fdf589cbfbed08961"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "freebayes": {
-                "git_sha": "9d0cad583b9a71a6509b754fdf589cbfbed08961"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/applybqsr": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/applyvqsr": {
-                "git_sha": "598d7abdb2a8df1aa3471c48d9186a9e3465983f"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/baserecalibrator": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/calculatecontamination": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/createsequencedictionary": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/estimatelibrarycomplexity": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/filtermutectcalls": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/gatherbqsrreports": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/genomicsdbimport": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "967fb22dedc2c8855f00e64c3d7b5814c85242a6"
             },
             "gatk4/genotypegvcfs": {
-                "git_sha": "598d7abdb2a8df1aa3471c48d9186a9e3465983f"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/getpileupsummaries": {
-                "git_sha": "f5d5926516d2319c1af83fb4b33834cc4461ce62"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/haplotypecaller": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/learnreadorientationmodel": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/markduplicates": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/mutect2": {
-                "git_sha": "f5d5926516d2319c1af83fb4b33834cc4461ce62"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "gatk4/variantrecalibrator": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "manta/germline": {
-                "git_sha": "9d0cad583b9a71a6509b754fdf589cbfbed08961"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "manta/somatic": {
-                "git_sha": "9d0cad583b9a71a6509b754fdf589cbfbed08961"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "manta/tumoronly": {
-                "git_sha": "9d0cad583b9a71a6509b754fdf589cbfbed08961"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "msisensorpro/msi_somatic": {
                 "git_sha": "c8ebd0de36c649a14fc92f2f73cbd9f691a8ce0a"
@@ -112,58 +112,58 @@
                 "git_sha": "c8ebd0de36c649a14fc92f2f73cbd9f691a8ce0a"
             },
             "multiqc": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samblaster": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samtools/bam2fq": {
-                "git_sha": "e751e5040af57e1b4e06ed4e0f3efe6de25c1683"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samtools/faidx": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samtools/index": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samtools/merge": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samtools/mpileup": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samtools/stats": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "samtools/view": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "seqkit/split2": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "snpeff": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "strelka/germline": {
-                "git_sha": "f5d5926516d2319c1af83fb4b33834cc4461ce62"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "strelka/somatic": {
-                "git_sha": "f5d5926516d2319c1af83fb4b33834cc4461ce62"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "tabix/bgziptabix": {
-                "git_sha": "e22966ce74340cb671576143e5fdbbd71670cffa"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "tabix/tabix": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "tiddit/sv": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "trimgalore": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "vcftools": {
-                "git_sha": "e20e57f90b6787ac9a010a980cf6ea98bd990046"
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             }
         }
     }

--- a/modules/local/bgzip.nf
+++ b/modules/local/bgzip.nf
@@ -15,6 +15,9 @@ process BGZIP {
     tuple val(meta), path("*.vcf"), emit: vcf
     path "versions.yml"           , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/build_intervals/main.nf
+++ b/modules/local/build_intervals/main.nf
@@ -13,6 +13,9 @@ process BUILD_INTERVALS {
     output:
     path "*.bed", emit: bed
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     awk -v FS='\t' -v OFS='\t' '{ print \$1, \"0\", \$2 }' ${fasta_fai} > ${fasta_fai.baseName}.bed

--- a/modules/local/concat_vcf/main.nf
+++ b/modules/local/concat_vcf/main.nf
@@ -17,13 +17,16 @@ process CONCAT_VCF {
     tuple val(meta), path("${prefix}.vcf.gz.tbi"), emit: tbi
     path  "versions.yml"                         , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args  ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     def target_options   = target_bed ? "-t ${target_bed}" : ""
-
     """
     concatenateVCFs.sh -i ${fasta_fai} -c ${task.cpus} -o ${prefix}.vcf ${target_options} $args
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')

--- a/modules/local/create_intervals_bed/main.nf
+++ b/modules/local/create_intervals_bed/main.nf
@@ -14,6 +14,9 @@ process CREATE_INTERVALS_BED {
     path ("*.bed"), emit: bed
     //TODO version number missing
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     // If intervals file is in BED format,
     // Fifth column is interpreted to contain runtime estimates

--- a/modules/local/deeptools/bamcoverage.nf
+++ b/modules/local/deeptools/bamcoverage.nf
@@ -14,10 +14,12 @@ process DEEPTOOLS_BAMCOVERAGE {
     tuple val(meta), path("*.bigWig"), emit: bigwig
     path "versions.yml"              , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-
     """
     bamCoverage \
     --bam $bam \

--- a/modules/local/gatk4/applybqsrspark/main.nf
+++ b/modules/local/gatk4/applybqsrspark/main.nf
@@ -16,6 +16,9 @@ process GATK4_APPLYBQSR_SPARK {
     tuple val(meta), path("*.cram"), emit: cram
     path "versions.yml"            , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args  ?: ''
     def avail_mem = 3

--- a/modules/local/gatk4/baserecalibratorspark/main.nf
+++ b/modules/local/gatk4/baserecalibratorspark/main.nf
@@ -18,6 +18,9 @@ process GATK4_BASERECALIBRATOR_SPARK {
     tuple val(meta), path("*.table"), emit: table
     path "versions.yml"             , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args  ?: ''
     def avail_mem = 3

--- a/modules/local/gatk4/gatherpileupsummaries.nf
+++ b/modules/local/gatk4/gatherpileupsummaries.nf
@@ -17,6 +17,9 @@ process GATK4_GATHERPILEUPSUMMARIES {
     tuple val(meta), path("*.table"), emit: table
     path "versions.yml"           , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/gatk4/intervallisttobed.nf
+++ b/modules/local/gatk4/intervallisttobed.nf
@@ -14,6 +14,9 @@ process GATK4_INTERVALLISTTOBED {
     tuple val(meta), path("*.bed"), emit: bed
     path "versions.yml"           , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/gatk4/mergemutectstats.nf
+++ b/modules/local/gatk4/mergemutectstats.nf
@@ -15,6 +15,9 @@ process GATK4_MERGEMUTECTSTATS {
     tuple val(meta), path("*.stats"), emit: stats
     path "versions.yml"             , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/index_target_bed/main.nf
+++ b/modules/local/index_target_bed/main.nf
@@ -14,6 +14,9 @@ process INDEX_TARGET_BED {
     output:
     tuple path("*.gz"), path("*.gz.tbi"), emit: gz_tbi
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     bgzip --threads ${task.cpus} -c ${target_bed} > ${target_bed}.gz

--- a/modules/local/msisensorpro/msi/main.nf
+++ b/modules/local/msisensorpro/msi/main.nf
@@ -18,6 +18,9 @@ process MSISENSORPRO_MSI {
     tuple val(meta), path("${prefix}_somatic.list") , emit: output_somatic
     path "versions.yml"                             , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args  ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"

--- a/modules/local/msisensorpro/scan/main.nf
+++ b/modules/local/msisensorpro/scan/main.nf
@@ -14,6 +14,9 @@ process MSISENSORPRO_SCAN {
     tuple val(meta), path("*.list"), emit: list
     path "versions.yml"            , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args  ?: ''
     def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"

--- a/modules/local/qualimap/bamqc/main.nf
+++ b/modules/local/qualimap/bamqc/main.nf
@@ -15,6 +15,9 @@ process QUALIMAP_BAMQC {
     tuple val(meta), path("${prefix}"), emit: results
     path  "versions.yml"              , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"

--- a/modules/local/qualimap/bamqccram/main.nf
+++ b/modules/local/qualimap/bamqccram/main.nf
@@ -17,6 +17,9 @@ process QUALIMAP_BAMQC_CRAM {
     tuple val(meta), path("${prefix}"), emit: results
     path  "versions.yml"              , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"

--- a/modules/local/samtools/fastq/main.nf
+++ b/modules/local/samtools/fastq/main.nf
@@ -16,13 +16,13 @@ process SAMTOOLS_FASTQ {
     tuple val(meta), path("*.fq.gz"), emit: reads
     path "versions.yml"             , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def args2 = task.ext.args ?: ''
-
     def prefix = task.ext.prefix ?: "${meta.id}"
-
-
     """
     samtools collate -O -@$task.cpus $args $input . |
 

--- a/modules/local/samtools/index/main.nf
+++ b/modules/local/samtools/index/main.nf
@@ -16,6 +16,9 @@ process SAMTOOLS_INDEX {
     tuple val(meta), path("*.cram", includeInputs:true), path("*.crai"), optional:true, emit: cram_crai
     path  "versions.yml"                                                              , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args  ?: ''
     """

--- a/modules/local/samtools/mergecram/main.nf
+++ b/modules/local/samtools/mergecram/main.nf
@@ -15,6 +15,9 @@ process SAMTOOLS_MERGE_CRAM {
     tuple val(meta), path("*.cram"), emit: cram
     path  "versions.yml"           , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
     """

--- a/modules/local/samtools/viewindex/main.nf
+++ b/modules/local/samtools/viewindex/main.nf
@@ -11,12 +11,15 @@ process SAMTOOLS_VIEWINDEX {
     input:
     tuple val(meta), path(input), path(index)
     path  fasta
-    path  fai_fai
+    path  fasta_fai
 
     output:
     tuple val(meta), path("*.bam"), path("*.bai")  , optional: true, emit: bam_bai
     tuple val(meta), path("*.cram"), path("*.crai"), optional: true, emit: cram_crai
     path  "versions.yml"                                           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args  ?: ''

--- a/modules/local/samtoolsview.nf
+++ b/modules/local/samtoolsview.nf
@@ -15,6 +15,9 @@ process SAMTOOLS_VIEW {
     tuple val(meta), path("*.bam"), path("*.bai") , emit: bam
     path  "versions.yml"           , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''

--- a/modules/nf-core/modules/bcftools/stats/meta.yml
+++ b/modules/nf-core/modules/bcftools/stats/meta.yml
@@ -1,42 +1,42 @@
 name: bcftools_stats
 description: Generates stats from VCF files
 keywords:
-    - variant calling
-    - stats
-    - VCF
+  - variant calling
+  - stats
+  - VCF
 tools:
-    - stats:
-        description: |
-          Parses VCF or BCF and produces text file stats which is suitable for
-          machine processing and can be plotted using plot-vcfstats.
-        homepage: http://samtools.github.io/bcftools/bcftools.html
-        documentation: http://www.htslib.org/doc/bcftools.html
-        doi: 10.1093/bioinformatics/btp352
-        licence: ['MIT']
+  - stats:
+      description: |
+        Parses VCF or BCF and produces text file stats which is suitable for
+        machine processing and can be plotted using plot-vcfstats.
+      homepage: http://samtools.github.io/bcftools/bcftools.html
+      documentation: http://www.htslib.org/doc/bcftools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - vcf:
-        type: file
-        description: VCF input file
-        pattern: "*.{vcf}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: VCF input file
+      pattern: "*.{vcf}"
 output:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - stats:
-        type: file
-        description: Text output file containing stats
-        pattern: "*_{stats.txt}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - stats:
+      type: file
+      description: Text output file containing stats
+      pattern: "*_{stats.txt}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@joseespinosa"
-    - "@drpatelh"
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/modules/bwa/index/meta.yml
+++ b/modules/nf-core/modules/bwa/index/meta.yml
@@ -1,32 +1,32 @@
 name: bwa_index
 description: Create BWA index for reference genome
 keywords:
-    - index
-    - fasta
-    - genome
-    - reference
+  - index
+  - fasta
+  - genome
+  - reference
 tools:
-    - bwa:
-        description: |
-            BWA is a software package for mapping DNA sequences against
-            a large reference genome, such as the human genome.
-        homepage: http://bio-bwa.sourceforge.net/
-        documentation: http://www.htslib.org/doc/samtools.html
-        arxiv: arXiv:1303.3997
-        licence: ['GPL-3.0-or-later']
+  - bwa:
+      description: |
+        BWA is a software package for mapping DNA sequences against
+        a large reference genome, such as the human genome.
+      homepage: http://bio-bwa.sourceforge.net/
+      documentation: http://www.htslib.org/doc/samtools.html
+      arxiv: arXiv:1303.3997
+      licence: ["GPL-3.0-or-later"]
 input:
-    - fasta:
-        type: file
-        description: Input genome fasta file
+  - fasta:
+      type: file
+      description: Input genome fasta file
 output:
-    - index:
-        type: file
-        description: BWA genome index files
-        pattern: "*.{amb,ann,bwt,pac,sa}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - index:
+      type: file
+      description: BWA genome index files
+      pattern: "*.{amb,ann,bwt,pac,sa}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@maxulysse"
+  - "@drpatelh"
+  - "@maxulysse"

--- a/modules/nf-core/modules/bwa/mem/meta.yml
+++ b/modules/nf-core/modules/bwa/mem/meta.yml
@@ -1,50 +1,50 @@
 name: bwa_mem
 description: Performs fastq alignment to a fasta reference using BWA
 keywords:
-    - mem
-    - bwa
-    - alignment
-    - map
-    - fastq
-    - bam
-    - sam
+  - mem
+  - bwa
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
 tools:
-    - bwa:
-        description: |
-            BWA is a software package for mapping DNA sequences against
-            a large reference genome, such as the human genome.
-        homepage: http://bio-bwa.sourceforge.net/
-        documentation: http://www.htslib.org/doc/samtools.html
-        arxiv: arXiv:1303.3997
-        licence: ['GPL-3.0-or-later']
+  - bwa:
+      description: |
+        BWA is a software package for mapping DNA sequences against
+        a large reference genome, such as the human genome.
+      homepage: http://bio-bwa.sourceforge.net/
+      documentation: http://www.htslib.org/doc/samtools.html
+      arxiv: arXiv:1303.3997
+      licence: ["GPL-3.0-or-later"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: |
-            List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-            respectively.
-    - index:
-        type: file
-        description: BWA genome index files
-        pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
-    - sort_bam:
-        type: boolean
-        description: use samtools sort (true) or samtools view (false)
-        pattern: "true or false"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - index:
+      type: file
+      description: BWA genome index files
+      pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+      pattern: "true or false"
 output:
-    - bam:
-        type: file
-        description: Output BAM file containing read alignments
-        pattern: "*.{bam}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - bam:
+      type: file
+      description: Output BAM file containing read alignments
+      pattern: "*.{bam}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@jeremy1805"
+  - "@drpatelh"
+  - "@jeremy1805"

--- a/modules/nf-core/modules/bwamem2/index/meta.yml
+++ b/modules/nf-core/modules/bwamem2/index/meta.yml
@@ -1,30 +1,30 @@
 name: bwamem2_index
 description: Create BWA-mem2 index for reference genome
 keywords:
-    - index
-    - fasta
-    - genome
-    - reference
+  - index
+  - fasta
+  - genome
+  - reference
 tools:
-    - bwa:
-        description: |
-            BWA-mem2 is a software package for mapping DNA sequences against
-            a large reference genome, such as the human genome.
-        homepage: https://github.com/bwa-mem2/bwa-mem2
-        documentation: https://github.com/bwa-mem2/bwa-mem2#usage
-        licence: ['MIT']
+  - bwa:
+      description: |
+        BWA-mem2 is a software package for mapping DNA sequences against
+        a large reference genome, such as the human genome.
+      homepage: https://github.com/bwa-mem2/bwa-mem2
+      documentation: https://github.com/bwa-mem2/bwa-mem2#usage
+      licence: ["MIT"]
 input:
-    - fasta:
-        type: file
-        description: Input genome fasta file
+  - fasta:
+      type: file
+      description: Input genome fasta file
 output:
-    - index:
-        type: file
-        description: BWA genome index files
-        pattern: "*.{0132,amb,ann,bwt.2bit.64,pac}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - index:
+      type: file
+      description: BWA genome index files
+      pattern: "*.{0132,amb,ann,bwt.2bit.64,pac}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@maxulysse"
+  - "@maxulysse"

--- a/modules/nf-core/modules/bwamem2/mem/meta.yml
+++ b/modules/nf-core/modules/bwamem2/mem/meta.yml
@@ -1,49 +1,49 @@
 name: bwamem2_mem
 description: Performs fastq alignment to a fasta reference using BWA
 keywords:
-    - mem
-    - bwa
-    - alignment
-    - map
-    - fastq
-    - bam
-    - sam
+  - mem
+  - bwa
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
 tools:
-    - bwa:
-        description: |
-            BWA-mem2 is a software package for mapping DNA sequences against
-            a large reference genome, such as the human genome.
-        homepage: https://github.com/bwa-mem2/bwa-mem2
-        documentation: http://www.htslib.org/doc/samtools.html
-        arxiv: arXiv:1303.3997
-        licence: ['MIT']
+  - bwa:
+      description: |
+        BWA-mem2 is a software package for mapping DNA sequences against
+        a large reference genome, such as the human genome.
+      homepage: https://github.com/bwa-mem2/bwa-mem2
+      documentation: http://www.htslib.org/doc/samtools.html
+      arxiv: arXiv:1303.3997
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: |
-            List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-            respectively.
-    - index:
-        type: file
-        description: BWA genome index files
-        pattern: "Directory containing BWA index *.{0132,amb,ann,bwt.2bit.64,pac}"
-    - sort_bam:
-        type: boolean
-        description: use samtools sort (true) or samtools view (false)
-        pattern: "true or false"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - index:
+      type: file
+      description: BWA genome index files
+      pattern: "Directory containing BWA index *.{0132,amb,ann,bwt.2bit.64,pac}"
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+      pattern: "true or false"
 output:
-    - bam:
-        type: file
-        description: Output BAM file containing read alignments
-        pattern: "*.{bam}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - bam:
+      type: file
+      description: Output BAM file containing read alignments
+      pattern: "*.{bam}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@maxulysse"
+  - "@maxulysse"

--- a/modules/nf-core/modules/cat/fastq/meta.yml
+++ b/modules/nf-core/modules/cat/fastq/meta.yml
@@ -1,39 +1,39 @@
 name: cat_fastq
 description: Concatenates fastq files
 keywords:
-    - fastq
-    - concatenate
+  - fastq
+  - concatenate
 tools:
-    - cat:
-        description: |
-            The cat utility reads files sequentially, writing them to the standard output.
-        documentation: https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html
-        licence: ['GPL-3.0-or-later']
+  - cat:
+      description: |
+        The cat utility reads files sequentially, writing them to the standard output.
+      documentation: https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html
+      licence: ["GPL-3.0-or-later"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: list
-        description: |
-            List of input FastQ files to be concatenated.
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: list
+      description: |
+        List of input FastQ files to be concatenated.
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: Merged fastq file
-        pattern: "*.{merged.fastq.gz}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: Merged fastq file
+      pattern: "*.{merged.fastq.gz}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 
 authors:
-    - "@joseespinosa"
-    - "@drpatelh"
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/modules/cnvkit/batch/meta.yml
+++ b/modules/nf-core/modules/cnvkit/batch/meta.yml
@@ -10,7 +10,7 @@ tools:
         CNVkit is a Python library and command-line software toolkit to infer and visualize copy number from high-throughput DNA sequencing data. It is designed for use with hybrid capture, including both whole-exome and custom target panels, and short-read sequencing platforms such as Illumina and Ion Torrent.
       homepage: https://cnvkit.readthedocs.io/en/stable/index.html
       documentation: https://cnvkit.readthedocs.io/en/stable/index.html
-      licence: ['Apache-2.0']
+      licence: ["Apache-2.0"]
 params:
   - outdir:
       type: string
@@ -85,9 +85,9 @@ output:
       description: File containing software versions
       pattern: "versions.yml"
 authors:
-    - "@kaurravneet4123"
-    - "@KevinMenden"
-    - "@MaxUlysse"
-    - "@drpatelh"
-    - "@fbdtemme"
-    - "@lassefolkersen"
+  - "@kaurravneet4123"
+  - "@KevinMenden"
+  - "@MaxUlysse"
+  - "@drpatelh"
+  - "@fbdtemme"
+  - "@lassefolkersen"

--- a/modules/nf-core/modules/custom/dumpsoftwareversions/meta.yml
+++ b/modules/nf-core/modules/custom/dumpsoftwareversions/meta.yml
@@ -8,7 +8,7 @@ tools:
       description: Custom module used to dump software versions within the nf-core pipeline template
       homepage: https://github.com/nf-core/tools
       documentation: https://github.com/nf-core/tools
-      licence: ['MIT']
+      licence: ["MIT"]
 input:
   - versions:
       type: file

--- a/modules/nf-core/modules/deepvariant/meta.yml
+++ b/modules/nf-core/modules/deepvariant/meta.yml
@@ -10,7 +10,7 @@ tools:
       documentation: https://github.com/google/deepvariant
       tool_dev_url: https://github.com/google/deepvariant
       doi: "https://doi.org/10.1038/nbt.4235"
-      licence: ['BSD-3-clause']
+      licence: ["BSD-3-clause"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/ensemblvep/meta.yml
+++ b/modules/nf-core/modules/ensemblvep/meta.yml
@@ -1,65 +1,65 @@
 name: ENSEMBLVEP
 description: Ensembl Variant Effect Predictor (VEP)
 keywords:
-    - annotation
+  - annotation
 tools:
-    - ensemblvep:
-        description: |
-            VEP determines the effect of your variants (SNPs, insertions, deletions, CNVs
-            or structural variants) on genes, transcripts, and protein sequence, as well as regulatory regions.
-        homepage: https://www.ensembl.org/info/docs/tools/vep/index.html
-        documentation: https://www.ensembl.org/info/docs/tools/vep/script/index.html
-        licence: ['Apache-2.0']
+  - ensemblvep:
+      description: |
+        VEP determines the effect of your variants (SNPs, insertions, deletions, CNVs
+        or structural variants) on genes, transcripts, and protein sequence, as well as regulatory regions.
+      homepage: https://www.ensembl.org/info/docs/tools/vep/index.html
+      documentation: https://www.ensembl.org/info/docs/tools/vep/script/index.html
+      licence: ["Apache-2.0"]
 params:
-    - use_cache:
-        type: boolean
-        description: |
-          Enable the usage of containers with cache
-          Does not work with conda
-    - vep_tag:
-        type: value
-        description: |
-          Specify the tag for the container
-          https://hub.docker.com/r/nfcore/vep/tags
+  - use_cache:
+      type: boolean
+      description: |
+        Enable the usage of containers with cache
+        Does not work with conda
+  - vep_tag:
+      type: value
+      description: |
+        Specify the tag for the container
+        https://hub.docker.com/r/nfcore/vep/tags
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - vcf:
-        type: file
-        description: |
-            vcf to annotate
-    - genome:
-        type: value
-        description: |
-            which genome to annotate with
-    - species:
-        type: value
-        description: |
-            which species to annotate with
-    - cache_version:
-        type: value
-        description: |
-            which version of the cache to annotate with
-    - cache:
-        type: file
-        description: |
-            path to VEP cache (optional)
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: |
+        vcf to annotate
+  - genome:
+      type: value
+      description: |
+        which genome to annotate with
+  - species:
+      type: value
+      description: |
+        which species to annotate with
+  - cache_version:
+      type: value
+      description: |
+        which version of the cache to annotate with
+  - cache:
+      type: file
+      description: |
+        path to VEP cache (optional)
 output:
-    - vcf:
-        type: file
-        description: |
-            annotated vcf
-        pattern: "*.ann.vcf"
-    - report:
-        type: file
-        description: VEP report file
-        pattern: "*.html"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - vcf:
+      type: file
+      description: |
+        annotated vcf
+      pattern: "*.ann.vcf"
+  - report:
+      type: file
+      description: VEP report file
+      pattern: "*.html"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@maxulysse"
+  - "@maxulysse"

--- a/modules/nf-core/modules/fastqc/meta.yml
+++ b/modules/nf-core/modules/fastqc/meta.yml
@@ -1,52 +1,52 @@
 name: fastqc
 description: Run FastQC on sequenced reads
 keywords:
-    - quality control
-    - qc
-    - adapters
-    - fastq
+  - quality control
+  - qc
+  - adapters
+  - fastq
 tools:
-    - fastqc:
-        description: |
-            FastQC gives general quality metrics about your reads.
-            It provides information about the quality score distribution
-            across your reads, the per base sequence content (%A/C/G/T).
-            You get information about adapter contamination and other
-            overrepresented sequences.
-        homepage: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/
-        documentation: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/
-        licence: ['GPL-2.0-only']
+  - fastqc:
+      description: |
+        FastQC gives general quality metrics about your reads.
+        It provides information about the quality score distribution
+        across your reads, the per base sequence content (%A/C/G/T).
+        You get information about adapter contamination and other
+        overrepresented sequences.
+      homepage: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/
+      documentation: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/
+      licence: ["GPL-2.0-only"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: |
-            List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-            respectively.
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - html:
-        type: file
-        description: FastQC report
-        pattern: "*_{fastqc.html}"
-    - zip:
-        type: file
-        description: FastQC report archive
-        pattern: "*_{fastqc.zip}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - html:
+      type: file
+      description: FastQC report
+      pattern: "*_{fastqc.html}"
+  - zip:
+      type: file
+      description: FastQC report archive
+      pattern: "*_{fastqc.zip}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@grst"
-    - "@ewels"
-    - "@FelixKrueger"
+  - "@drpatelh"
+  - "@grst"
+  - "@ewels"
+  - "@FelixKrueger"

--- a/modules/nf-core/modules/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/nf-core/modules/fgbio/callmolecularconsensusreads/main.nf
@@ -14,6 +14,9 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
     tuple val(meta), path("*.bam"), emit: bam
     path  "versions.yml"          , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/nf-core/modules/fgbio/callmolecularconsensusreads/meta.yml
+++ b/modules/nf-core/modules/fgbio/callmolecularconsensusreads/meta.yml
@@ -2,44 +2,44 @@ name: fgbio_callmolecularconsensusreads
 description: Calls consensus sequences from reads with the same unique molecular tag.
 
 keywords:
-    - UMIs
-    - consensus sequence
-    - bam
-    - sam
+  - UMIs
+  - consensus sequence
+  - bam
+  - sam
 tools:
-    - fgbio:
-        description: Tools for working with genomic and high throughput sequencing data.
-        homepage: https://github.com/fulcrumgenomics/fgbio
-        documentation: http://fulcrumgenomics.github.io/fgbio/
-        licence: ['MIT']
+  - fgbio:
+      description: Tools for working with genomic and high throughput sequencing data.
+      homepage: https://github.com/fulcrumgenomics/fgbio
+      documentation: http://fulcrumgenomics.github.io/fgbio/
+      licence: ["MIT"]
 
 input:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false, collapse:false ]
-    - bam:
-        type: file
-        description: |
-          The input SAM or BAM file.
-        pattern: "*.{bam,sam}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false, collapse:false ]
+  - bam:
+      type: file
+      description: |
+        The input SAM or BAM file.
+      pattern: "*.{bam,sam}"
 
 output:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - bam:
-        type: file
-        description: |
-          Output SAM or BAM file to write consensus reads.
-        pattern: "*.{bam,sam}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: |
+        Output SAM or BAM file to write consensus reads.
+      pattern: "*.{bam,sam}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 
 authors:
-    - "@sruthipsuresh"
+  - "@sruthipsuresh"

--- a/modules/nf-core/modules/fgbio/fastqtobam/main.nf
+++ b/modules/nf-core/modules/fgbio/fastqtobam/main.nf
@@ -15,6 +15,9 @@ process FGBIO_FASTQTOBAM {
     tuple val(meta), path("*_umi_converted.bam"), emit: umibam
     path "versions.yml"                         , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/nf-core/modules/fgbio/fastqtobam/meta.yml
+++ b/modules/nf-core/modules/fgbio/fastqtobam/meta.yml
@@ -1,6 +1,6 @@
 name: fgbio_fastqtobam
 description: |
-      Using the FGBIO tools, converts FASTQ files sequenced with UMIs into BAM files, moving the UMI barcode into the RX field of the BAM file
+  Using the FGBIO tools, converts FASTQ files sequenced with UMIs into BAM files, moving the UMI barcode into the RX field of the BAM file
 keywords:
   - fastqtobam
   - fgbio
@@ -11,7 +11,7 @@ tools:
       documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
       tool_dev_url: https://github.com/fulcrumgenomics/fgbio
       doi: ""
-      licence: ['MIT']
+      licence: ["MIT"]
 
 input:
   - reads:
@@ -22,11 +22,11 @@ input:
   - read_structure:
       type: string
       description: |
-                  A read structure should always be provided for each of the fastq files.
-                  If single end, the string will contain only one structure (i.e. "2M11S+T"), if paired-end the string
-                  will contain two structures separated by a blank space (i.e. "2M11S+T 2M11S+T").
-                  If the read does not contain any UMI, the structure will be +T (i.e. only template of any length).
-                  https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures
+        A read structure should always be provided for each of the fastq files.
+        If single end, the string will contain only one structure (i.e. "2M11S+T"), if paired-end the string
+        will contain two structures separated by a blank space (i.e. "2M11S+T 2M11S+T").
+        If the read does not contain any UMI, the structure will be +T (i.e. only template of any length).
+        https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures
 
 output:
   - meta:

--- a/modules/nf-core/modules/fgbio/groupreadsbyumi/main.nf
+++ b/modules/nf-core/modules/fgbio/groupreadsbyumi/main.nf
@@ -16,6 +16,9 @@ process FGBIO_GROUPREADSBYUMI {
     tuple val(meta), path("*_umi_histogram.txt"), emit: histogram
     path "versions.yml"                         , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/nf-core/modules/fgbio/groupreadsbyumi/meta.yml
+++ b/modules/nf-core/modules/fgbio/groupreadsbyumi/meta.yml
@@ -1,11 +1,11 @@
 name: fgbio_groupreadsbyumi
 description: |
-      Groups reads together that appear to have come from the same original molecule.
-      Reads are grouped by template, and then templates are sorted by the 5’ mapping positions
-      of the reads from the template, used from earliest mapping position to latest.
-      Reads that have the same end positions are then sub-grouped by UMI sequence.
-      (!) Note: the MQ tag is required on reads with mapped mates (!)
-      This can be added using samblaster with the optional argument --addMateTags.
+  Groups reads together that appear to have come from the same original molecule.
+  Reads are grouped by template, and then templates are sorted by the 5’ mapping positions
+  of the reads from the template, used from earliest mapping position to latest.
+  Reads that have the same end positions are then sub-grouped by UMI sequence.
+  (!) Note: the MQ tag is required on reads with mapped mates (!)
+  This can be added using samblaster with the optional argument --addMateTags.
 keywords:
   - UMI
   - groupreads
@@ -17,7 +17,7 @@ tools:
       documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
       tool_dev_url: https://github.com/fulcrumgenomics/fgbio
       doi: ""
-      licence: ['MIT']
+      licence: ["MIT"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/freebayes/main.nf
+++ b/modules/nf-core/modules/freebayes/main.nf
@@ -8,7 +8,7 @@ process FREEBAYES {
         'quay.io/biocontainers/freebayes:1.3.5--py38ha193a2f_3' }"
 
     input:
-    tuple val(meta), path(input_1), path(input_1_index), path(input_2), path(input_2_index), path (target_bed)
+    tuple val(meta), path(input_1), path(input_1_index), path(input_2), path(input_2_index), path(target_bed)
     path fasta
     path fasta_fai
     path samples
@@ -19,11 +19,14 @@ process FREEBAYES {
     tuple val(meta), path("*.vcf.gz"), emit: vcf
     path  "versions.yml"             , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def input            = input_2        ? "${input_1} ${input_2}"        : "${input_1}"
-    def targets_file     = target_bed     ? "--target ${target_bed}"          : ""
+    def targets_file     = target_bed     ? "--target ${target_bed}"       : ""
     def samples_file     = samples        ? "--samples ${samples}"         : ""
     def populations_file = populations    ? "--populations ${populations}" : ""
     def cnv_file         = cnv            ? "--cnv-map ${cnv}"             : ""
@@ -59,7 +62,7 @@ process FREEBAYES {
             $args \\
             $input > ${prefix}.vcf
 
-        gzip --no-name ${prefix}.vcf
+        bgzip ${prefix}.vcf
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/nf-core/modules/freebayes/meta.yml
+++ b/modules/nf-core/modules/freebayes/meta.yml
@@ -16,7 +16,7 @@ tools:
       documentation: https://github.com/freebayes/freebayes
       tool_dev_url: https://github.com/freebayes/freebayes
       doi: "arXiv:1207.3907"
-      licence: ['MIT']
+      licence: ["MIT"]
 
 input:
   - meta:
@@ -31,7 +31,11 @@ input:
   - input_index:
       type: file
       description: BAM/CRAM/SAM index file
-      pattern: "*.bam.bai"
+      pattern: "*.{bai,crai}"
+  - target_bed:
+      type: file
+      description: Optional - Limit analysis to targets listed in this BED-format FILE.
+      pattern: "*.bed"
   - fasta:
       type: file
       description: reference fasta file
@@ -40,10 +44,6 @@ input:
       type: file
       description: reference fasta file index
       pattern: "*.{fa,fasta}.fai"
-  - targets:
-      type: file
-      description: Optional - Limit analysis to targets listed in this BED-format FILE.
-      pattern: "*.bed"
   - samples:
       type: file
       description: Optional - Limit analysis to samples listed (one per line) in the FILE.
@@ -55,10 +55,10 @@ input:
   - cnv:
       type: file
       description: |
-          A copy number map BED file, which has either a sample-level ploidy:
-          sample_name copy_number
-          or a region-specific format:
-          seq_name start end sample_name copy_number
+        A copy number map BED file, which has either a sample-level ploidy:
+        sample_name copy_number
+        or a region-specific format:
+        seq_name start end sample_name copy_number
       pattern: "*.bed"
 
 output:

--- a/modules/nf-core/modules/gatk4/applybqsr/main.nf
+++ b/modules/nf-core/modules/gatk4/applybqsr/main.nf
@@ -2,10 +2,10 @@ process GATK4_APPLYBQSR {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(input), path(input_index), path(bqsr_table), path(intervals)

--- a/modules/nf-core/modules/gatk4/applybqsr/meta.yml
+++ b/modules/nf-core/modules/gatk4/applybqsr/meta.yml
@@ -6,13 +6,13 @@ keywords:
 tools:
   - gatk4:
     description: |
-        Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
-        with a primary focus on variant discovery and genotyping. Its powerful processing engine
-        and high-performance computing features make it capable of taking on projects of any size.
+      Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+      with a primary focus on variant discovery and genotyping. Its powerful processing engine
+      and high-performance computing features make it capable of taking on projects of any size.
     homepage: https://gatk.broadinstitute.org/hc/en-us
     documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
     doi: 10.1158/1538-7445.AM2017-3590
-    licence: ['Apache-2.0']
+    licence: ["Apache-2.0"]
 
 input:
   - meta:
@@ -46,7 +46,6 @@ input:
       type: file
       description: GATK sequence dictionary
       pattern: "*.dict"
-
 
 output:
   - meta:

--- a/modules/nf-core/modules/gatk4/applyvqsr/main.nf
+++ b/modules/nf-core/modules/gatk4/applyvqsr/main.nf
@@ -2,32 +2,29 @@ process GATK4_APPLYVQSR {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi), path(recal), path(recalidx), path(tranches)
     path fasta
     path fai
     path dict
-    val allelespecific
-    val truthsensitivity
-    val mode
 
     output:
     tuple val(meta), path("*.vcf.gz")     , emit: vcf
     tuple val(meta), path("*.tbi")        , emit: tbi
     path "versions.yml"                   , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     refCommand = fasta ? "-R ${fasta} " : ''
-    alleleSpecificCommand = allelespecific ? '-AS' : ''
-    truthSensitivityCommand = truthsensitivity ? "--truth-sensitivity-filter-level ${truthsensitivity}" : ''
-    modeCommand = mode ? "--mode ${mode} " : 'SNP'
 
     def avail_mem = 3
     if (!task.memory) {
@@ -40,11 +37,8 @@ process GATK4_APPLYVQSR {
         ${refCommand} \\
         -V ${vcf} \\
         -O ${prefix}.vcf.gz \\
-        ${alleleSpecificCommand} \\
-        ${truthSensitivityCommand} \\
         --tranches-file $tranches \\
         --recal-file $recal \\
-        ${modeCommand} \\
         $args
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/modules/gatk4/applyvqsr/meta.yml
+++ b/modules/nf-core/modules/gatk4/applyvqsr/meta.yml
@@ -17,7 +17,7 @@ tools:
       homepage: https://gatk.broadinstitute.org/hc/en-us
       documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
       doi: 10.1158/1538-7445.AM2017-3590
-      licence: ['Apache-2.0']
+      licence: ["Apache-2.0"]
 
 input:
   - meta:
@@ -57,18 +57,6 @@ input:
       type: file
       description: GATK sequence dictionary
       pattern: "*.dict"
-  - allelespecific:
-      type: boolean
-      description: Whether or not to run ApplyVQSR in allele specific mode, this should be kept the same as the stage 1 VariantRecalibrator run.
-      pattern: "{true,false}"
-  - truthsensitivity:
-      type: double
-      description: Value to be used as the truth sensitivity cutoff score.
-      pattern: "99.0"
-  - mode:
-      type: String
-      description: Specifies which recalibration mode to employ, should be the same as the stage 1 VariantRecalibrator run. (SNP is default, BOTH is intended for testing only)
-      pattern: "{SNP,INDEL,BOTH}"
 
 output:
   - vcf:

--- a/modules/nf-core/modules/gatk4/baserecalibrator/main.nf
+++ b/modules/nf-core/modules/gatk4/baserecalibrator/main.nf
@@ -2,10 +2,10 @@ process GATK4_BASERECALIBRATOR {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/modules/gatk4/baserecalibrator/meta.yml
+++ b/modules/nf-core/modules/gatk4/baserecalibrator/meta.yml
@@ -5,14 +5,13 @@ keywords:
 tools:
   - gatk4:
     description: |
-        Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
-        with a primary focus on variant discovery and genotyping. Its powerful processing engine
-        and high-performance computing features make it capable of taking on projects of any size.
+      Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+      with a primary focus on variant discovery and genotyping. Its powerful processing engine
+      and high-performance computing features make it capable of taking on projects of any size.
     homepage: https://gatk.broadinstitute.org/hc/en-us
     documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
     doi: 10.1158/1538-7445.AM2017-3590
-    licence: ['Apache-2.0']
-
+    licence: ["Apache-2.0"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/calculatecontamination/main.nf
+++ b/modules/nf-core/modules/gatk4/calculatecontamination/main.nf
@@ -2,10 +2,10 @@ process GATK4_CALCULATECONTAMINATION {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(pileup), path(matched)

--- a/modules/nf-core/modules/gatk4/calculatecontamination/meta.yml
+++ b/modules/nf-core/modules/gatk4/calculatecontamination/meta.yml
@@ -16,7 +16,7 @@ tools:
       homepage: https://gatk.broadinstitute.org/hc/en-us
       documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
       doi: 10.1158/1538-7445.AM2017-3590
-      licence: ['Apache-2.0']
+      licence: ["Apache-2.0"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/createsequencedictionary/main.nf
+++ b/modules/nf-core/modules/gatk4/createsequencedictionary/main.nf
@@ -2,10 +2,10 @@ process GATK4_CREATESEQUENCEDICTIONARY {
     tag "$fasta"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     path fasta

--- a/modules/nf-core/modules/gatk4/createsequencedictionary/meta.yml
+++ b/modules/nf-core/modules/gatk4/createsequencedictionary/meta.yml
@@ -1,32 +1,32 @@
 name: gatk4_createsequencedictionary
 description: Creates a sequence dictionary for a reference sequence
 keywords:
-    - dictionary
-    - fasta
+  - dictionary
+  - fasta
 tools:
-    - gatk:
-        description: |
-            Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
-            with a primary focus on variant discovery and genotyping. Its powerful processing engine
-            and high-performance computing features make it capable of taking on projects of any size.
-        homepage: https://gatk.broadinstitute.org/hc/en-us
-        documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
-        doi: 10.1158/1538-7445.AM2017-3590
-        licence: ['Apache-2.0']
+  - gatk:
+    description: |
+      Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+      with a primary focus on variant discovery and genotyping. Its powerful processing engine
+      and high-performance computing features make it capable of taking on projects of any size.
+    homepage: https://gatk.broadinstitute.org/hc/en-us
+    documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
+    doi: 10.1158/1538-7445.AM2017-3590
+    licence: ["Apache-2.0"]
 
 input:
-    - fasta:
-        type: file
-        description: Input fasta file
-        pattern: "*.{fasta,fa}"
+  - fasta:
+    type: file
+    description: Input fasta file
+    pattern: "*.{fasta,fa}"
 output:
-    - dict:
-        type: file
-        description: gatk dictionary file
-        pattern: "*.{dict}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - dict:
+    type: file
+    description: gatk dictionary file
+    pattern: "*.{dict}"
+  - versions:
+    type: file
+    description: File containing software versions
+    pattern: "versions.yml"
 authors:
-    - "@maxulysse"
+  - "@maxulysse"

--- a/modules/nf-core/modules/gatk4/estimatelibrarycomplexity/main.nf
+++ b/modules/nf-core/modules/gatk4/estimatelibrarycomplexity/main.nf
@@ -2,10 +2,10 @@ process GATK4_ESTIMATELIBRARYCOMPLEXITY {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(cram)

--- a/modules/nf-core/modules/gatk4/estimatelibrarycomplexity/meta.yml
+++ b/modules/nf-core/modules/gatk4/estimatelibrarycomplexity/meta.yml
@@ -12,7 +12,7 @@ tools:
       documentation: https://gatk.broadinstitute.org/hc/en-us
       tool_dev_url: https://github.com/broadinstitute/gatk
       doi: "10.1158/1538-7445.AM2017-3590"
-      licence: ['Apache-2.0']
+      licence: ["Apache-2.0"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/filtermutectcalls/main.nf
+++ b/modules/nf-core/modules/gatk4/filtermutectcalls/main.nf
@@ -2,10 +2,10 @@ process GATK4_FILTERMUTECTCALLS {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi), path(stats), path(orientationbias), path(segmentation), path(contaminationfile), val(contaminationest)

--- a/modules/nf-core/modules/gatk4/filtermutectcalls/meta.yml
+++ b/modules/nf-core/modules/gatk4/filtermutectcalls/meta.yml
@@ -1,6 +1,6 @@
 name: gatk4_filtermutectcalls
 description: |
-        Filters the raw output of mutect2, can optionally use outputs of calculatecontamination and learnreadorientationmodel to improve filtering.
+  Filters the raw output of mutect2, can optionally use outputs of calculatecontamination and learnreadorientationmodel to improve filtering.
 keywords:
   - filtermutectcalls
   - mutect2

--- a/modules/nf-core/modules/gatk4/gatherbqsrreports/main.nf
+++ b/modules/nf-core/modules/gatk4/gatherbqsrreports/main.nf
@@ -2,10 +2,10 @@ process GATK4_GATHERBQSRREPORTS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(recal_table)

--- a/modules/nf-core/modules/gatk4/gatherbqsrreports/meta.yml
+++ b/modules/nf-core/modules/gatk4/gatherbqsrreports/meta.yml
@@ -11,7 +11,7 @@ tools:
       documentation: https://gatk.broadinstitute.org/hc/en-us
       tool_dev_url: https://github.com/broadinstitute/gatk
       doi: "10.1158/1538-7445.AM2017-3590"
-      licence: ['BSD-3-clause']
+      licence: ["BSD-3-clause"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/genomicsdbimport/main.nf
+++ b/modules/nf-core/modules/gatk4/genomicsdbimport/main.nf
@@ -2,10 +2,10 @@ process GATK4_GENOMICSDBIMPORT {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi), path(intervalfile), val(intervalval), path(wspace)

--- a/modules/nf-core/modules/gatk4/genotypegvcfs/main.nf
+++ b/modules/nf-core/modules/gatk4/genotypegvcfs/main.nf
@@ -2,10 +2,10 @@ process GATK4_GENOTYPEGVCFS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(gvcf), path(gvcf_index), path(intervals)
@@ -19,6 +19,9 @@ process GATK4_GENOTYPEGVCFS {
     tuple val(meta), path("*.vcf.gz"), emit: vcf
     tuple val(meta), path("*.tbi")   , emit: tbi
     path  "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/nf-core/modules/gatk4/genotypegvcfs/meta.yml
+++ b/modules/nf-core/modules/gatk4/genotypegvcfs/meta.yml
@@ -12,7 +12,7 @@ tools:
       documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
       tool_dev_url: https://github.com/broadinstitute/gatk
       doi: "10.1158/1538-7445.AM2017-3590"
-      licence: ['BSD-3-clause']
+      licence: ["BSD-3-clause"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/getpileupsummaries/main.nf
+++ b/modules/nf-core/modules/gatk4/getpileupsummaries/main.nf
@@ -2,10 +2,10 @@ process GATK4_GETPILEUPSUMMARIES {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(input), path(index), path(intervals)

--- a/modules/nf-core/modules/gatk4/getpileupsummaries/meta.yml
+++ b/modules/nf-core/modules/gatk4/getpileupsummaries/meta.yml
@@ -15,7 +15,7 @@ tools:
       homepage: https://gatk.broadinstitute.org/hc/en-us
       documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
       doi: 10.1158/1538-7445.AM2017-3590
-      licence: ['Apache-2.0']
+      licence: ["Apache-2.0"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/haplotypecaller/main.nf
+++ b/modules/nf-core/modules/gatk4/haplotypecaller/main.nf
@@ -2,10 +2,10 @@ process GATK4_HAPLOTYPECALLER {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/modules/gatk4/haplotypecaller/meta.yml
+++ b/modules/nf-core/modules/gatk4/haplotypecaller/meta.yml
@@ -7,13 +7,13 @@ keywords:
 tools:
   - gatk4:
     description: |
-        Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
-        with a primary focus on variant discovery and genotyping. Its powerful processing engine
-        and high-performance computing features make it capable of taking on projects of any size.
+      Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+      with a primary focus on variant discovery and genotyping. Its powerful processing engine
+      and high-performance computing features make it capable of taking on projects of any size.
     homepage: https://gatk.broadinstitute.org/hc/en-us
     documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
     doi: 10.1158/1538-7445.AM2017-3590
-    licence: ['Apache-2.0']
+    licence: ["Apache-2.0"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/learnreadorientationmodel/main.nf
+++ b/modules/nf-core/modules/gatk4/learnreadorientationmodel/main.nf
@@ -2,10 +2,10 @@ process GATK4_LEARNREADORIENTATIONMODEL {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(f1r2)

--- a/modules/nf-core/modules/gatk4/learnreadorientationmodel/meta.yml
+++ b/modules/nf-core/modules/gatk4/learnreadorientationmodel/meta.yml
@@ -15,7 +15,7 @@ tools:
       homepage: https://gatk.broadinstitute.org/hc/en-us
       documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
       doi: 10.1158/1538-7445.AM2017-3590
-      licence: ['Apache-2.0']
+      licence: ["Apache-2.0"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/markduplicates/main.nf
+++ b/modules/nf-core/modules/gatk4/markduplicates/main.nf
@@ -2,10 +2,10 @@ process GATK4_MARKDUPLICATES {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bams)

--- a/modules/nf-core/modules/gatk4/markduplicates/meta.yml
+++ b/modules/nf-core/modules/gatk4/markduplicates/meta.yml
@@ -6,14 +6,15 @@ keywords:
   - sort
 tools:
   - gatk4:
-      description: Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+      description:
+        Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
         with a primary focus on variant discovery and genotyping. Its powerful processing engine
         and high-performance computing features make it capable of taking on projects of any size.
       homepage: https://gatk.broadinstitute.org/hc/en-us
       documentation: https://gatk.broadinstitute.org/hc/en-us/articles/360037052812-MarkDuplicates-Picard-
       tool_dev_url: https://github.com/broadinstitute/gatk
       doi: 10.1158/1538-7445.AM2017-3590
-      licence: ['MIT']
+      licence: ["MIT"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/mutect2/main.nf
+++ b/modules/nf-core/modules/gatk4/mutect2/main.nf
@@ -2,10 +2,10 @@ process GATK4_MUTECT2 {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta) , path(input) , path(input_index) , path(intervals), val(which_norm)

--- a/modules/nf-core/modules/gatk4/mutect2/meta.yml
+++ b/modules/nf-core/modules/gatk4/mutect2/meta.yml
@@ -1,5 +1,5 @@
 name: gatk4_mutect2
-description:  Call somatic SNVs and indels via local assembly of haplotypes.
+description: Call somatic SNVs and indels via local assembly of haplotypes.
 keywords:
   - gatk4
   - mutect2
@@ -14,7 +14,7 @@ tools:
       homepage: https://gatk.broadinstitute.org/hc/en-us
       documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
       doi: 10.1158/1538-7445.AM2017-3590
-      licence: ['Apache-2.0']
+      licence: ["Apache-2.0"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/gatk4/variantrecalibrator/main.nf
+++ b/modules/nf-core/modules/gatk4/variantrecalibrator/main.nf
@@ -2,21 +2,17 @@ process GATK4_VARIANTRECALIBRATOR {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::gatk4=4.2.4.1" : null)
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gatk4:4.2.4.1--hdfd78af_0' :
-        'quay.io/biocontainers/gatk4:4.2.4.1--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.5.0--hdfd78af_0' :
+        'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(vcf) , path(tbi)
     path fasta
     path fai
     path dict
-    val allelespecific
     tuple path(resvcfs), path(restbis), val(reslabels)
-    val annotation
-    val mode
-    val create_rscript
 
     output:
     tuple val(meta), path("*.recal")   , emit: recal
@@ -32,11 +28,7 @@ process GATK4_VARIANTRECALIBRATOR {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     refCommand = fasta ? "-R ${fasta} " : ''
-    alleleSpecificCommand = allelespecific ? '-AS' : ''
     resourceCommand = '--resource:' + reslabels.join( ' --resource:')
-    annotationCommand = '-an ' + annotation.join( ' -an ')
-    modeCommand = mode ? "--mode ${mode} " : 'SNP'
-    rscriptCommand = create_rscript ? "--rscript-file ${prefix}.plots.R" : ''
 
     def avail_mem = 3
     if (!task.memory) {
@@ -48,13 +40,9 @@ process GATK4_VARIANTRECALIBRATOR {
     gatk --java-options "-Xmx${avail_mem}g" VariantRecalibrator \\
         ${refCommand} \\
         -V ${vcf} \\
-        ${alleleSpecificCommand} \\
-        ${resourceCommand} \\
-        ${annotationCommand} \\
-        ${modeCommand} \\
         -O ${prefix}.recal \\
         --tranches-file ${prefix}.tranches \\
-        ${rscriptCommand}\\
+        ${resourceCommand} \\
         $args
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/modules/manta/germline/main.nf
+++ b/modules/nf-core/modules/manta/germline/main.nf
@@ -8,9 +8,11 @@ process MANTA_GERMLINE {
         'quay.io/biocontainers/manta:1.6.0--h9ee0642_1' }"
 
     input:
-    tuple val(meta), path(input), path(input_index), path (target_bed), path(target_bed_tbi)
+    tuple val(meta), path(input), path(index)
     path fasta
-    path fai
+    path fasta_fai
+    tuple path(target_bed), path(target_bed_tbi)
+
 
     output:
     tuple val(meta), path("*candidate_small_indels.vcf.gz")    , emit: candidate_small_indels_vcf
@@ -21,17 +23,21 @@ process MANTA_GERMLINE {
     tuple val(meta), path("*diploid_sv.vcf.gz.tbi")            , emit: diploid_sv_vcf_tbi
     path "versions.yml"                                        , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def input_files = input.collect{"--bam ${it}"}.join(' ')
     def options_manta = target_bed ? "--callRegions $target_bed" : ""
     """
     configManta.py \
-        --bam $input \
+        ${input_files} \
         --reference $fasta \
+        --runDir manta \
         $options_manta \
-        $args \
-        --runDir manta
+        $args
 
     python manta/runWorkflow.py -m local -j $task.cpus
 
@@ -47,6 +53,22 @@ process MANTA_GERMLINE {
         ${prefix}.diploid_sv.vcf.gz
     mv manta/results/variants/diploidSV.vcf.gz.tbi \
         ${prefix}.diploid_sv.vcf.gz.tbi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        manta: \$( configManta.py --version )
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.candidate_small_indels.vcf.gz
+    touch ${prefix}.candidate_small_indels.vcf.gz.tbi
+    touch ${prefix}.candidate_sv.vcf.gz
+    touch ${prefix}.candidate_sv.vcf.gz.tbi
+    touch ${prefix}.diploid_sv.vcf.gz
+    touch ${prefix}.diploid_sv.vcf.gz.tbi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/modules/manta/germline/meta.yml
+++ b/modules/nf-core/modules/manta/germline/meta.yml
@@ -15,7 +15,7 @@ tools:
       documentation: https://github.com/Illumina/manta/blob/v1.6.0/docs/userGuide/README.md
       tool_dev_url: https://github.com/Illumina/manta
       doi: "10.1093/bioinformatics/btv710"
-      licence: ['GPL v3']
+      licence: ["GPL v3"]
 
 input:
   - meta:
@@ -25,17 +25,17 @@ input:
         e.g. [ id:'test', single_end:false ]
   - input:
       type: file
-      description: BAM/CRAM/SAM file
+      description: BAM/CRAM/SAM file. For joint calling use a list of files.
       pattern: "*.{bam,cram,sam}"
-  - input_index:
+  - index:
       type: file
-      description: BAM/CRAM/SAM index file
+      description: BAM/CRAM/SAM index file. For joint calling use a list of files.
       pattern: "*.{bai,crai,sai}"
   - fasta:
       type: file
       description: Genome reference FASTA file
       pattern: "*.{fa,fasta}"
-  - fai:
+  - fasta_fai:
       type: file
       description: Genome reference FASTA index file
       pattern: "*.{fa.fai,fasta.fai}"
@@ -85,3 +85,4 @@ output:
 
 authors:
   - "@maxulysse"
+  - "@ramprasadn"

--- a/modules/nf-core/modules/manta/somatic/main.nf
+++ b/modules/nf-core/modules/manta/somatic/main.nf
@@ -8,9 +8,11 @@ process MANTA_SOMATIC {
         'quay.io/biocontainers/manta:1.6.0--h9ee0642_1' }"
 
     input:
-    tuple val(meta), path(input_normal), path(input_index_normal), path(input_tumor), path(input_index_tumor), path (interval), path(interval_index)
+    tuple val(meta), path(input_normal), path(input_index_normal), path(input_tumor), path(input_index_tumor)
     path fasta
     path fai
+    path target_bed
+    path target_bed_tbi
 
     output:
     tuple val(meta), path("*.candidate_small_indels.vcf.gz")     , emit: candidate_small_indels_vcf
@@ -23,10 +25,13 @@ process MANTA_SOMATIC {
     tuple val(meta), path("*.somatic_sv.vcf.gz.tbi")             , emit: somatic_sv_vcf_tbi
     path "versions.yml"                                          , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def options_manta = interval ? "--callRegions $interval" : ""
+    def options_manta = target_bed ? "--exome --callRegions $target_bed" : ""
 
     """
     configManta.py \

--- a/modules/nf-core/modules/manta/somatic/meta.yml
+++ b/modules/nf-core/modules/manta/somatic/meta.yml
@@ -15,7 +15,7 @@ tools:
       documentation: https://github.com/Illumina/manta/blob/v1.6.0/docs/userGuide/README.md
       tool_dev_url: https://github.com/Illumina/manta
       doi: "10.1093/bioinformatics/btv710"
-      licence: ['GPL v3']
+      licence: ["GPL v3"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/manta/tumoronly/main.nf
+++ b/modules/nf-core/modules/manta/tumoronly/main.nf
@@ -8,9 +8,11 @@ process MANTA_TUMORONLY {
         'quay.io/biocontainers/manta:1.6.0--h9ee0642_1' }"
 
     input:
-    tuple val(meta), path(input), path(input_index), path(target_bed), path(target_bed_tbi)
+    tuple val(meta), path(input), path(input_index)
     path fasta
     path fai
+    path target_bed
+    path target_bed_tbi
 
     output:
     tuple val(meta), path("*candidate_small_indels.vcf.gz")    , emit: candidate_small_indels_vcf
@@ -21,10 +23,13 @@ process MANTA_TUMORONLY {
     tuple val(meta), path("*tumor_sv.vcf.gz.tbi")              , emit: tumor_sv_vcf_tbi
     path "versions.yml"                                        , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def options_manta = target_bed ? "--callRegions $target_bed" : ""
+    def options_manta = target_bed ? "--exome --callRegions $target_bed" : ""
     """
     configManta.py \
         --tumorBam $input \

--- a/modules/nf-core/modules/manta/tumoronly/meta.yml
+++ b/modules/nf-core/modules/manta/tumoronly/meta.yml
@@ -15,7 +15,7 @@ tools:
       documentation: https://github.com/Illumina/manta/blob/v1.6.0/docs/userGuide/README.md
       tool_dev_url: https://github.com/Illumina/manta
       doi: "10.1093/bioinformatics/btv710"
-      licence: ['GPL v3']
+      licence: ["GPL v3"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/multiqc/main.nf
+++ b/modules/nf-core/modules/multiqc/main.nf
@@ -1,10 +1,10 @@
 process MULTIQC {
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::multiqc=1.11' : null)
+    conda (params.enable_conda ? 'bioconda::multiqc=1.12' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.11--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
+        'quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0' }"
 
     input:
     path multiqc_files

--- a/modules/nf-core/modules/multiqc/meta.yml
+++ b/modules/nf-core/modules/multiqc/meta.yml
@@ -1,40 +1,40 @@
 name: MultiQC
 description: Aggregate results from bioinformatics analyses across many samples into a single report
 keywords:
-    - QC
-    - bioinformatics tools
-    - Beautiful stand-alone HTML report
+  - QC
+  - bioinformatics tools
+  - Beautiful stand-alone HTML report
 tools:
-    - multiqc:
-        description: |
-            MultiQC searches a given directory for analysis logs and compiles a HTML report.
-            It's a general use tool, perfect for summarising the output from numerous bioinformatics tools.
-        homepage: https://multiqc.info/
-        documentation: https://multiqc.info/docs/
-        licence: ['GPL-3.0-or-later']
+  - multiqc:
+      description: |
+        MultiQC searches a given directory for analysis logs and compiles a HTML report.
+        It's a general use tool, perfect for summarising the output from numerous bioinformatics tools.
+      homepage: https://multiqc.info/
+      documentation: https://multiqc.info/docs/
+      licence: ["GPL-3.0-or-later"]
 input:
-    - multiqc_files:
-        type: file
-        description: |
-            List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
+  - multiqc_files:
+      type: file
+      description: |
+        List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
 output:
-    - report:
-        type: file
-        description: MultiQC report file
-        pattern: "multiqc_report.html"
-    - data:
-        type: dir
-        description: MultiQC data dir
-        pattern: "multiqc_data"
-    - plots:
-        type: file
-        description: Plots created by MultiQC
-        pattern: "*_data"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - report:
+      type: file
+      description: MultiQC report file
+      pattern: "multiqc_report.html"
+  - data:
+      type: dir
+      description: MultiQC data dir
+      pattern: "multiqc_data"
+  - plots:
+      type: file
+      description: Plots created by MultiQC
+      pattern: "*_data"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@abhi18av"
-    - "@bunop"
-    - "@drpatelh"
+  - "@abhi18av"
+  - "@bunop"
+  - "@drpatelh"

--- a/modules/nf-core/modules/samblaster/meta.yml
+++ b/modules/nf-core/modules/samblaster/meta.yml
@@ -1,13 +1,13 @@
 name: samblaster
 description: |
-      This module combines samtools and samblaster in order to use
-      samblaster capability to filter or tag SAM files, with the advantage
-      of maintaining both input and output in BAM format.
-      Samblaster input must contain a sequence header: for this reason it has been piped
-      with the "samtools view -h" command.
-      Additional desired arguments for samtools can be passed using:
-      options.args2 for the input bam file
-      options.args3 for the output bam file
+  This module combines samtools and samblaster in order to use
+  samblaster capability to filter or tag SAM files, with the advantage
+  of maintaining both input and output in BAM format.
+  Samblaster input must contain a sequence header: for this reason it has been piped
+  with the "samtools view -h" command.
+  Additional desired arguments for samtools can be passed using:
+  options.args2 for the input bam file
+  options.args3 for the output bam file
 keywords:
   - sort
 tools:
@@ -21,7 +21,7 @@ tools:
       documentation: https://github.com/GregoryFaust/samblaster
       tool_dev_url: https://github.com/GregoryFaust/samblaster
       doi: "10.1093/bioinformatics/btu314"
-      licence: ['MIT']
+      licence: ["MIT"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/samtools/bam2fq/main.nf
+++ b/modules/nf-core/modules/samtools/bam2fq/main.nf
@@ -15,6 +15,9 @@ process SAMTOOLS_BAM2FQ {
     tuple val(meta), path("*.fq.gz"), emit: reads
     path "versions.yml"             , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/nf-core/modules/samtools/bam2fq/meta.yml
+++ b/modules/nf-core/modules/samtools/bam2fq/meta.yml
@@ -1,7 +1,7 @@
 name: samtools_bam2fq
 description: |
-    The module uses bam2fq method from samtools to
-    convert a SAM, BAM or CRAM file to FASTQ format
+  The module uses bam2fq method from samtools to
+  convert a SAM, BAM or CRAM file to FASTQ format
 keywords:
   - bam2fq
   - samtools
@@ -13,7 +13,7 @@ tools:
       documentation: http://www.htslib.org/doc/1.1/samtools.html
       tool_dev_url: None
       doi: ""
-      licence: ['MIT']
+      licence: ["MIT"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/samtools/faidx/meta.yml
+++ b/modules/nf-core/modules/samtools/faidx/meta.yml
@@ -1,43 +1,43 @@
 name: samtools_faidx
 description: Index FASTA file
 keywords:
-    - index
-    - fasta
+  - index
+  - fasta
 tools:
-    - samtools:
-        description: |
-            SAMtools is a set of utilities for interacting with and post-processing
-            short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
-            These files are generated as output by short read aligners like BWA.
-        homepage: http://www.htslib.org/
-        documentation: http://www.htslib.org/doc/samtools.html
-        doi: 10.1093/bioinformatics/btp352
-        licence: ['MIT']
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: http://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - fasta:
-        type: file
-        description: FASTA file
-        pattern: "*.{fa,fasta}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: FASTA file
+      pattern: "*.{fa,fasta}"
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - fai:
-        type: file
-        description: FASTA index file
-        pattern: "*.{fai}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fai:
+      type: file
+      description: FASTA index file
+      pattern: "*.{fai}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@ewels"
-    - "@phue"
+  - "@drpatelh"
+  - "@ewels"
+  - "@phue"

--- a/modules/nf-core/modules/samtools/index/meta.yml
+++ b/modules/nf-core/modules/samtools/index/meta.yml
@@ -1,53 +1,53 @@
 name: samtools_index
 description: Index SAM/BAM/CRAM file
 keywords:
-    - index
-    - bam
-    - sam
-    - cram
+  - index
+  - bam
+  - sam
+  - cram
 tools:
-    - samtools:
-        description: |
-            SAMtools is a set of utilities for interacting with and post-processing
-            short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
-            These files are generated as output by short read aligners like BWA.
-        homepage: http://www.htslib.org/
-        documentation: hhttp://www.htslib.org/doc/samtools.html
-        doi: 10.1093/bioinformatics/btp352
-        licence: ['MIT']
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: hhttp://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - bam:
-        type: file
-        description: BAM/CRAM/SAM file
-        pattern: "*.{bam,cram,sam}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - bai:
-        type: file
-        description: BAM/CRAM/SAM index file
-        pattern: "*.{bai,crai,sai}"
-    - crai:
-        type: file
-        description: BAM/CRAM/SAM index file
-        pattern: "*.{bai,crai,sai}"
-    - csi:
-        type: file
-        description: CSI index file
-        pattern: "*.{csi}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bai:
+      type: file
+      description: BAM/CRAM/SAM index file
+      pattern: "*.{bai,crai,sai}"
+  - crai:
+      type: file
+      description: BAM/CRAM/SAM index file
+      pattern: "*.{bai,crai,sai}"
+  - csi:
+      type: file
+      description: CSI index file
+      pattern: "*.{csi}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@ewels"
-    - "@maxulysse"
+  - "@drpatelh"
+  - "@ewels"
+  - "@maxulysse"

--- a/modules/nf-core/modules/samtools/merge/meta.yml
+++ b/modules/nf-core/modules/samtools/merge/meta.yml
@@ -1,54 +1,54 @@
 name: samtools_merge
 description: Merge BAM or CRAM file
 keywords:
-    - merge
-    - bam
-    - sam
-    - cram
+  - merge
+  - bam
+  - sam
+  - cram
 tools:
-    - samtools:
-        description: |
-            SAMtools is a set of utilities for interacting with and post-processing
-            short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
-            These files are generated as output by short read aligners like BWA.
-        homepage: http://www.htslib.org/
-        documentation: hhttp://www.htslib.org/doc/samtools.html
-        doi: 10.1093/bioinformatics/btp352
-        licence: ['MIT']
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: hhttp://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - input_files:
-        type: file
-        description: BAM/CRAM file
-        pattern: "*.{bam,cram,sam}"
-    - fasta:
-        type: optional file
-        description: Reference file the CRAM was created with
-        pattern: "*.{fasta,fa}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - input_files:
+      type: file
+      description: BAM/CRAM file
+      pattern: "*.{bam,cram,sam}"
+  - fasta:
+      type: optional file
+      description: Reference file the CRAM was created with
+      pattern: "*.{fasta,fa}"
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - bam:
-        type: file
-        description: BAM file
-        pattern: "*.{bam}"
-    - cram:
-        type: file
-        description: CRAM file
-        pattern: "*.{cram}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: BAM file
+      pattern: "*.{bam}"
+  - cram:
+      type: file
+      description: CRAM file
+      pattern: "*.{cram}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@yuukiiwa "
-    - "@maxulysse"
-    - "@FriederikeHanssen"
+  - "@drpatelh"
+  - "@yuukiiwa "
+  - "@maxulysse"
+  - "@FriederikeHanssen"

--- a/modules/nf-core/modules/samtools/mpileup/meta.yml
+++ b/modules/nf-core/modules/samtools/mpileup/meta.yml
@@ -1,48 +1,48 @@
 name: samtools_mpileup
-description:  BAM
+description: BAM
 keywords:
-    - mpileup
-    - bam
-    - sam
-    - cram
+  - mpileup
+  - bam
+  - sam
+  - cram
 tools:
-    - samtools:
-        description: |
-            SAMtools is a set of utilities for interacting with and post-processing
-            short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
-            These files are generated as output by short read aligners like BWA.
-        homepage: http://www.htslib.org/
-        documentation: hhttp://www.htslib.org/doc/samtools.html
-        doi: 10.1093/bioinformatics/btp352
-        licence: ['MIT']
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: hhttp://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - bam:
-        type: file
-        description: BAM/CRAM/SAM file
-        pattern: "*.{bam,cram,sam}"
-    - fasta:
-        type: file
-        description: FASTA reference file
-        pattern: "*.{fasta,fa}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+  - fasta:
+      type: file
+      description: FASTA reference file
+      pattern: "*.{fasta,fa}"
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - mpileup:
-        type: file
-        description: mpileup file
-        pattern: "*.{mpileup}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - mpileup:
+      type: file
+      description: mpileup file
+      pattern: "*.{mpileup}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@joseespinosa"
+  - "@drpatelh"
+  - "@joseespinosa"

--- a/modules/nf-core/modules/samtools/stats/meta.yml
+++ b/modules/nf-core/modules/samtools/stats/meta.yml
@@ -1,53 +1,53 @@
 name: samtools_stats
 description: Produces comprehensive statistics from SAM/BAM/CRAM file
 keywords:
-    - statistics
-    - counts
-    - bam
-    - sam
-    - cram
+  - statistics
+  - counts
+  - bam
+  - sam
+  - cram
 tools:
-    - samtools:
-        description: |
-            SAMtools is a set of utilities for interacting with and post-processing
-            short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
-            These files are generated as output by short read aligners like BWA.
-        homepage: http://www.htslib.org/
-        documentation: hhttp://www.htslib.org/doc/samtools.html
-        doi: 10.1093/bioinformatics/btp352
-        licence: ['MIT']
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: hhttp://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - input:
-      type: file
-      description: BAM/CRAM file from alignment
-      pattern: "*.{bam,cram}"
-    - input_index:
-      type: file
-      description: BAI/CRAI file from alignment
-      pattern: "*.{bai,crai}"
-    - fasta:
-        type: optional file
-        description: Reference file the CRAM was created with
-        pattern: "*.{fasta,fa}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - input:
+    type: file
+    description: BAM/CRAM file from alignment
+    pattern: "*.{bam,cram}"
+  - input_index:
+    type: file
+    description: BAI/CRAI file from alignment
+    pattern: "*.{bai,crai}"
+  - fasta:
+      type: optional file
+      description: Reference file the CRAM was created with
+      pattern: "*.{fasta,fa}"
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - stats:
-        type: file
-        description: File containing samtools stats output
-        pattern: "*.{stats}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - stats:
+      type: file
+      description: File containing samtools stats output
+      pattern: "*.{stats}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@FriederikeHanssen"
+  - "@drpatelh"
+  - "@FriederikeHanssen"

--- a/modules/nf-core/modules/samtools/view/meta.yml
+++ b/modules/nf-core/modules/samtools/view/meta.yml
@@ -1,53 +1,53 @@
 name: samtools_view
 description: filter/convert SAM/BAM/CRAM file
 keywords:
-    - view
-    - bam
-    - sam
-    - cram
+  - view
+  - bam
+  - sam
+  - cram
 tools:
-    - samtools:
-        description: |
-            SAMtools is a set of utilities for interacting with and post-processing
-            short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
-            These files are generated as output by short read aligners like BWA.
-        homepage: http://www.htslib.org/
-        documentation: hhttp://www.htslib.org/doc/samtools.html
-        doi: 10.1093/bioinformatics/btp352
-        licence: ['MIT']
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: hhttp://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - input:
-        type: file
-        description: BAM/CRAM/SAM file
-        pattern: "*.{bam,cram,sam}"
-    - fasta:
-        type: optional file
-        description: Reference file the CRAM was created with
-        pattern: "*.{fasta,fa}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - input:
+      type: file
+      description: BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+  - fasta:
+      type: optional file
+      description: Reference file the CRAM was created with
+      pattern: "*.{fasta,fa}"
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - bam:
-        type: file
-        description: filtered/converted BAM/SAM file
-        pattern: "*.{bam,sam}"
-    - cram:
-        type: file
-        description: filtered/converted CRAM file
-        pattern: "*.cram"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: filtered/converted BAM/SAM file
+      pattern: "*.{bam,sam}"
+  - cram:
+      type: file
+      description: filtered/converted CRAM file
+      pattern: "*.cram"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@joseespinosa"
-    - "@FriederikeHanssen"
+  - "@drpatelh"
+  - "@joseespinosa"
+  - "@FriederikeHanssen"

--- a/modules/nf-core/modules/seqkit/split2/meta.yml
+++ b/modules/nf-core/modules/seqkit/split2/meta.yml
@@ -1,39 +1,39 @@
 name: seqkit_split2
 description: Split single or paired-end fastq.gz files
 keywords:
-    - split
-    - fastq
+  - split
+  - fastq
 tools:
-    - seqkit:
-        description: |
-            Cross-platform and ultrafast toolkit for FASTA/Q file manipulation, written by Wei Shen.
-        homepage: https://github.com/shenwei356/seqkit
-        documentation: https://bioinf.shenwei.me/seqkit/
-        doi: 10.1371/journal.pone.0163962
-        licence: ['MIT']
+  - seqkit:
+    description: |
+      Cross-platform and ultrafast toolkit for FASTA/Q file manipulation, written by Wei Shen.
+    homepage: https://github.com/shenwei356/seqkit
+    documentation: https://bioinf.shenwei.me/seqkit/
+    doi: 10.1371/journal.pone.0163962
+    licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: FastQ files
-        pattern: "*.{fq.gz/fastq.gz}"
+  - meta:
+    type: map
+    description: |
+      Groovy Map containing sample information
+      e.g. [ id:'test', single_end:false ]
+  - reads:
+    type: file
+    description: FastQ files
+    pattern: "*.{fq.gz/fastq.gz}"
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: Split fastq files
-        pattern: "*.{fq.gz/fastq.gz}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+    type: map
+    description: |
+      Groovy Map containing sample information
+      e.g. [ id:'test', single_end:false ]
+  - reads:
+    type: file
+    description: Split fastq files
+    pattern: "*.{fq.gz/fastq.gz}"
+  - versions:
+    type: file
+    description: File containing software versions
+    pattern: "versions.yml"
 authors:
-    - "@FriederikeHanssen"
+  - "@FriederikeHanssen"

--- a/modules/nf-core/modules/snpeff/meta.yml
+++ b/modules/nf-core/modules/snpeff/meta.yml
@@ -1,58 +1,58 @@
 name: snpEff
 description: Genetic variant annotation and functional effect prediction toolbox
 keywords:
-    - annotation
+  - annotation
 tools:
-    - snpeff:
-        description: |
-            SnpEff is a variant annotation and effect prediction tool.
-            It annotates and predicts the effects of genetic variants on genes and proteins (such as amino acid changes).
-        homepage: https://pcingola.github.io/SnpEff/
-        documentation: https://pcingola.github.io/SnpEff/se_introduction/
-        licence: ['MIT']
+  - snpeff:
+      description: |
+        SnpEff is a variant annotation and effect prediction tool.
+        It annotates and predicts the effects of genetic variants on genes and proteins (such as amino acid changes).
+      homepage: https://pcingola.github.io/SnpEff/
+      documentation: https://pcingola.github.io/SnpEff/se_introduction/
+      licence: ["MIT"]
 params:
-    - use_cache:
-        type: boolean
-        description: |
-          boolean to enable the usage of containers with cache
-          Enable the usage of containers with cache
-          Does not work with conda
-    - snpeff_tag:
-        type: value
-        description: |
-          Specify the tag for the container
-          https://hub.docker.com/r/nfcore/snpeff/tags
+  - use_cache:
+      type: boolean
+      description: |
+        boolean to enable the usage of containers with cache
+        Enable the usage of containers with cache
+        Does not work with conda
+  - snpeff_tag:
+      type: value
+      description: |
+        Specify the tag for the container
+        https://hub.docker.com/r/nfcore/snpeff/tags
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - vcf:
-        type: file
-        description: |
-            vcf to annotate
-    - db:
-        type: value
-        description: |
-            which db to annotate with
-    - cache:
-        type: file
-        description: |
-            path to snpEff cache (optional)
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: |
+        vcf to annotate
+  - db:
+      type: value
+      description: |
+        which db to annotate with
+  - cache:
+      type: file
+      description: |
+        path to snpEff cache (optional)
 output:
-    - vcf:
-        type: file
-        description: |
-            annotated vcf
-        pattern: "*.ann.vcf"
-    - report:
-        type: file
-        description: snpEff report file
-        pattern: "*.html"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - vcf:
+      type: file
+      description: |
+        annotated vcf
+      pattern: "*.ann.vcf"
+  - report:
+      type: file
+      description: snpEff report file
+      pattern: "*.html"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@maxulysse"
+  - "@maxulysse"

--- a/modules/nf-core/modules/strelka/germline/meta.yml
+++ b/modules/nf-core/modules/strelka/germline/meta.yml
@@ -13,7 +13,7 @@ tools:
       documentation: https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md
       tool_dev_url: https://github.com/Illumina/strelka
       doi: 10.1038/s41592-018-0051-x
-      licence: ['GPL v3']
+      licence: ["GPL v3"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/strelka/somatic/meta.yml
+++ b/modules/nf-core/modules/strelka/somatic/meta.yml
@@ -13,7 +13,7 @@ tools:
       documentation: https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md
       tool_dev_url: https://github.com/Illumina/strelka
       doi: 10.1038/s41592-018-0051-x
-      licence: ['GPL v3']
+      licence: ["GPL v3"]
 
 input:
   - meta:

--- a/modules/nf-core/modules/tabix/bgziptabix/main.nf
+++ b/modules/nf-core/modules/tabix/bgziptabix/main.nf
@@ -14,12 +14,15 @@ process TABIX_BGZIPTABIX {
     tuple val(meta), path("*.gz"), path("*.tbi"), emit: gz_tbi
     path  "versions.yml" ,                        emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    bgzip --threads ${task.cpus} -c $args $input > ${prefix}.gz
+    bgzip  --threads ${task.cpus} -c $args $input > ${prefix}.gz
     tabix $args2 ${prefix}.gz
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/modules/tabix/bgziptabix/meta.yml
+++ b/modules/nf-core/modules/tabix/bgziptabix/meta.yml
@@ -1,45 +1,45 @@
 name: tabix_bgziptabix
 description: bgzip a sorted tab-delimited genome file and then create tabix index
 keywords:
-    - bgzip
-    - compress
-    - index
-    - tabix
-    - vcf
+  - bgzip
+  - compress
+  - index
+  - tabix
+  - vcf
 tools:
-    - tabix:
-        description: Generic indexer for TAB-delimited genome position files.
-        homepage: https://www.htslib.org/doc/tabix.html
-        documentation: https://www.htslib.org/doc/tabix.1.html
-        doi: 10.1093/bioinformatics/btq671
-        licence: ['MIT']
+  - tabix:
+      description: Generic indexer for TAB-delimited genome position files.
+      homepage: https://www.htslib.org/doc/tabix.html
+      documentation: https://www.htslib.org/doc/tabix.1.html
+      doi: 10.1093/bioinformatics/btq671
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - tab:
-        type: file
-        description: TAB-delimited genome position file
-        pattern: "*.{bed,gff,sam,vcf}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - tab:
+      type: file
+      description: TAB-delimited genome position file
+      pattern: "*.{bed,gff,sam,vcf}"
 output:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - gz:
-        type: file
-        description: Output compressed file
-        pattern: "*.{gz}"
-    - tbi:
-        type: file
-        description: tabix index file
-        pattern: "*.{gz.tbi}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - gz:
+      type: file
+      description: Output compressed file
+      pattern: "*.{gz}"
+  - tbi:
+      type: file
+      description: tabix index file
+      pattern: "*.{gz.tbi}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@maxulysse"
+  - "@maxulysse"

--- a/modules/nf-core/modules/tabix/tabix/meta.yml
+++ b/modules/nf-core/modules/tabix/tabix/meta.yml
@@ -1,41 +1,41 @@
 name: tabix_tabix
 description: create tabix index from a sorted bgzip tab-delimited genome file
 keywords:
-    - index
-    - tabix
-    - vcf
+  - index
+  - tabix
+  - vcf
 tools:
-    - tabix:
-        description: Generic indexer for TAB-delimited genome position files.
-        homepage: https://www.htslib.org/doc/tabix.html
-        documentation: https://www.htslib.org/doc/tabix.1.html
-        doi: 10.1093/bioinformatics/btq671
-        licence: ['MIT']
+  - tabix:
+      description: Generic indexer for TAB-delimited genome position files.
+      homepage: https://www.htslib.org/doc/tabix.html
+      documentation: https://www.htslib.org/doc/tabix.1.html
+      doi: 10.1093/bioinformatics/btq671
+      licence: ["MIT"]
 input:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - tab:
-        type: file
-        description: TAB-delimited genome position file compressed with bgzip
-        pattern: "*.{bed.gz,gff.gz,sam.gz,vcf.gz}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - tab:
+      type: file
+      description: TAB-delimited genome position file compressed with bgzip
+      pattern: "*.{bed.gz,gff.gz,sam.gz,vcf.gz}"
 output:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - tbi:
-        type: file
-        description: tabix index file
-        pattern: "*.{tbi}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - tbi:
+      type: file
+      description: tabix index file
+      pattern: "*.{tbi}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@joseespinosa"
-    - "@drpatelh"
-    - "@maxulysse"
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@maxulysse"

--- a/modules/nf-core/modules/tiddit/sv/meta.yml
+++ b/modules/nf-core/modules/tiddit/sv/meta.yml
@@ -1,51 +1,51 @@
 name: tiddit_sv
 description: Identify chromosomal rearrangements.
 keywords:
-    - structural
-    - variants
-    - vcf
+  - structural
+  - variants
+  - vcf
 tools:
-    - sv:
-        description:  Search for structural variants.
-        homepage: https://github.com/SciLifeLab/TIDDIT
-        documentation: https://github.com/SciLifeLab/TIDDIT/blob/master/README.md
-        doi: 10.12688/f1000research.11168.1
-        licence: ['GPL-3.0-or-later']
+  - sv:
+      description: Search for structural variants.
+      homepage: https://github.com/SciLifeLab/TIDDIT
+      documentation: https://github.com/SciLifeLab/TIDDIT/blob/master/README.md
+      doi: 10.12688/f1000research.11168.1
+      licence: ["GPL-3.0-or-later"]
 input:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - fasta:
-        type: file
-        description: Input FASTA file
-        pattern: "*.{fasta,fa}"
-    - fai:
-        type: file
-        description: FASTA index file
-        pattern: "*.{fai}"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Input FASTA file
+      pattern: "*.{fasta,fa}"
+  - fai:
+      type: file
+      description: FASTA index file
+      pattern: "*.{fai}"
 output:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - vcf:
-        type: file
-        description: vcf
-        pattern: "*.{vcf}"
-    - ploidy:
-        type: file
-        description: tab
-        pattern: "*.{ploidy.tab}"
-    - signals:
-        type: file
-        description: tab
-        pattern: "*.{signals.tab}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: vcf
+      pattern: "*.{vcf}"
+  - ploidy:
+      type: file
+      description: tab
+      pattern: "*.{ploidy.tab}"
+  - signals:
+      type: file
+      description: tab
+      pattern: "*.{signals.tab}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@maxulysse"
+  - "@maxulysse"

--- a/modules/nf-core/modules/trimgalore/meta.yml
+++ b/modules/nf-core/modules/trimgalore/meta.yml
@@ -1,59 +1,59 @@
 name: trimgalore
 description: Trim FastQ files using Trim Galore!
 keywords:
-    - trimming
-    - adapters
-    - sequencing adapters
-    - fastq
+  - trimming
+  - adapters
+  - sequencing adapters
+  - fastq
 tools:
-    - trimgalore:
-        description: |
-            A wrapper tool around Cutadapt and FastQC to consistently apply quality
-            and adapter trimming to FastQ files, with some extra functionality for
-            MspI-digested RRBS-type (Reduced Representation Bisufite-Seq) libraries.
-        homepage: https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/
-        documentation: https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md
-        licence: ['GPL-3.0-or-later']
+  - trimgalore:
+      description: |
+        A wrapper tool around Cutadapt and FastQC to consistently apply quality
+        and adapter trimming to FastQ files, with some extra functionality for
+        MspI-digested RRBS-type (Reduced Representation Bisufite-Seq) libraries.
+      homepage: https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/
+      documentation: https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md
+      licence: ["GPL-3.0-or-later"]
 input:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: |
-            List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-            respectively.
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
 output:
-    - meta:
-        type: map
-        description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: |
-            List of input adapter trimmed FastQ files of size 1 and 2 for
-            single-end and paired-end data, respectively.
-        pattern: "*.{fq.gz}"
-    - html:
-        type: file
-        description: FastQC report (optional)
-        pattern: "*_{fastqc.html}"
-    - zip:
-        type: file
-        description: FastQC report archive (optional)
-        pattern: "*_{fastqc.zip}"
-    - log:
-        type: file
-        description: Trim Galore! trimming report
-        pattern: "*_{report.txt}"
-    - versions:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input adapter trimmed FastQ files of size 1 and 2 for
+        single-end and paired-end data, respectively.
+      pattern: "*.{fq.gz}"
+  - html:
+      type: file
+      description: FastQC report (optional)
+      pattern: "*_{fastqc.html}"
+  - zip:
+      type: file
+      description: FastQC report archive (optional)
+      pattern: "*_{fastqc.zip}"
+  - log:
+      type: file
+      description: Trim Galore! trimming report
+      pattern: "*_{report.txt}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
-    - "@drpatelh"
-    - "@ewels"
-    - "@FelixKrueger"
+  - "@drpatelh"
+  - "@ewels"
+  - "@FelixKrueger"

--- a/modules/nf-core/modules/vcftools/meta.yml
+++ b/modules/nf-core/modules/vcftools/meta.yml
@@ -9,7 +9,7 @@ tools:
       documentation: http://vcftools.sourceforge.net/man_latest.html
       tool_dev_url: None
       doi:
-      licence: ['LGPL']
+      licence: ["LGPL"]
 
 input:
   - meta:

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,7 @@ params {
     sentieon = false // Not using Sentieon by default
     target_bed = null // No default TargetBED file for targeted sequencing
     tools = null // No default Variant_Calling or Annotation tools
-    skip_tools = null // All tools (markduplicates + bqsr + QC) are used by default
+    skip_tools = null // All tools (markduplicates + baserecalibrator + QC) are used by default
 
     // Modify fastqs (trim/split)
     trim_fastq = false // No trimming

--- a/nextflow.config
+++ b/nextflow.config
@@ -221,7 +221,7 @@ dag {
 
 manifest {
     name            = 'nf-core/sarek'
-    author          = 'Maxime Garcia, Szilveszter Juhos, Friedrike Hanssen'
+    author          = 'Maxime Garcia, Szilveszter Juhos, Friederike Hanssen'
     homePage        = 'https://github.com/nf-core/sarek'
     description     = 'An open-source analysis pipeline to detect germline or somatic variants from whole genome or targeted sequencing'
     mainScript      = 'main.nf'

--- a/nextflow.config
+++ b/nextflow.config
@@ -90,6 +90,7 @@ params {
     // Boilerplate options
     outdir                     = './results'
     tracedir                   = "${params.outdir}/pipeline_info"
+    publish_dir_mode           = 'copy'
     email                      = null
     email_on_fail              = null
     plaintext_email            = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,9 +24,9 @@ params {
     no_intervals = false // Intervals will be built from the fasta file
     nucleotides_per_second = 1000 // Default interval size
     sentieon = false // Not using Sentieon by default
-    skip_qc = null // All QC tools are used
     target_bed = null // No default TargetBED file for targeted sequencing
     tools = null // No default Variant_Calling or Annotation tools
+    skip_tools = null // All tools (markduplicates + bqsr + QC) are used by default
 
     // Modify fastqs (trim/split)
     trim_fastq = false // No trimming
@@ -36,11 +36,11 @@ params {
     three_prime_clip_r2 = 0
     trim_nextseq = 0
     save_trimmed = false
-    split_fastq = 0 // FASTQ files will not be split by default
+    split_fastq  = 0 // FASTQ files will not be split by default
     save_split_fastqs  = false
 
     // UMI tagged reads
-    umi_read_structure = null // no umi
+    umi_read_structure    = null // no umi
     group_by_umi_strategy = 'Adjacency' //
 
     // Preprocessing
@@ -48,11 +48,7 @@ params {
     markdup_java_options = '"-Xms4000m -Xmx7g"' // Established values for markDuplicates memory consumption, see https://github.com/SciLifeLab/Sarek/pull/689 for details
     use_gatk_spark = null // GATK Spark implementation of their tools in local mode not used by default
     save_bam_mapped = false // Mapped BAMs not saved
-    skip_markduplicates = false // Do not skip markDuplicates by default
     sequencing_center = null // No sequencing center to be written in BAM header in MapReads process
-
-    //BQSR
-    skip_bqsr = false
 
     // Variant Calling
     ascat_ploidy = null // Use default value
@@ -225,7 +221,7 @@ dag {
 
 manifest {
     name            = 'nf-core/sarek'
-    author          = 'Maxime Garcia, Szilveszter Juhos'
+    author          = 'Maxime Garcia, Szilveszter Juhos, Friedrike Hanssen'
     homePage        = 'https://github.com/nf-core/sarek'
     description     = 'An open-source analysis pipeline to detect germline or somatic variants from whole genome or targeted sequencing'
     mainScript      = 'main.nf'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -222,7 +222,7 @@
                     "fa_icon": "fas fa-forward",
                     "description": "Tools for which to enable usage of GATK Spark implementation",
                     "help_text": "Multiple separated with commas.\n\n GATK4 BQSR tools are currently only available as Beta release. Use with caution!",
-                    "pattern": "^((markduplicates|bqsr)*,?)*$"
+                    "pattern": "^((baserecalibrator|markduplicates)*,?)*$"
                 },
                 "save_bam_mapped": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -84,8 +84,8 @@
                     "type": "string",
                     "fa_icon": "fas fa-forward",
                     "description": "Disable specified tools.",
-                    "help_text": "Multiple tools can be specified, separated by commas.\n\n> **NB** `--skip_tools baserecalibrator_qc` is actually just not saving the reports.\n> **NB** `--skip_tools markduplicates_qc` does not skip `MarkDuplicates` but prevent the collection of duplicate metrics that slows down performance.\n> **NB** tools can be specified with no concern for case.",
-                    "pattern": "^((bamqc|baserecalibrator|baserecalibrator_qc|bcftools|documentation|fastqc|markduplicates|markduplicates_qc|multiqc|samtools|vcftools|versions|deeptools)*(,)*)*$"
+                    "help_text": "Multiple tools can be specified, separated by commas.\n\n> **NB** `--skip_tools baserecalibrator_report` is actually just not saving the reports.\n> **NB** `--skip_tools markduplicates_report` does not skip `MarkDuplicates` but prevent the collection of duplicate metrics that slows down performance.\n> **NB** tools can be specified with no concern for case.",
+                    "pattern": "^((bamqc|baserecalibrator|baserecalibrator_report|bcftools|documentation|fastqc|markduplicates|markduplicates_report|multiqc|samtools|vcftools|versions|deeptools)*(,)*)*$"
                 },
                 "target_bed": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -655,6 +655,22 @@
                     "fa_icon": "fas fa-question-circle",
                     "hidden": true
                 },
+                "publish_dir_mode": {
+                    "type": "string",
+                    "default": "copy",
+                    "description": "Method used to save pipeline results to output directory.",
+                    "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
+                    "fa_icon": "fas fa-copy",
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
+                    "hidden": true
+                },
                 "email": {
                     "type": "string",
                     "description": "Email address for completion summary.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -80,12 +80,12 @@
                     "description": "Enable Sentieon if available.",
                     "help_text": "Sentieon is a commercial solution to process genomics data with high computing efficiency, fast turnaround time, exceptional accuracy, and 100% consistency.\n\n> **NB** Adds the following tools for the `--tools` options: `DNAseq`, `DNAscope` and `TNscope`."
                 },
-                "skip_qc": {
+                "skip_tools": {
                     "type": "string",
                     "fa_icon": "fas fa-forward",
-                    "description": "Disable specified QC and Reporting tools.",
-                    "help_text": "Multiple tools can be specified, separated by commas.\n\n> **NB** `--skip_qc BaseRecalibrator` is actually just not saving the reports.\n> **NB** `--skip_qc MarkDuplicates` does not skip `MarkDuplicates` but prevent the collection of duplicate metrics that slows down performance.\n> **NB** tools can be specified with no concern for case.",
-                    "pattern": "^((bamqc|baserecalibrator|bcftools|documentation|fastqc|markduplicates|multiqc|samtools|vcftools|versions|deeptools)*(,)*)*$"
+                    "description": "Disable specified tools.",
+                    "help_text": "Multiple tools can be specified, separated by commas.\n\n> **NB** `--skip_tools baserecalibrator_qc` is actually just not saving the reports.\n> **NB** `--skip_tools markduplicates_qc` does not skip `MarkDuplicates` but prevent the collection of duplicate metrics that slows down performance.\n> **NB** tools can be specified with no concern for case.",
+                    "pattern": "^((bamqc|baserecalibrator|baserecalibrator_qc|bcftools|documentation|fastqc|markduplicates|markduplicates_qc|multiqc|samtools|vcftools|versions|deeptools)*(,)*)*$"
                 },
                 "target_bed": {
                     "type": "string",
@@ -114,6 +114,7 @@
                     "type": "boolean",
                     "fa_icon": "fas fa-cut",
                     "description": "Run Trim Galore.",
+                    "default": false,
                     "hidden": true,
                     "help_text": "Use this to perform adapter trimming with Trim Galore.\ncf [Trim Galore User Guide](https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md)"
                 },
@@ -179,7 +180,6 @@
                 },
                 "umi_read_structure": {
                     "type": "string",
-                    "default": "None",
                     "fa_icon": "fas fa-tape",
                     "hidden": true
                 },
@@ -228,17 +228,6 @@
                     "type": "boolean",
                     "fa_icon": "fas fa-download",
                     "description": "Save Mapped BAMs"
-                },
-                "skip_markduplicates": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-fast-forward",
-                    "description": "Skip GATK MarkDuplicates",
-                    "help_text": "This params will also save the mapped BAMS, to enable restart from step `prepare_recalibration`"
-                },
-                "skip_bqsr": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-fast-forward",
-                    "description": "Skip Base Quality Recalibration"
                 }
             }
         },

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -38,15 +38,9 @@ workflow PREPARE_GENOME {
 
     ch_bwa = Channel.empty()
     if (!(params.bwa) && 'mapping' in step) {
-        if (params.aligner == "bwa-mem") {
-            BWAMEM1_INDEX(fasta)
-            ch_bwa = BWAMEM1_INDEX.out.index
-            ch_versions = ch_versions.mix(BWAMEM1_INDEX.out.versions)
-        } else if (params.aligner == "bwa-mem2") {
-            BWAMEM2_INDEX(fasta)
-            ch_bwa = BWAMEM2_INDEX.out.index
-            ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
-        }
+        (ch_bwa, ch_bwa_version) = BWAMEM1_INDEX(fasta)
+        (ch_bwa, ch_bwa_version) = BWAMEM2_INDEX(fasta)
+        ch_versions = ch_versions.mix(ch_bwa_version)
     }
 
     ch_dict = Channel.empty()

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -33,6 +33,9 @@ workflow PREPARE_GENOME {
 
     BWAMEM1_INDEX(fasta) // If aligner is bwa-mem
     BWAMEM2_INDEX(fasta) // If aligner is bwa-mem2
+    // if we use mix here, bwa becomes a channel that is comsumed
+    ch_bwa = params.aligner == "bwa-mem" ? BWAMEM1_INDEX.out.index : BWAMEM2_INDEX.out.index
+
     GATK4_CREATESEQUENCEDICTIONARY(fasta)
     MSISENSORPRO_SCAN(fasta.map{ it -> [[id:it[0].baseName], it] })
     SAMTOOLS_FAIDX(fasta.map{ it -> [[id:it[0].getName()], it] })
@@ -53,7 +56,7 @@ workflow PREPARE_GENOME {
     ch_versions = ch_versions.mix(TABIX_PON.out.versions)
 
     emit:
-        bwa                              = BWAMEM1_INDEX.out.index.mix(BWAMEM2_INDEX.out.index)           // path: {bwamem1,bwamem2}/index
+        bwa                              = ch_bwa                                                         // path: {bwamem1,bwamem2}/index
         dbsnp_tbi                        = TABIX_DBSNP.out.tbi.map{ meta, tbi -> [tbi] }                  // path: dbsnb.vcf.gz.tbi
         dict                             = GATK4_CREATESEQUENCEDICTIONARY.out.dict                        // path: genome.fasta.dict
         fasta_fai                        = SAMTOOLS_FAIDX.out.fai.map{ meta, fai -> [fai] }               // path: genome.fasta.fai

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -8,20 +8,15 @@
 // Condition is based on params.step and params.tools
 // If and extra condition exists, it's specified in comments
 
-include { BUILD_INTERVALS                                     } from '../../modules/local/build_intervals/main'
-include { BWA_INDEX as BWAMEM1_INDEX                          } from '../../modules/nf-core/modules/bwa/index/main'
-include { BWAMEM2_INDEX                                       } from '../../modules/nf-core/modules/bwamem2/index/main'
-include { CREATE_INTERVALS_BED                                } from '../../modules/local/create_intervals_bed/main'
-include { GATK4_CREATESEQUENCEDICTIONARY                      } from '../../modules/nf-core/modules/gatk4/createsequencedictionary/main'
-include { GATK4_INTERVALLISTTOBED                             } from '../../modules/local/gatk4/intervallisttobed'
-include { MSISENSORPRO_SCAN                                   } from '../../modules/nf-core/modules/msisensorpro/scan/main'
-include { SAMTOOLS_FAIDX                                      } from '../../modules/nf-core/modules/samtools/faidx/main'
-include { TABIX_BGZIPTABIX as TABIX_BGZIPTABIX_INTERVAL_SPLIT } from '../../modules/nf-core/modules/tabix/bgziptabix/main'
-include { TABIX_BGZIPTABIX as TABIX_BGZIPTABIX_INTERVAL_ALL   } from '../../modules/nf-core/modules/tabix/bgziptabix/main'
-include { TABIX_TABIX as TABIX_DBSNP                          } from '../../modules/nf-core/modules/tabix/tabix/main'
-include { TABIX_TABIX as TABIX_GERMLINE_RESOURCE              } from '../../modules/nf-core/modules/tabix/tabix/main'
-include { TABIX_TABIX as TABIX_KNOWN_INDELS                   } from '../../modules/nf-core/modules/tabix/tabix/main'
-include { TABIX_TABIX as TABIX_PON                            } from '../../modules/nf-core/modules/tabix/tabix/main'
+include { BWA_INDEX as BWAMEM1_INDEX             } from '../../modules/nf-core/modules/bwa/index/main'
+include { BWAMEM2_INDEX                          } from '../../modules/nf-core/modules/bwamem2/index/main'
+include { GATK4_CREATESEQUENCEDICTIONARY         } from '../../modules/nf-core/modules/gatk4/createsequencedictionary/main'
+include { MSISENSORPRO_SCAN                      } from '../../modules/nf-core/modules/msisensorpro/scan/main'
+include { SAMTOOLS_FAIDX                         } from '../../modules/nf-core/modules/samtools/faidx/main'
+include { TABIX_TABIX as TABIX_DBSNP             } from '../../modules/nf-core/modules/tabix/tabix/main'
+include { TABIX_TABIX as TABIX_GERMLINE_RESOURCE } from '../../modules/nf-core/modules/tabix/tabix/main'
+include { TABIX_TABIX as TABIX_KNOWN_INDELS      } from '../../modules/nf-core/modules/tabix/tabix/main'
+include { TABIX_TABIX as TABIX_PON               } from '../../modules/nf-core/modules/tabix/tabix/main'
 
 workflow PREPARE_GENOME {
     take:
@@ -36,117 +31,36 @@ workflow PREPARE_GENOME {
 
     ch_versions = Channel.empty()
 
-    BWAMEM1_INDEX(fasta) // params.aligner == bwa-mem
-    BWAMEM2_INDEX(fasta) // params.aligner == bwa-mem2
+    BWAMEM1_INDEX(fasta) // If aligner is bwa-mem
+    BWAMEM2_INDEX(fasta) // If aligner is bwa-mem2
     GATK4_CREATESEQUENCEDICTIONARY(fasta)
-
-    // There can be only one (ore none), so ch_bwa contains the proper indexes
-    ch_bwa  = BWAMEM1_INDEX.out.index.mix(BWAMEM2_INDEX.out.index)
-    ch_dict = GATK4_CREATESEQUENCEDICTIONARY.out.dict
-
-    ch_versions = ch_versions.mix(BWAMEM1_INDEX.out.versions)
-    ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
-    ch_versions = ch_versions.mix(GATK4_CREATESEQUENCEDICTIONARY.out.versions)
-
-    // fasta_fai is the one oddball here
-    // It can be generated from the fasta or can be provided
-    // And it can be used to generate intervals
-    // So we need to check if it is provided and if not, generate it
-    if (fasta_fai) ch_fasta_fai = fasta_fai
-    else {
-        SAMTOOLS_FAIDX(fasta.map{ it -> [[id:it[0].getName()], it] })
-        ch_fasta_fai = SAMTOOLS_FAIDX.out.fai.map{ meta, fai -> [fai] }
-        ch_versions  = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
-    }
-
+    MSISENSORPRO_SCAN(fasta.map{ it -> [[id:it[0].baseName], it] })
+    SAMTOOLS_FAIDX(fasta.map{ it -> [[id:it[0].getName()], it] })
     TABIX_DBSNP(dbsnp.map{ it -> [[id:it[0].baseName], it] })
     TABIX_GERMLINE_RESOURCE(germline_resource.map{ it -> [[id:it[0].baseName], it] })
     TABIX_KNOWN_INDELS(known_indels.map{ it -> [[id:it[0].baseName], it] })
     TABIX_PON(pon.map{ it -> [[id:it[0].baseName], it] })
-    MSISENSORPRO_SCAN(fasta.map{ it -> [[id:it[0].baseName], it] })
 
-    ch_dbsnp_tbi             = TABIX_DBSNP.out.tbi.map{ meta, tbi -> [tbi] }
-    ch_germline_resource_tbi = TABIX_GERMLINE_RESOURCE.out.tbi.map{ meta, tbi -> [tbi] }
-    ch_known_indels_tbi      = TABIX_KNOWN_INDELS.out.tbi.map{ meta, tbi -> [tbi] }
-    ch_pon_tbi               = TABIX_PON.out.tbi.map{ meta, tbi -> [tbi] }
-    ch_msisensorpro_scan     = MSISENSORPRO_SCAN.out.list.map{ meta, list -> [list] }
-
+    // Gather versions of all tools used
+    ch_versions  = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
+    ch_versions = ch_versions.mix(BWAMEM1_INDEX.out.versions)
+    ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
+    ch_versions = ch_versions.mix(GATK4_CREATESEQUENCEDICTIONARY.out.versions)
+    ch_versions = ch_versions.mix(MSISENSORPRO_SCAN.out.versions)
     ch_versions = ch_versions.mix(TABIX_DBSNP.out.versions)
     ch_versions = ch_versions.mix(TABIX_GERMLINE_RESOURCE.out.versions)
     ch_versions = ch_versions.mix(TABIX_KNOWN_INDELS.out.versions)
     ch_versions = ch_versions.mix(TABIX_PON.out.versions)
-    ch_versions = ch_versions.mix(MSISENSORPRO_SCAN.out.versions)
-
-    ch_intervals                        = Channel.empty()
-    ch_intervals_bed_gz_tbi             = Channel.empty()
-    ch_intervals_combined_bed_gz_tbi    = Channel.empty() //Create bed.gz and bed.gz.tbi for input/or created interval file. It contains ALL regions.
-
-    tabix_in_combined = Channel.empty()
-
-    if (params.no_intervals) {
-        file("${params.outdir}/no_intervals.bed").text = "no_intervals\n"
-        ch_intervals = Channel.fromPath(file("${params.outdir}/no_intervals.bed"))
-        tabix_in_combined = ch_intervals.map{it -> [[id:it.getName()], it] }
-    } else if (params.step != "annotate" && params.step != "controlfreec") {
-        if (!params.intervals) {
-            BUILD_INTERVALS(ch_fasta_fai)
-            tabix_in_combined = BUILD_INTERVALS.out.bed.map{it -> [[id:it.getName()], it] }
-            ch_intervals = CREATE_INTERVALS_BED(BUILD_INTERVALS.out.bed)
-        }else{
-            tabix_in_combined = Channel.fromPath(file(params.intervals)).map{it -> [[id:it.baseName], it] }
-            if(!params.intervals.endsWith(".bed")) {
-                GATK4_INTERVALLISTTOBED(tabix_in_combined)
-                tabix_in_combined = GATK4_INTERVALLISTTOBED.out.bed
-                ch_versions = ch_versions.mix(GATK4_INTERVALLISTTOBED.out.versions)
-            }
-            ch_intervals = CREATE_INTERVALS_BED(file(params.intervals))
-        }
-    }
-
-    if (params.step != "annotate" && params.step != "controlfreec") {
-
-        TABIX_BGZIPTABIX_INTERVAL_ALL(tabix_in_combined)
-        ch_intervals_combined_bed_gz_tbi = TABIX_BGZIPTABIX_INTERVAL_ALL.out.gz_tbi.map{ meta, bed, tbi -> [bed, tbi] }
-        ch_versions = ch_versions.mix(TABIX_BGZIPTABIX_INTERVAL_ALL.out.versions)
-
-        if (!params.no_intervals) {
-            ch_intervals = ch_intervals.flatten()
-                .map{ intervalFile ->
-                    def duration = 0.0
-                    for (line in intervalFile.readLines()) {
-                        final fields = line.split('\t')
-                        if (fields.size() >= 5) duration += fields[4].toFloat()
-                        else {
-                            start = fields[1].toInteger()
-                            end = fields[2].toInteger()
-                            duration += (end - start) / params.nucleotides_per_second
-                        }
-                    }
-                    [duration, intervalFile]
-                }.toSortedList({ a, b -> b[0] <=> a[0] })
-                .flatten().collate(2)
-                .map{duration, intervalFile -> intervalFile}
-        }
-
-        // Create bed.gz and bed.gz.tbi for each interval file. They are split by region (see above)
-        tabix_in = ch_intervals.map{it -> [[id:it.baseName], it] }
-        TABIX_BGZIPTABIX_INTERVAL_SPLIT(tabix_in)
-        ch_intervals_bed_gz_tbi = TABIX_BGZIPTABIX_INTERVAL_SPLIT.out.gz_tbi.map{ meta, bed, tbi -> [bed, tbi] }
-        ch_versions = ch_versions.mix(TABIX_BGZIPTABIX_INTERVAL_SPLIT.out.versions)
-    }
 
     emit:
-        bwa                              = ch_bwa                           // path: {bwamem1,bwamem2}/index
-        dbsnp_tbi                        = ch_dbsnp_tbi                     // path: dbsnb.vcf.gz.tbi
-        dict                             = ch_dict                          // path: genome.fasta.dict
-        fasta_fai                        = ch_fasta_fai                     // path: genome.fasta.fai
-        germline_resource_tbi            = ch_germline_resource_tbi         // path: germline_resource.vcf.gz.tbi
-        known_indels_tbi                 = ch_known_indels_tbi.collect()    // path: {known_indels*}.vcf.gz.tbi
-        msisensorpro_scan                = ch_msisensorpro_scan             // path: genome_msi.list
-        pon_tbi                          = ch_pon_tbi                       // path: pon.vcf.gz.tbi
-        intervals_bed                    = ch_intervals                     // path: intervals.bed                        [intervals split for parallel execution]
-        intervals_bed_gz_tbi             = ch_intervals_bed_gz_tbi          // path: target.bed.gz, target.bed.gz.tbi     [intervals split for parallel execution]
-        intervals_combined_bed_gz_tbi    = ch_intervals_combined_bed_gz_tbi // path: interval.bed.gz, interval.bed.gz.tbi [all intervals in one file]
+        bwa                              = BWAMEM1_INDEX.out.index.mix(BWAMEM2_INDEX.out.index)           // path: {bwamem1,bwamem2}/index
+        dbsnp_tbi                        = TABIX_DBSNP.out.tbi.map{ meta, tbi -> [tbi] }                  // path: dbsnb.vcf.gz.tbi
+        dict                             = GATK4_CREATESEQUENCEDICTIONARY.out.dict                        // path: genome.fasta.dict
+        fasta_fai                        = SAMTOOLS_FAIDX.out.fai.map{ meta, fai -> [fai] }               // path: genome.fasta.fai
+        germline_resource_tbi            = TABIX_GERMLINE_RESOURCE.out.tbi.map{ meta, tbi -> [tbi] }      // path: germline_resource.vcf.gz.tbi
+        known_indels_tbi                 = TABIX_KNOWN_INDELS.out.tbi.map{ meta, tbi -> [tbi] }.collect() // path: {known_indels*}.vcf.gz.tbi
+        msisensorpro_scan                = MSISENSORPRO_SCAN.out.list.map{ meta, list -> [list] }         // path: genome_msi.list
+        pon_tbi                          = TABIX_PON.out.tbi.map{ meta, tbi -> [tbi] }                    // path: pon.vcf.gz.tbi
 
-        versions                         = ch_versions                      // channel: [ versions.yml ]
+        versions                         = ch_versions                                                    // channel: [ versions.yml ]
 }

--- a/subworkflows/local/prepare_intervals.nf
+++ b/subworkflows/local/prepare_intervals.nf
@@ -30,12 +30,12 @@ workflow PREPARE_INTERVALS {
         file("${params.outdir}/no_intervals.bed").text = "no_intervals\n"
         ch_intervals = Channel.fromPath(file("${params.outdir}/no_intervals.bed"))
         tabix_in_combined = ch_intervals.map{it -> [[id:it.getName()], it] }
-    } else if (params.step != "annotate" && params.step != "controlfreec") {
+    } else if (params.step != 'annotate' && params.step != 'controlfreec') {
         if (!params.intervals) {
             BUILD_INTERVALS(fasta_fai)
             tabix_in_combined = BUILD_INTERVALS.out.bed.map{it -> [[id:it.getName()], it] }
             ch_intervals = CREATE_INTERVALS_BED(BUILD_INTERVALS.out.bed)
-        }else{
+        } else {
             tabix_in_combined = Channel.fromPath(file(params.intervals)).map{it -> [[id:it.baseName], it] }
             if(!params.intervals.endsWith(".bed")) {
                 GATK4_INTERVALLISTTOBED(tabix_in_combined)
@@ -45,8 +45,7 @@ workflow PREPARE_INTERVALS {
             ch_intervals = CREATE_INTERVALS_BED(file(params.intervals))
         }
     }
-
-    if (params.step != "annotate" && params.step != "controlfreec") {
+    if (params.step != 'annotate' && params.step != 'controlfreec') {
 
         TABIX_BGZIPTABIX_INTERVAL_ALL(tabix_in_combined)
         ch_intervals_combined_bed_gz_tbi = TABIX_BGZIPTABIX_INTERVAL_ALL.out.gz_tbi.map{ meta, bed, tbi -> [bed, tbi] }

--- a/subworkflows/local/prepare_intervals.nf
+++ b/subworkflows/local/prepare_intervals.nf
@@ -1,0 +1,87 @@
+//
+// PREPARE INTERVALS
+//
+
+// Initialize channels based on params or indices that were just built
+// For all modules here:
+// A when clause condition is defined in the conf/modules.config to determine if the module should be run
+
+include { BUILD_INTERVALS                                     } from '../../modules/local/build_intervals/main'
+include { CREATE_INTERVALS_BED                                } from '../../modules/local/create_intervals_bed/main'
+include { GATK4_INTERVALLISTTOBED                             } from '../../modules/local/gatk4/intervallisttobed'
+include { TABIX_BGZIPTABIX as TABIX_BGZIPTABIX_INTERVAL_SPLIT } from '../../modules/nf-core/modules/tabix/bgziptabix/main'
+include { TABIX_BGZIPTABIX as TABIX_BGZIPTABIX_INTERVAL_ALL   } from '../../modules/nf-core/modules/tabix/bgziptabix/main'
+
+workflow PREPARE_INTERVALS {
+    take:
+        fasta_fai         // channel: [optional]  fasta_fai
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    ch_intervals                        = Channel.empty()
+    ch_intervals_bed_gz_tbi             = Channel.empty()
+    ch_intervals_combined_bed_gz_tbi    = Channel.empty() // Create bed.gz and bed.gz.tbi for input/or created interval file. Contains ALL regions.
+
+    tabix_in_combined = Channel.empty()
+
+    if (params.no_intervals) {
+        file("${params.outdir}/no_intervals.bed").text = "no_intervals\n"
+        ch_intervals = Channel.fromPath(file("${params.outdir}/no_intervals.bed"))
+        tabix_in_combined = ch_intervals.map{it -> [[id:it.getName()], it] }
+    } else if (params.step != "annotate" && params.step != "controlfreec") {
+        if (!params.intervals) {
+            BUILD_INTERVALS(fasta_fai)
+            tabix_in_combined = BUILD_INTERVALS.out.bed.map{it -> [[id:it.getName()], it] }
+            ch_intervals = CREATE_INTERVALS_BED(BUILD_INTERVALS.out.bed)
+        }else{
+            tabix_in_combined = Channel.fromPath(file(params.intervals)).map{it -> [[id:it.baseName], it] }
+            if(!params.intervals.endsWith(".bed")) {
+                GATK4_INTERVALLISTTOBED(tabix_in_combined)
+                tabix_in_combined = GATK4_INTERVALLISTTOBED.out.bed
+                ch_versions = ch_versions.mix(GATK4_INTERVALLISTTOBED.out.versions)
+            }
+            ch_intervals = CREATE_INTERVALS_BED(file(params.intervals))
+        }
+    }
+
+    if (params.step != "annotate" && params.step != "controlfreec") {
+
+        TABIX_BGZIPTABIX_INTERVAL_ALL(tabix_in_combined)
+        ch_intervals_combined_bed_gz_tbi = TABIX_BGZIPTABIX_INTERVAL_ALL.out.gz_tbi.map{ meta, bed, tbi -> [bed, tbi] }
+        ch_versions = ch_versions.mix(TABIX_BGZIPTABIX_INTERVAL_ALL.out.versions)
+
+        if (!params.no_intervals) {
+            ch_intervals = ch_intervals.flatten()
+                .map{ intervalFile ->
+                    def duration = 0.0
+                    for (line in intervalFile.readLines()) {
+                        final fields = line.split('\t')
+                        if (fields.size() >= 5) duration += fields[4].toFloat()
+                        else {
+                            start = fields[1].toInteger()
+                            end = fields[2].toInteger()
+                            duration += (end - start) / params.nucleotides_per_second
+                        }
+                    }
+                    [duration, intervalFile]
+                }.toSortedList({ a, b -> b[0] <=> a[0] })
+                .flatten().collate(2)
+                .map{duration, intervalFile -> intervalFile}
+        }
+
+        // Create bed.gz and bed.gz.tbi for each interval file. They are split by region (see above)
+        tabix_in = ch_intervals.map{it -> [[id:it.baseName], it] }
+        TABIX_BGZIPTABIX_INTERVAL_SPLIT(tabix_in)
+        ch_intervals_bed_gz_tbi = TABIX_BGZIPTABIX_INTERVAL_SPLIT.out.gz_tbi.map{ meta, bed, tbi -> [bed, tbi] }
+        ch_versions = ch_versions.mix(TABIX_BGZIPTABIX_INTERVAL_SPLIT.out.versions)
+    }
+
+    emit:
+        intervals_bed                    = ch_intervals                     // path: intervals.bed                        [intervals split for parallel execution]
+        intervals_bed_gz_tbi             = ch_intervals_bed_gz_tbi          // path: target.bed.gz, target.bed.gz.tbi     [intervals split for parallel execution]
+        intervals_combined_bed_gz_tbi    = ch_intervals_combined_bed_gz_tbi // path: interval.bed.gz, interval.bed.gz.tbi [all intervals in one file]
+
+        versions                         = ch_versions                      // channel: [ versions.yml ]
+}

--- a/subworkflows/local/prepare_intervals.nf
+++ b/subworkflows/local/prepare_intervals.nf
@@ -20,9 +20,9 @@ workflow PREPARE_INTERVALS {
 
     ch_versions = Channel.empty()
 
-    ch_intervals                        = Channel.empty()
-    ch_intervals_bed_gz_tbi             = Channel.empty()
-    ch_intervals_combined_bed_gz_tbi    = Channel.empty() // Create bed.gz and bed.gz.tbi for input/or created interval file. Contains ALL regions.
+    ch_intervals                     = Channel.empty()
+    ch_intervals_bed_gz_tbi          = Channel.empty()
+    ch_intervals_combined_bed_gz_tbi = Channel.empty() // Create bed.gz and bed.gz.tbi for input/or created interval file. Contains ALL regions.
 
     tabix_in_combined = Channel.empty()
 

--- a/subworkflows/local/split_fastq.nf
+++ b/subworkflows/local/split_fastq.nf
@@ -1,6 +1,8 @@
 //
 // SPLIT_FASTQ
 //
+// For all modules here:
+// A when clause condition is defined in the conf/modules.config to determine if the module should be run
 
 include { SEQKIT_SPLIT2 } from '../../modules/nf-core/modules/seqkit/split2/main'
 
@@ -17,6 +19,7 @@ workflow SPLIT_FASTQ {
         [meta, reads]
     }
 
+    // Only if we want to split fastq files
     SEQKIT_SPLIT2(reads_input)
 
     reads_input_split = SEQKIT_SPLIT2.out.reads.map{ key, reads ->
@@ -30,9 +33,9 @@ workflow SPLIT_FASTQ {
         [key, read_files]
     }.transpose()
 
-    ch_versions = ch_versions.mix(SEQKIT_SPLIT2.out.versions)
-
     reads_input_all = reads_input.mix(reads_input_split)
+
+    ch_versions = ch_versions.mix(SEQKIT_SPLIT2.out.versions)
 
     emit:
         reads       = reads_input_all

--- a/subworkflows/local/split_fastq.nf
+++ b/subworkflows/local/split_fastq.nf
@@ -1,0 +1,41 @@
+//
+// SPLIT_FASTQ
+//
+
+include { SEQKIT_SPLIT2 } from '../../modules/nf-core/modules/seqkit/split2/main'
+
+workflow SPLIT_FASTQ {
+    take:
+        reads_input // channel: [mandatory] meta, reads_input
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    reads_input = reads_input.map{ meta, reads ->
+        meta.size = 1
+        [meta, reads]
+    }
+
+    SEQKIT_SPLIT2(reads_input)
+
+    reads_input_split = SEQKIT_SPLIT2.out.reads.map{ key, reads ->
+        //TODO maybe this can be replaced by a regex to include part_001 etc.
+
+        //sorts list of split fq files by :
+        //[R1.part_001, R2.part_001, R1.part_002, R2.part_002,R1.part_003, R2.part_003,...]
+        //TODO: determine whether it is possible to have an uneven number of parts, so remainder: true woud need to be used, I guess this could be possible for unfiltered reads, reads that don't have pairs etc.
+        read_files = reads.sort{ a,b -> a.getName().tokenize('.')[ a.getName().tokenize('.').size() - 3] <=> b.getName().tokenize('.')[ b.getName().tokenize('.').size() - 3]}.collate(2)
+        key.size = read_files.size()
+        [key, read_files]
+    }.transpose()
+
+    ch_versions = ch_versions.mix(SEQKIT_SPLIT2.out.versions)
+
+    reads_input_all = reads_input.mix(reads_input_split)
+
+    emit:
+        reads       = reads_input_all
+        versions    = ch_versions
+}
+

--- a/subworkflows/local/split_fastq.nf
+++ b/subworkflows/local/split_fastq.nf
@@ -25,7 +25,7 @@ workflow SPLIT_FASTQ {
     // Empty channel when splitting fastq files
     if (params.split_fastq > 1) reads_no_split = Channel.empty()
 
-    // Remmaping the channel
+    // Remapping the channel
     reads_split = SEQKIT_SPLIT2.out.reads.map{ key, reads ->
         //TODO maybe this can be replaced by a regex to include part_001 etc.
 

--- a/subworkflows/nf-core/fastqc_trimgalore.nf
+++ b/subworkflows/nf-core/fastqc_trimgalore.nf
@@ -8,42 +8,27 @@ include { TRIMGALORE } from '../../modules/nf-core/modules/trimgalore/main'
 workflow FASTQC_TRIMGALORE {
     take:
     reads         // channel: [ val(meta), [ reads ] ]
-    skip_fastqc   // boolean: true/false
-    skip_trimming // boolean: true/false
 
     main:
     ch_versions = Channel.empty()
-    fastqc_html = Channel.empty()
-    fastqc_zip  = Channel.empty()
 
-    if (!skip_fastqc) {
-        FASTQC ( reads ).html.set { fastqc_html }
-        fastqc_zip  = FASTQC.out.zip
-        ch_versions = ch_versions.mix(FASTQC.out.versions.first())
-    }
+    FASTQC(reads)
+    TRIMGALORE(reads)
 
-    trim_reads = reads
-    trim_html  = Channel.empty()
-    trim_zip   = Channel.empty()
-    trim_log   = Channel.empty()
+    out_reads = reads.mix(TRIMGALORE.out.reads)
 
-    if (!skip_trimming) {
-        TRIMGALORE ( reads ).reads.set { trim_reads }
-        trim_html   = TRIMGALORE.out.html
-        trim_zip    = TRIMGALORE.out.zip
-        trim_log    = TRIMGALORE.out.log
-        ch_versions = ch_versions.mix(TRIMGALORE.out.versions.first())
-    }
+    ch_versions = ch_versions.mix(FASTQC.out.versions.first())
+    ch_versions = ch_versions.mix(TRIMGALORE.out.versions.first())
 
     emit:
-    reads = trim_reads // channel: [ val(meta), [ reads ] ]
+    reads = out_reads               // channel: [ val(meta), [ reads ] ]
 
-    fastqc_html        // channel: [ val(meta), [ html ] ]
-    fastqc_zip         // channel: [ val(meta), [ zip ] ]
+    fastqc_html = FASTQC.out.html   // channel: [ val(meta), [ html ] ]
+    fastqc_zip  = FASTQC.out.zip    // channel: [ val(meta), [ zip ] ]
 
-    trim_html          // channel: [ val(meta), [ html ] ]
-    trim_zip           // channel: [ val(meta), [ zip ] ]
-    trim_log           // channel: [ val(meta), [ txt ] ]
+    trim_html = TRIMGALORE.out.html // channel: [ val(meta), [ html ] ]
+    trim_zip  = TRIMGALORE.out.zip  // channel: [ val(meta), [ zip ] ]
+    trim_log  = TRIMGALORE.out.log  // channel: [ val(meta), [ txt ] ]
 
-    versions = ch_versions // channel: [ versions.yml ]
+    versions = ch_versions          // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/gatk4_mapping/main.nf
+++ b/subworkflows/nf-core/gatk4_mapping/main.nf
@@ -11,18 +11,19 @@ include { SAMTOOLS_MERGE as MERGE_MAPPING } from '../../../modules/nf-core/modul
 
 workflow GATK4_MAPPING {
     take:
-        reads_input // channel: [mandatory] meta, reads_input
-        bwa         // channel: [mandatory] bwa
-        fasta       // channel: [mandatory] fasta
-        fasta_fai   // channel: [mandatory] fasta_fai
+        reads     // channel: [mandatory] meta, reads
+        bwa       // channel: [mandatory] bwa
+        fasta     // channel: [mandatory] fasta
+        fasta_fai // channel: [mandatory] fasta_fai
 
     main:
 
     ch_versions = Channel.empty()
 
     // Only one of the following will be run
-    BWAMEM1_MEM(reads_input, bwa, true) // If aligner is bwa-mem
-    BWAMEM2_MEM(reads_input, bwa, true) // If aligner is bwa-mem2
+
+    BWAMEM1_MEM(reads, bwa, true) // If aligner is bwa-mem
+    BWAMEM2_MEM(reads, bwa, true) // If aligner is bwa-mem2
 
     ch_versions = ch_versions.mix(BWAMEM1_MEM.out.versions.first())
     ch_versions = ch_versions.mix(BWAMEM2_MEM.out.versions.first())

--- a/subworkflows/nf-core/gatk4_mapping/main.nf
+++ b/subworkflows/nf-core/gatk4_mapping/main.nf
@@ -5,70 +5,47 @@
 include { BWAMEM2_MEM                     } from '../../../modules/nf-core/modules/bwamem2/mem/main'
 include { BWA_MEM as BWAMEM1_MEM          } from '../../../modules/nf-core/modules/bwa/mem/main'
 include { SAMTOOLS_INDEX as INDEX_MAPPING } from '../../../modules/local/samtools/index/main'
-include { SAMTOOLS_MERGE                  } from '../../../modules/nf-core/modules/samtools/merge/main'
+include { SAMTOOLS_MERGE as MERGE_MAPPING } from '../../../modules/nf-core/modules/samtools/merge/main'
 include { SEQKIT_SPLIT2                   } from '../../../modules/nf-core/modules/seqkit/split2/main'
 
 workflow GATK4_MAPPING {
     take:
-        aligner             // string:  [mandatory] "bwa-mem" or "bwa-mem2"
-        bwa                 // channel: [mandatory] bwa
-        fasta               // channel: [mandatory] fasta
-        fasta_fai           // channel: [mandatory] fasta_fai
-        reads_input         // channel: [mandatory] meta, reads_input
-        skip_markduplicates // boolean: true/false
-        save_bam_mapped     // boolean: true/false
+        reads_input // channel: [mandatory] meta, reads_input
+        bwa         // channel: [mandatory] bwa
+        fasta       // channel: [mandatory] fasta
+        fasta_fai   // channel: [mandatory] fasta_fai
 
     main:
 
-    bam_indexed = Channel.empty()
+    ch_versions = Channel.empty()
 
-    if (params.split_fastq > 1) {
-        reads_input_split = SEQKIT_SPLIT2(reads_input).reads.map{ key, reads ->
-            //TODO maybe this can be replaced by a regex to include part_001 etc.
-
-            //sorts list of split fq files by :
-            //[R1.part_001, R2.part_001, R1.part_002, R2.part_002,R1.part_003, R2.part_003,...]
-            //TODO: determine whether it is possible to have an uneven number of parts, so remainder: true woud need to be used, I guess this could be possible for unfiltered reads, reads that don't have pairs etc.
-            read_files = reads.sort{ a,b -> a.getName().tokenize('.')[ a.getName().tokenize('.').size() - 3] <=> b.getName().tokenize('.')[ b.getName().tokenize('.').size() - 3]}.collate(2)
-            key.size = read_files.size()
-            [key, read_files]
-        }.transpose()
-    } else {
-        reads_input_split =  reads_input.map{ meta, reads ->
-            meta.size = 1
-            [meta, reads]
-        }
+    reads_input = reads_input.map{ meta, reads ->
+        meta.size = 1
+        [meta, reads]
     }
 
+    SEQKIT_SPLIT2(reads_input)
 
+    reads_input_split = SEQKIT_SPLIT2.out.reads.map{ key, reads ->
+        //TODO maybe this can be replaced by a regex to include part_001 etc.
 
-    bam_bwamem1      = Channel.empty()
-    bam_bwamem2      = Channel.empty()
-    bam_from_aligner = Channel.empty()
-    tool_versions    = Channel.empty()
+        //sorts list of split fq files by :
+        //[R1.part_001, R2.part_001, R1.part_002, R2.part_002,R1.part_003, R2.part_003,...]
+        //TODO: determine whether it is possible to have an uneven number of parts, so remainder: true woud need to be used, I guess this could be possible for unfiltered reads, reads that don't have pairs etc.
+        read_files = reads.sort{ a,b -> a.getName().tokenize('.')[ a.getName().tokenize('.').size() - 3] <=> b.getName().tokenize('.')[ b.getName().tokenize('.').size() - 3]}.collate(2)
+        key.size = read_files.size()
+        [key, read_files]
+    }.transpose()
 
-    if (aligner == "bwa-mem") {
-        BWAMEM1_MEM(reads_input_split, bwa, true)
+    reads_input_all = reads_input.mix(reads_input_split)
 
-        bam_bwamem1 = BWAMEM1_MEM.out.bam
+    BWAMEM1_MEM(reads_input_all, bwa, true)
+    BWAMEM2_MEM(reads_input_all, bwa, true)
 
-        bwamem1_version = BWAMEM1_MEM.out.versions.first()
+    ch_versions = ch_versions.mix(BWAMEM1_MEM.out.versions.first())
+    ch_versions = ch_versions.mix(BWAMEM2_MEM.out.versions.first())
 
-        tool_versions = tool_versions.mix(bwamem1_version)
-    } else {
-        BWAMEM2_MEM(reads_input_split, bwa, true)
-
-        bam_bwamem2 = BWAMEM2_MEM.out.bam
-
-        bwamem2_version = BWAMEM2_MEM.out.versions.first()
-
-        tool_versions = tool_versions.mix(bwamem2_version)
-    }
-
-    bam_from_aligner = bam_from_aligner.mix(bam_bwamem1)
-    bam_from_aligner = bam_from_aligner.mix(bam_bwamem2)
-
-    bam_from_aligner.map{ meta, bam ->
+    bam_mapped = BWAMEM1_MEM.out.bam.mix(BWAMEM2_MEM.out.bam).map{ meta, bam ->
         new_meta = meta.clone()
         new_meta.remove('read_group')
         new_meta.remove('size')
@@ -83,28 +60,24 @@ workflow GATK4_MAPPING {
     }.groupTuple(by:[0,1]).map{
         groupKey, new_meta, bam ->
         [new_meta, bam]
-    }.set{bam_mapped}
+    }
 
     // GATK markduplicates can handle multiple BAMS as input
     // So no merging/indexing at this step
     // Except if and only if skipping markduplicates
     // Or saving mapped BAMs
 
-    if (save_bam_mapped || skip_markduplicates) {
-        bam_mapped.branch{
-            single:   it[1].size() == 1
-            multiple: it[1].size() > 1
-        }.set{bam_to_merge}
+    bam_mapped.branch{
+        single:   it[1].size() == 1
+        multiple: it[1].size() > 1
+    }.set{bam_to_merge}
 
-        SAMTOOLS_MERGE(bam_to_merge.multiple, [])
-        bam_merged = bam_to_merge.single.mix(SAMTOOLS_MERGE.out.bam)
+    MERGE_MAPPING(bam_to_merge.multiple, [])
 
-        INDEX_MAPPING(bam_merged)
-        bam_indexed = INDEX_MAPPING.out.bam_bai
-    }
+    INDEX_MAPPING(bam_to_merge.single.mix(MERGE_MAPPING.out.bam))
 
     emit:
         bam         = bam_mapped
-        bam_indexed = bam_indexed
-        versions    = tool_versions
+        bam_indexed = INDEX_MAPPING.out.bam_bai
+        versions    = ch_versions
 }

--- a/subworkflows/nf-core/gatk4_mapping/main.nf
+++ b/subworkflows/nf-core/gatk4_mapping/main.nf
@@ -18,6 +18,8 @@ workflow GATK4_MAPPING {
 
     main:
 
+    reads.view()
+
     ch_versions = Channel.empty()
 
     // Only one of the following will be run

--- a/subworkflows/nf-core/markduplicates.nf
+++ b/subworkflows/nf-core/markduplicates.nf
@@ -70,7 +70,7 @@ workflow MARKDUPLICATES {
     qc_reports = qc_reports.mix(QUALIMAP_BAMQC.out.results)
     qc_reports = qc_reports.mix(SAMTOOLS_STATS.out.stats)
 
-    // Gather all versions of tools used
+    // Gather versions of all tools used
     ch_versions = ch_versions.mix(DEEPTOOLS_BAMCOVERAGE.out.versions)
     ch_versions = ch_versions.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.versions.first())
     ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES.out.versions.first())

--- a/subworkflows/nf-core/markduplicates.nf
+++ b/subworkflows/nf-core/markduplicates.nf
@@ -1,6 +1,8 @@
 //
 // MARKDUPLICATES AND/OR QC after mapping
 //
+// For all modules here:
+// A when clause condition is defined in the conf/modules.config to determine if the module should be run
 
 include { DEEPTOOLS_BAMCOVERAGE                                    } from '../../modules/local/deeptools/bamcoverage'
 include { GATK4_ESTIMATELIBRARYCOMPLEXITY                          } from '../../modules/nf-core/modules/gatk4/estimatelibrarycomplexity/main'
@@ -15,68 +17,70 @@ include { SAMTOOLS_VIEWINDEX as SAMTOOLS_BAM_TO_CRAM_SPARK         } from '../..
 
 workflow MARKDUPLICATES {
     take:
-        bam_mapped                      // channel: [mandatory, if no --skip_tools markduplicates, else optional] meta, bam
-        bam_indexed                     // channel: [mandatory, if --skip_tools markduplicates, else optional] meta, bam, bai
-        dict                            // channel: [mandatory] dict
-        fasta                           // channel: [mandatory] fasta
-        fasta_fai                       // channel: [mandatory] fasta_fai
-        intervals_combined_bed_gz_tbi   // channel: [optional]  intervals_bed.gz, intervals_bed.gz.tbi
+        bam_mapped                    // channel: [mandatory, when running Markduplicates, else optional] meta, bam
+        bam_indexed                   // channel: [mandatory, when skipping Markduplicates, else optional] meta, bam, bai
+        dict                          // channel: [mandatory] dict
+        fasta                         // channel: [mandatory] fasta
+        fasta_fai                     // channel: [mandatory] fasta_fai
+        intervals_combined_bed_gz_tbi // channel: [optional]  intervals_bed.gz, intervals_bed.gz.tbi
 
     main:
-
     ch_versions = Channel.empty()
     qc_reports  = Channel.empty()
 
+    // When skipping Markduplicates converting bam input to cram
     SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES(bam_indexed, fasta, fasta_fai)
-    cram_markduplicates = SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.cram_crai
 
-    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.versions.first())
-
+    // Run Markupduplicates spark
+    // When running bamqc and/or deeptools output is bam, else cram
     GATK4_MARKDUPLICATES_SPARK(bam_mapped, fasta, fasta_fai, dict)
     INDEX_MARKDUPLICATES(GATK4_MARKDUPLICATES_SPARK.out.output)
 
-    //If BAMQC should be run on MD output, then don't use MDSpark to convert to cram, but use bam output instead
-    bam_markduplicates  = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.bam_bai)
-    cram_markduplicates = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai)
+    // Convert Markupduplicates spark bam output to cram when running bamqc and/or deeptools
+    SAMTOOLS_BAM_TO_CRAM_SPARK(GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.bam_bai), fasta, fasta_fai)
 
-    SAMTOOLS_BAM_TO_CRAM_SPARK(bam_markduplicates, fasta, fasta_fai)
-    cram_markduplicates = SAMTOOLS_BAM_TO_CRAM_SPARK.out.cram_crai
-
-    cram_markduplicates = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai)
-
-    ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES_SPARK.out.versions.first())
-    ch_versions = ch_versions.mix(INDEX_MARKDUPLICATES.out.versions.first())
-    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_SPARK.out.versions.first())
-
+    // Run Markupduplicates
     GATK4_MARKDUPLICATES(bam_mapped)
+    // Convert output to cram
     SAMTOOLS_BAM_TO_CRAM_DUPLICATES(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai), fasta, fasta_fai)
 
-    cram_markduplicates = SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.cram_crai
+    // Only one of these channel is not empty:
+    // - skipping Markduplicates
+    // - running Markupduplicates spark with cram output
+    // - running Markupduplicates spark with bam output
+    // - running Markupduplicates
+    cram_markduplicates = Channel.empty().mix(
+        SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.cram_crai,
+        GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai),
+        SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.cram_crai,
+        SAMTOOLS_BAM_TO_CRAM_SPARK.out.cram_crai)
 
-    qc_reports = qc_reports.mix(GATK4_MARKDUPLICATES.out.metrics)
-
-    ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES.out.versions.first())
-    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.versions.first())
-
-    // GATK4_ESTIMATELIBRARYCOMPLEXITY is only run with SPARK, otherwise reports is from GATK4_MARKDUPLICATES
-    // If --skip_tools markduplicates then QC tools are run on mapped bams,
-    // If no --skip_tools markduplicates, then QC tools are run on duplicate marked crams
-    // After bamqc finishes, convert to cram for further analysis
-
+    // When running Marduplicates spark, and saving reports
     GATK4_ESTIMATELIBRARYCOMPLEXITY(bam_mapped, fasta, fasta_fai, dict)
-    SAMTOOLS_STATS(cram_markduplicates, fasta)
+    // Reports on Marduplicates spark bam output
     QUALIMAP_BAMQC(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai), intervals_combined_bed_gz_tbi)
     DEEPTOOLS_BAMCOVERAGE(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai))
+    // Other reports run on cram
+    SAMTOOLS_STATS(cram_markduplicates, fasta)
 
-    qc_reports = qc_reports.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.metrics)
-    qc_reports = qc_reports.mix(SAMTOOLS_STATS.out.stats)
-    qc_reports = qc_reports.mix(QUALIMAP_BAMQC.out.results)
+    // Gather all reports generated
     qc_reports = qc_reports.mix(DEEPTOOLS_BAMCOVERAGE.out.bigwig)
+    qc_reports = qc_reports.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.metrics)
+    qc_reports = qc_reports.mix(GATK4_MARKDUPLICATES.out.metrics)
+    qc_reports = qc_reports.mix(QUALIMAP_BAMQC.out.results)
+    qc_reports = qc_reports.mix(SAMTOOLS_STATS.out.stats)
 
-    ch_versions = ch_versions.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.versions.first())
-    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())
+    // Gather all versions of tools used
     ch_versions = ch_versions.mix(DEEPTOOLS_BAMCOVERAGE.out.versions)
+    ch_versions = ch_versions.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.versions.first())
+    ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES.out.versions.first())
+    ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES_SPARK.out.versions.first())
+    ch_versions = ch_versions.mix(INDEX_MARKDUPLICATES.out.versions.first())
     ch_versions = ch_versions.mix(QUALIMAP_BAMQC.out.versions.first())
+    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.versions.first())
+    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.versions.first())
+    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_SPARK.out.versions.first())
+    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())
 
     emit:
         cram     = cram_markduplicates

--- a/subworkflows/nf-core/markduplicates.nf
+++ b/subworkflows/nf-core/markduplicates.nf
@@ -57,9 +57,9 @@ workflow MARKDUPLICATES {
 
     // When running Marduplicates spark, and saving reports
     GATK4_ESTIMATELIBRARYCOMPLEXITY(bam_mapped, fasta, fasta_fai, dict)
-    // Reports on Marduplicates spark bam output
-    QUALIMAP_BAMQC(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai), intervals_combined_bed_gz_tbi)
-    DEEPTOOLS_BAMCOVERAGE(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai))
+    // Reports on Marduplicates spark bam output or on bam input
+    QUALIMAP_BAMQC(bam_indexed.mix(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai)), intervals_combined_bed_gz_tbi)
+    DEEPTOOLS_BAMCOVERAGE(bam_indexed.mix(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai)))
     // Other reports run on cram
     SAMTOOLS_STATS(cram_markduplicates, fasta)
 

--- a/subworkflows/nf-core/markduplicates.nf
+++ b/subworkflows/nf-core/markduplicates.nf
@@ -2,120 +2,81 @@
 // MARKDUPLICATES AND/OR QC after mapping
 //
 
-include { GATK4_ESTIMATELIBRARYCOMPLEXITY                  } from '../../modules/nf-core/modules/gatk4/estimatelibrarycomplexity/main'
-include { GATK4_MARKDUPLICATES                             } from '../../modules/nf-core/modules/gatk4/markduplicates/main'
-include { GATK4_MARKDUPLICATES_SPARK                       } from '../../modules/local/gatk4/markduplicatesspark/main'
-include { QUALIMAP_BAMQC                                   } from '../../modules/local/qualimap/bamqc/main'
-include { SAMTOOLS_INDEX as INDEX_MARKDUPLICATES           } from '../../modules/local/samtools/index/main'
-include { SAMTOOLS_STATS                                   } from '../../modules/nf-core/modules/samtools/stats/main'
-include { SAMTOOLS_VIEWINDEX as SAMTOOLS_BAM_TO_CRAM       } from '../../modules/local/samtools/viewindex/main'
-include { SAMTOOLS_VIEWINDEX as SAMTOOLS_BAM_TO_CRAM_SPARK } from '../../modules/local/samtools/viewindex/main'
-include { DEEPTOOLS_BAMCOVERAGE                            } from '../../modules/local/deeptools/bamcoverage'
+include { DEEPTOOLS_BAMCOVERAGE                                    } from '../../modules/local/deeptools/bamcoverage'
+include { GATK4_ESTIMATELIBRARYCOMPLEXITY                          } from '../../modules/nf-core/modules/gatk4/estimatelibrarycomplexity/main'
+include { GATK4_MARKDUPLICATES                                     } from '../../modules/nf-core/modules/gatk4/markduplicates/main'
+include { GATK4_MARKDUPLICATES_SPARK                               } from '../../modules/local/gatk4/markduplicatesspark/main'
+include { QUALIMAP_BAMQC                                           } from '../../modules/local/qualimap/bamqc/main'
+include { SAMTOOLS_INDEX as INDEX_MARKDUPLICATES                   } from '../../modules/local/samtools/index/main'
+include { SAMTOOLS_STATS                                           } from '../../modules/nf-core/modules/samtools/stats/main'
+include { SAMTOOLS_VIEWINDEX as SAMTOOLS_BAM_TO_CRAM_DUPLICATES    } from '../../modules/local/samtools/viewindex/main'
+include { SAMTOOLS_VIEWINDEX as SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES } from '../../modules/local/samtools/viewindex/main'
+include { SAMTOOLS_VIEWINDEX as SAMTOOLS_BAM_TO_CRAM_SPARK         } from '../../modules/local/samtools/viewindex/main'
 
 workflow MARKDUPLICATES {
     take:
-        bam_mapped                      // channel: [mandatory, if --skip_markdiplicate is false, else optional] meta, bam
-        bam_indexed                     // channel: [mandatory, if --skip_markduplicates is set, else optional] meta, bam, bai
-        use_gatk_spark                  //   value: [mandatory] use gatk spark
-        save_metrics                    //   value: [mandatory] save metrics
+        bam_mapped                      // channel: [mandatory, if no --skip_tools markduplicates, else optional] meta, bam
+        bam_indexed                     // channel: [mandatory, if --skip_tools markduplicates, else optional] meta, bam, bai
         dict                            // channel: [mandatory] dict
         fasta                           // channel: [mandatory] fasta
         fasta_fai                       // channel: [mandatory] fasta_fai
-        skip_markduplicates             // boolean: true/false
-        skip_bamqc                      // boolean: true/false
-        skip_samtools                   // boolean: true/false
-        skip_coverage                   // boolean: true/false
         intervals_combined_bed_gz_tbi   // channel: [optional]  intervals_bed.gz, intervals_bed.gz.tbi
 
     main:
 
-    ch_versions           = Channel.empty()
-    report_markduplicates = Channel.empty()
+    ch_versions = Channel.empty()
+    qc_reports  = Channel.empty()
 
-    if (skip_markduplicates) {
-        bam_bai_markduplicates = bam_indexed
-        SAMTOOLS_BAM_TO_CRAM(bam_bai_markduplicates, fasta, fasta_fai)
-        cram_markduplicates = SAMTOOLS_BAM_TO_CRAM.out.cram_crai
+    SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES(bam_indexed, fasta, fasta_fai)
+    cram_markduplicates = SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.cram_crai
 
-        ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM.out.versions.first())
-    } else {
-        if (use_gatk_spark) {
-            //If BAMQC should be run on MD output, then don't use MDSpark to convert to cram, but use bam output instead
-            if (!skip_bamqc || !skip_coverage) {
-                GATK4_MARKDUPLICATES_SPARK(bam_mapped, fasta, fasta_fai, dict, "bam")
-                INDEX_MARKDUPLICATES(GATK4_MARKDUPLICATES_SPARK.out.output)
-                bam_markduplicates = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.bam_bai)
+    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.versions.first())
 
-                SAMTOOLS_BAM_TO_CRAM_SPARK(bam_markduplicates, fasta, fasta_fai)
-                cram_markduplicates = SAMTOOLS_BAM_TO_CRAM_SPARK.out.cram_crai
+    GATK4_MARKDUPLICATES_SPARK(bam_mapped, fasta, fasta_fai, dict)
+    INDEX_MARKDUPLICATES(GATK4_MARKDUPLICATES_SPARK.out.output)
 
-                ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES_SPARK.out.versions.first())
-                ch_versions = ch_versions.mix(INDEX_MARKDUPLICATES.out.versions.first())
-                ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_SPARK.out.versions.first())
-            } else {
-                GATK4_MARKDUPLICATES_SPARK(bam_mapped, fasta, fasta_fai, dict, "cram")
-                INDEX_MARKDUPLICATES(GATK4_MARKDUPLICATES_SPARK.out.output)
-                cram_markduplicates = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.crai)
+    //If BAMQC should be run on MD output, then don't use MDSpark to convert to cram, but use bam output instead
+    bam_markduplicates  = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.bam_bai)
+    cram_markduplicates = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai)
 
-                ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES_SPARK.out.versions.first())
-                ch_versions = ch_versions.mix(INDEX_MARKDUPLICATES.out.versions.first())
-            }
+    SAMTOOLS_BAM_TO_CRAM_SPARK(bam_markduplicates, fasta, fasta_fai)
+    cram_markduplicates = SAMTOOLS_BAM_TO_CRAM_SPARK.out.cram_crai
 
-            if (save_metrics) {
-                GATK4_ESTIMATELIBRARYCOMPLEXITY(bam_mapped, fasta, fasta_fai, dict)
-                report_markduplicates = GATK4_ESTIMATELIBRARYCOMPLEXITY.out.metrics
+    cram_markduplicates = GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai)
 
-                ch_versions = ch_versions.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.versions.first())
-            }
+    ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES_SPARK.out.versions.first())
+    ch_versions = ch_versions.mix(INDEX_MARKDUPLICATES.out.versions.first())
+    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_SPARK.out.versions.first())
 
-        } else {
-            GATK4_MARKDUPLICATES(bam_mapped)
-            report_markduplicates  = GATK4_MARKDUPLICATES.out.metrics
-            bam_markduplicates     = GATK4_MARKDUPLICATES.out.bam
-            bai_markduplicates     = GATK4_MARKDUPLICATES.out.bai
-            bam_bai_markduplicates = bam_markduplicates.join(bai_markduplicates)
+    GATK4_MARKDUPLICATES(bam_mapped)
+    SAMTOOLS_BAM_TO_CRAM_DUPLICATES(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai), fasta, fasta_fai)
 
-            SAMTOOLS_BAM_TO_CRAM(bam_bai_markduplicates, fasta, fasta_fai)
-            cram_markduplicates = SAMTOOLS_BAM_TO_CRAM.out.cram_crai
+    cram_markduplicates = SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.cram_crai
 
-            ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES.out.versions.first())
-            ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM.out.versions.first())
-        }
-    }
+    qc_reports = qc_reports.mix(GATK4_MARKDUPLICATES.out.metrics)
 
-    //If skip_markduplicates then QC tools are run on mapped bams,
-    //if !skip_markduplicates, then QC tools are run on duplicate marked crams
-    //After bamqc finishes, convert to cram for further analysis
-    samtools_stats = Channel.empty()
-    if (!skip_samtools) {
-        SAMTOOLS_STATS(cram_markduplicates, fasta)
-        samtools_stats = SAMTOOLS_STATS.out.stats
+    ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES.out.versions.first())
+    ch_versions = ch_versions.mix(SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.versions.first())
 
-        ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())
-    }
+    // GATK4_ESTIMATELIBRARYCOMPLEXITY is only run with SPARK, otherwise reports is from GATK4_MARKDUPLICATES
+    // If --skip_tools markduplicates then QC tools are run on mapped bams,
+    // If no --skip_tools markduplicates, then QC tools are run on duplicate marked crams
+    // After bamqc finishes, convert to cram for further analysis
 
-    qualimap_bamqc = Channel.empty()
-    if (!skip_bamqc) {
+    GATK4_ESTIMATELIBRARYCOMPLEXITY(bam_mapped, fasta, fasta_fai, dict)
+    SAMTOOLS_STATS(cram_markduplicates, fasta)
+    QUALIMAP_BAMQC(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai), intervals_combined_bed_gz_tbi)
+    DEEPTOOLS_BAMCOVERAGE(GATK4_MARKDUPLICATES.out.bam.join(GATK4_MARKDUPLICATES.out.bai))
 
-        if(!params.wes || params.no_intervals) intervals_combined_bed_gz_tbi = [] //TODO: intervals also with WGS data? Probably need a parameter if WGS for deepvariant tool, that would allow to check here too
+    qc_reports = qc_reports.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.metrics)
+    qc_reports = qc_reports.mix(SAMTOOLS_STATS.out.stats)
+    qc_reports = qc_reports.mix(QUALIMAP_BAMQC.out.results)
+    qc_reports = qc_reports.mix(DEEPTOOLS_BAMCOVERAGE.out.bigwig)
 
-        QUALIMAP_BAMQC(bam_bai_markduplicates, intervals_combined_bed_gz_tbi)
-        qualimap_bamqc = QUALIMAP_BAMQC.out.results
-
-        ch_versions = ch_versions.mix(QUALIMAP_BAMQC.out.versions.first())
-    }
-
-    deeptools_coverage = Channel.empty()
-    if (!skip_coverage) {
-
-        DEEPTOOLS_BAMCOVERAGE(bam_bai_markduplicates)
-        deeptools_coverage = DEEPTOOLS_BAMCOVERAGE.out.bigwig
-
-        ch_versions = ch_versions.mix(DEEPTOOLS_BAMCOVERAGE.out.versions)
-    }
-
-    qc_reports = samtools_stats.mix(qualimap_bamqc)
-    qc_reports = report_markduplicates.mix(qc_reports)
+    ch_versions = ch_versions.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.versions.first())
+    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())
+    ch_versions = ch_versions.mix(DEEPTOOLS_BAMCOVERAGE.out.versions)
+    ch_versions = ch_versions.mix(QUALIMAP_BAMQC.out.versions.first())
 
     emit:
         cram     = cram_markduplicates

--- a/subworkflows/nf-core/markduplicates.nf
+++ b/subworkflows/nf-core/markduplicates.nf
@@ -46,14 +46,14 @@ workflow MARKDUPLICATES {
 
     // Only one of these channel is not empty:
     // - skipping Markduplicates
-    // - running Markupduplicates spark with cram output
     // - running Markupduplicates spark with bam output
+    // - running Markupduplicates spark with cram output
     // - running Markupduplicates
     cram_markduplicates = Channel.empty().mix(
         SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.cram_crai,
-        GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai),
-        SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.cram_crai,
-        SAMTOOLS_BAM_TO_CRAM_SPARK.out.cram_crai)
+        SAMTOOLS_BAM_TO_CRAM_SPARK.out.cram_crai,
+        GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai)
+        SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.cram_crai)
 
     // When running Marduplicates spark, and saving reports
     GATK4_ESTIMATELIBRARYCOMPLEXITY(bam_mapped, fasta, fasta_fai, dict)

--- a/subworkflows/nf-core/markduplicates.nf
+++ b/subworkflows/nf-core/markduplicates.nf
@@ -52,7 +52,7 @@ workflow MARKDUPLICATES {
     cram_markduplicates = Channel.empty().mix(
         SAMTOOLS_BAM_TO_CRAM_NO_DUPLICATES.out.cram_crai,
         SAMTOOLS_BAM_TO_CRAM_SPARK.out.cram_crai,
-        GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai)
+        GATK4_MARKDUPLICATES_SPARK.out.output.join(INDEX_MARKDUPLICATES.out.cram_crai),
         SAMTOOLS_BAM_TO_CRAM_DUPLICATES.out.cram_crai)
 
     // When running Marduplicates spark, and saving reports
@@ -71,7 +71,7 @@ workflow MARKDUPLICATES {
     qc_reports = qc_reports.mix(SAMTOOLS_STATS.out.stats)
 
     // Gather versions of all tools used
-    ch_versions = ch_versions.mix(DEEPTOOLS_BAMCOVERAGE.out.versions)
+    ch_versions = ch_versions.mix(DEEPTOOLS_BAMCOVERAGE.out.versions.first())
     ch_versions = ch_versions.mix(GATK4_ESTIMATELIBRARYCOMPLEXITY.out.versions.first())
     ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES.out.versions.first())
     ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES_SPARK.out.versions.first())

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -281,14 +281,12 @@ workflow SAREK {
         // OPTIONNAL SPLIT OF FASTQ FILES WITH SEQKIT_SPLIT2
         SPLIT_FASTQ(reads_input)
 
-        reads_input_for_mapping = SPLIT_FASTQ.out.reads
-
         // Get versions from all software used
         ch_versions = ch_versions.mix(SPLIT_FASTQ.out.versions)
 
         // STEP 1: MAPPING READS TO REFERENCE GENOME
         GATK4_MAPPING(
-            reads_input,
+            SPLIT_FASTQ.out.reads,
             bwa,
             fasta,
             fasta_fai)

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -230,7 +230,7 @@ workflow SAREK {
     intervals_bed_gz_tbi          = PREPARE_INTERVALS.out.intervals_bed_gz_tbi                      // multiple interval.bed.gz/.tbi files, divided by useful intervals for scatter/gather
     intervals_bed_combined_gz_tbi = PREPARE_INTERVALS.out.intervals_combined_bed_gz_tbi.collect()   // one file containing all intervals interval.bed.gz/.tbi file
     intervals_bed_combined_gz     = intervals_bed_combined_gz_tbi.map{ bed, tbi -> [bed]}.collect() // one file containing all intervals interval.bed.gz file
-    intervals_combined_bed_gz_tbi_for_preprocessing = (!params.wes || params.no_intervals) ? [] : PREPARE_INTERVALS.out.intervals_combined_bed_gz_tbi.collect() //TODO: intervals also with WGS data? Probably need a parameter if WGS for deepvariant tool, that would allow to check here too
+    intervals_combined_bed_gz_tbi_for_preprocessing = (!params.wes || params.no_intervals) ? [] : PREPARE_INTERVALS.out.intervals_bed //TODO: intervals also with WGS data? Probably need a parameter if WGS for deepvariant tool, that would allow to check here too
 
     num_intervals = 0
     intervals.count().map{ num_intervals = it }

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -345,7 +345,6 @@ workflow SAREK {
 
             PREPARE_RECALIBRATION(
                 cram_markduplicates,
-                ('bqsr' in params.use_gatk_spark),
                 dict,
                 fasta,
                 fasta_fai,

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -230,7 +230,7 @@ workflow SAREK {
     intervals_bed_gz_tbi          = PREPARE_INTERVALS.out.intervals_bed_gz_tbi                      // multiple interval.bed.gz/.tbi files, divided by useful intervals for scatter/gather
     intervals_bed_combined_gz_tbi = PREPARE_INTERVALS.out.intervals_combined_bed_gz_tbi.collect()   // one file containing all intervals interval.bed.gz/.tbi file
     intervals_bed_combined_gz     = intervals_bed_combined_gz_tbi.map{ bed, tbi -> [bed]}.collect() // one file containing all intervals interval.bed.gz file
-    intervals_combined_bed_gz_tbi_for_preprocessing = (!params.wes || params.no_intervals) ? [] : intervals_combined_bed_gz_tbi //TODO: intervals also with WGS data? Probably need a parameter if WGS for deepvariant tool, that would allow to check here too
+    intervals_combined_bed_gz_tbi_for_preprocessing = (!params.wes || params.no_intervals) ? [] : PREPARE_INTERVALS.out.intervals_combined_bed_gz_tbi.collect() //TODO: intervals also with WGS data? Probably need a parameter if WGS for deepvariant tool, that would allow to check here too
 
     num_intervals = 0
     intervals.count().map{ num_intervals = it }

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -313,7 +313,7 @@ workflow SAREK {
         // index will be created down the road from Markduplicates
         // bam_indexed should only have indexes if Markduplicates is skipped
 
-        if ('markduplicates' in params.skip_tools) bam_indexed = input_sample
+        if (params.skip_tools && 'markduplicates' in params.skip_tools) bam_indexed = input_sample
         else bam_mapped = input_sample.map{ meta, bam, bai -> [meta, bam] }
     }
 

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -89,7 +89,7 @@ chr_dir           = params.chr_dir           ? Channel.fromPath(params.chr_dir).
 chr_length        = params.chr_length        ? Channel.fromPath(params.chr_length).collect()        : []
 dbsnp             = params.dbsnp             ? Channel.fromPath(params.dbsnp).collect()             : Channel.empty()
 fasta             = params.fasta             ? Channel.fromPath(params.fasta).collect()             : []
-germline_resource = params.germline_resource ? Channel.fromPath(params.germline_resource).collect() : []
+germline_resource = params.germline_resource ? Channel.fromPath(params.germline_resource).collect() : Channel.empty()
 known_indels      = params.known_indels      ? Channel.fromPath(params.known_indels).collect()      : Channel.empty()
 loci              = params.ac_loci           ? Channel.fromPath(params.ac_loci).collect()           : []
 loci_gc           = params.ac_loci_gc        ? Channel.fromPath(params.ac_loci_gc).collect()        : []
@@ -106,7 +106,7 @@ cadd_indels       = params.cadd_indels       ? Channel.fromPath(params.cadd_inde
 cadd_indels_tbi   = params.cadd_indels_tbi   ? Channel.fromPath(params.cadd_indels_tbi).collect()   : []
 cadd_wg_snvs      = params.cadd_wg_snvs      ? Channel.fromPath(params.cadd_wg_snvs).collect()      : []
 cadd_wg_snvs_tbi  = params.cadd_wg_snvs_tbi  ? Channel.fromPath(params.cadd_wg_snvs_tbi).collect()  : []
-pon               = params.pon               ? Channel.fromPath(params.pon).collect()               : []
+pon               = params.pon               ? Channel.fromPath(params.pon).collect()               : Channel.empty()
 snpeff_cache      = params.snpeff_cache      ? Channel.fromPath(params.snpeff_cache).collect()      : []
 //target_bed        = params.target_bed        ? Channel.fromPath(params.target_bed).collect()        : []
 vep_cache         = params.vep_cache         ? Channel.fromPath(params.vep_cache).collect()         : []
@@ -195,9 +195,7 @@ workflow SAREK {
         params.fasta_fai,
         germline_resource,
         known_indels,
-        pon,
-        params.tools,
-        params.step)
+        pon)
 
     // Gather built indices or get them from the params
     bwa                    = params.fasta                   ? params.bwa                   ? Channel.fromPath(params.bwa).collect()                   : PREPARE_GENOME.out.bwa                   : []


### PR DESCRIPTION
- Update all modules
- Add back `params.publish_dir_mode`
- refactor `--skip_qc`, `--skip_markduplicates` and `--skip_bqsr` into `--skip_tools`
- move out split_fastq into its own subworkflow
- move out prepare_intervals into its own subworkflow
- Use `ext.when` for modules in all current subworkflows
  - [ ] `annotate.nf`
  - [ ] `bam2fastq.nf`
  - [ ] `germline_variant_calling.nf`
  - [ ] `mapping_csv.nf`
  - [ ] `markduplicates_csv.nf`
  - [ ] `pair_copy_number_calling.nf`
  - [ ] `pair_variant_calling.nf`
  - [x] `prepare_genome.nf`
  - [x] `prepare_intervals.nf`
  - [ ] `prepare_recalibration_csv.nf`
  - [ ] `recalibrate_csv.nf`
  - [x] `split_fastq.nf`
  - [ ] `tumor_variant_calling.nf`
  - [x] `fastqc_trimgalore.nf`
  - [x] `markduplicates.nf`
  - [x] `prepare_recalibration.nf`
  - [x] `recalibrate.nf`
  - [ ] `annotation_ensemblvep/main.nf`
  - [ ] `annotation_snpeff/main.nf`
  - [ ] `fgbio_create_umi_consensus/main.nf`
  - [x] `gatk4_mapping/main.nf`
  - [ ] `gatk_tumor_normal_somatic_variant_calling/main.nf`
  - [ ] `gatk_tumor_only_somatic_variant_calling/main.nf`
  - [ ] `joint_germline_variant_calling/main.nf`