### PR TITLE
add memory error code

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -14,7 +14,8 @@ process {
     time   = { check_max( 4.h  * task.attempt, 'time'   ) }
     shell  = ['/bin/bash', '-euo', 'pipefail']
 
-    errorStrategy = { task.exitStatus in [143,137,104,134,139, 247] ? 'retry' : 'finish' }
+    // memory errors which should be retried. otherwise error out
+    errorStrategy = { task.exitStatus in [143,137,104,134,139,140,247] ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 


### PR DESCRIPTION
I have repeatedly noticed error code 140 relating to memory (notably during alignment using `bwa-mem`). This code relates to memory, and I've added it to the retry strategy list.