### PR TITLE
fix known_indel channel formatting (and others)

### DIFF
--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -41,10 +41,15 @@ workflow PREPARE_GENOME {
     GATK4_CREATESEQUENCEDICTIONARY(fasta)
     MSISENSORPRO_SCAN(fasta.map{ it -> [[id:it[0].baseName], it] })
     SAMTOOLS_FAIDX(fasta.map{ it -> [[id:it[0].getName()], it] })
-    TABIX_DBSNP(dbsnp.map{ it -> [[id:it[0].baseName], it] })
-    TABIX_GERMLINE_RESOURCE(germline_resource.map{ it -> [[id:it[0].baseName], it] })
+
+    // the following are flattened and mapped in case the user supplies more than one value for the param
+    // written for KNOWN_INDELS, but preemptively applied to the rest
+    // [file1,file2] becomes [[meta1,file1],[meta2,file2]]
+    // outputs are collected to maintain a single channel for relevant TBI files
+    TABIX_DBSNP(dbsnp.flatten().map{ it -> [[id:it.baseName], it] })
+    TABIX_GERMLINE_RESOURCE(germline_resource.flatten().map{ it -> [[id:it.baseName], it] })
     TABIX_KNOWN_INDELS( known_indels.flatten().map{ it -> [[id:it.baseName], it] } )
-    TABIX_PON(pon.map{ it -> [[id:it[0].baseName], it] })
+    TABIX_PON(pon.flatten().map{ it -> [[id:it.baseName], it] })
 
     chr_files = chr_dir
     //TODO this works, but is not pretty. I will leave this in your hands during refactoring @Maxime
@@ -69,13 +74,13 @@ workflow PREPARE_GENOME {
         bwa                              = BWAMEM1_INDEX.out.index                                        // path: bwa/*
         bwamem2                          = BWAMEM2_INDEX.out.index                                        // path: bwamem2/*
         hashtable                        = DRAGMAP_HASHTABLE.out.hashmap                                  // path: dragmap/*
-        dbsnp_tbi                        = TABIX_DBSNP.out.tbi.map{ meta, tbi -> [tbi] }                  // path: dbsnb.vcf.gz.tbi
+        dbsnp_tbi                        = TABIX_DBSNP.out.tbi.map{ meta, tbi -> [tbi] }.collect()        // path: dbsnb.vcf.gz.tbi 
         dict                             = GATK4_CREATESEQUENCEDICTIONARY.out.dict                        // path: genome.fasta.dict
         fasta_fai                        = SAMTOOLS_FAIDX.out.fai.map{ meta, fai -> [fai] }               // path: genome.fasta.fai
-        germline_resource_tbi            = TABIX_GERMLINE_RESOURCE.out.tbi.map{ meta, tbi -> [tbi] }      // path: germline_resource.vcf.gz.tbi
+        germline_resource_tbi            = TABIX_GERMLINE_RESOURCE.out.tbi.map{ meta, tbi -> [tbi] }.collect()      // path: germline_resource.vcf.gz.tbi
         known_indels_tbi                 = TABIX_KNOWN_INDELS.out.tbi.map{ meta, tbi -> [tbi] }.collect() // path: {known_indels*}.vcf.gz.tbi
         msisensorpro_scan                = MSISENSORPRO_SCAN.out.list.map{ meta, list -> [list] }         // path: genome_msi.list
-        pon_tbi                          = TABIX_PON.out.tbi.map{ meta, tbi -> [tbi] }                    // path: pon.vcf.gz.tbi
+        pon_tbi                          = TABIX_PON.out.tbi.map{ meta, tbi -> [tbi] }.collect()          // path: pon.vcf.gz.tbi
         chr_files                        = chr_files
         versions                         = ch_versions                                                    // channel: [ versions.yml ]
 }

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -43,7 +43,7 @@ workflow PREPARE_GENOME {
     SAMTOOLS_FAIDX(fasta.map{ it -> [[id:it[0].getName()], it] })
     TABIX_DBSNP(dbsnp.map{ it -> [[id:it[0].baseName], it] })
     TABIX_GERMLINE_RESOURCE(germline_resource.map{ it -> [[id:it[0].baseName], it] })
-    TABIX_KNOWN_INDELS(known_indels.map{ it -> [[id:it[0].baseName], it] })
+    TABIX_KNOWN_INDELS( known_indels.flatten().map{ it -> [[id:it.baseName], it] } )
     TABIX_PON(pon.map{ it -> [[id:it[0].baseName], it] })
 
     chr_files = chr_dir


### PR DESCRIPTION
If for some reason the `known_indel` channel is populated but the `known_indel_tbi` is not. Fix the formatting so that PREPARE_GENOME:TABIX_KNOWN_INDELS reads each element of known_indel separately and the tbi files generated for each one.
