### PR TITLE
Add mpileup subworkflow for paired varcalling

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -648,7 +648,7 @@ process{
         ]
     }
 
-    withName: 'CAT_MPILEUP_.*' {
+    withName: 'CAT_MPILEUP.*' {
         ext.when =  { meta.num_intervals > 1 }
         publishDir       = [
             mode: params.publish_dir_mode,
@@ -852,20 +852,42 @@ process{
     }
 
     //CONTROLFREEC
-    withName: 'MPILEUP_NORMAL' {
+    withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:RUN_MPILEUP_NORMAL:MPILEUP' {
         ext.prefix = { "${meta.id}.normal" }
+        publishDir       = [
+            mode: params.publish_dir_mode,
+            path: { "${params.outdir}/variant_calling/${meta.id}/mpileup" },
+            pattern: "*{mpileup}",
+            saveAs: { meta.num_intervals > 1 ? null : it }
+        ]
     }
 
-    withName: 'MPILEUP_TUMOR' {
+    withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:RUN_MPILEUP_TUMOR:MPILEUP' {
         ext.prefix = { "${meta.id}.tumor" }
+        publishDir       = [
+            mode: params.publish_dir_mode,
+            path: { "${params.outdir}/variant_calling/${meta.id}/mpileup" },
+            pattern: "*{mpileup}",
+            saveAs: { meta.num_intervals > 1 ? null : it }
+        ]
     }
 
-    withName: 'CAT_MPILEUP_NORMAL' {
+    withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:RUN_MPILEUP_NORMAL:CAT_MPILEUP' {
         ext.prefix = { "${meta.id}.normal.mpileup" }
+        publishDir       = [
+            mode: params.publish_dir_mode,
+            path: { "${params.outdir}/variant_calling/${meta.id}/mpileup" },
+            pattern: "*{mpileup}",
+        ]
     }
 
-    withName: 'CAT_MPILEUP_TUMOR' {
+    withName: 'NFCORE_SAREK:SAREK:PAIR_VARIANT_CALLING:RUN_MPILEUP_TUMOR:CAT_MPILEUP' {
         ext.prefix = { "${meta.id}.tumor.mpileup" }
+        publishDir       = [
+            mode: params.publish_dir_mode,
+            path: { "${params.outdir}/variant_calling/${meta.id}/mpileup" },
+            pattern: "*{mpileup}",
+        ]
     }
 
     withName: 'FREEC_SOMATIC'{

--- a/subworkflows/local/pair_variant_calling.nf
+++ b/subworkflows/local/pair_variant_calling.nf
@@ -7,6 +7,8 @@ include { RUN_CONTROLFREEC_SOMATIC                  } from '../nf-core/variantca
 include { RUN_FREEBAYES as RUN_FREEBAYES_SOMATIC    } from '../nf-core/variantcalling/freebayes/main.nf'
 include { RUN_MANTA_SOMATIC                         } from '../nf-core/variantcalling/manta/somatic/main.nf'
 include { RUN_STRELKA_SOMATIC                       } from '../nf-core/variantcalling/strelka/somatic/main.nf'
+include { RUN_MPILEUP as RUN_MPILEUP_NORMAL         } from '../nf-core/variantcalling/mpileup/main'
+include { RUN_MPILEUP as RUN_MPILEUP_TUMOR          } from '../nf-core/variantcalling/mpileup/main'
 
 workflow PAIR_VARIANT_CALLING {
     take:
@@ -68,7 +70,7 @@ workflow PAIR_VARIANT_CALLING {
             normal_cram, normal_crai, tumor_cram, tumor_crai, bed_new, tbi_new]
         }
 
-    if (tools.contains('controlfreec')){
+    if (tools.contains('mpileup') || tools.contains('controlfreec')){
         cram_normal_intervals_no_index = cram_pair_intervals
                     .map {meta, normal_cram, normal_crai, tumor_cram, tumor_crai, intervals ->
                             [meta, normal_cram, intervals]
@@ -79,8 +81,21 @@ workflow PAIR_VARIANT_CALLING {
                             [meta, tumor_cram, intervals]
                         }
 
-        RUN_CONTROLFREEC_SOMATIC(cram_normal_intervals_no_index,
-                        cram_tumor_intervals_no_index,
+        RUN_MPILEUP_NORMAL(cram_normal_intervals_no_index,
+                        fasta)
+
+        RUN_MPILEUP_TUMOR(cram_tumor_intervals_no_index,
+                        fasta)
+    }
+
+    if (tools.contains('controlfreec')){
+        RUN_MPILEUP_NORMAL.out.mpileup.cross(RUN_MPILEUP_TUMOR.out.mpileup)
+        .map{ normal, tumor ->
+            [normal[0], normal[1], tumor[1], [], [], [], []]
+        }
+        .set{controlfreec_input}
+
+        RUN_CONTROLFREEC_SOMATIC(controlfreec_input,
                         fasta,
                         fasta_fai,
                         dbsnp,

--- a/subworkflows/nf-core/variantcalling/controlfreec/somatic/main.nf
+++ b/subworkflows/nf-core/variantcalling/controlfreec/somatic/main.nf
@@ -8,8 +8,6 @@ include { CONTROLFREEC_MAKEGRAPH as MAKEGRAPH                    } from '../../.
 
 workflow RUN_CONTROLFREEC_SOMATIC {
     take:
-//    mpileup_normal              // channel: [mandatory] [meta, cram, crai, interval]
-//    mpileup_tumor               // channel: [mandatory] [meta, cram, crai, interval]
     controlfreec_input
     fasta                    // channel: [mandatory]
     fasta_fai                // channel: [mandatory]
@@ -23,23 +21,6 @@ workflow RUN_CONTROLFREEC_SOMATIC {
 
     ch_versions = Channel.empty()
 
-/*    controlfreec_input_normal = Channel.empty().mix(
-        mpileup_normal.out.cat_mpileup,
-        mpileup_normal.out.mpileup_no_intervals
-    ).map{ meta, pileup ->
-        new_meta = [patient:meta.patient, normal_id:meta.normal_id, tumor_id:meta.tumor_id, gender:meta.gender, id:meta.tumor_id + "_vs_" + meta.normal_id, num_intervals:meta.num_intervals]
-
-        [new_meta, pileup]
-    }
-
-    controlfreec_input_tumor = Channel.empty().mix(
-        mpileup_tumor.out.cat_mpileup,
-        mpileup_tumor.out.mpileup_no_intervals
-    ).map{ meta, pileup ->
-        new_meta = [patient:meta.patient, normal_id:meta.normal_id, tumor_id:meta.tumor_id, gender:meta.gender, id:meta.tumor_id + "_vs_" + meta.normal_id, num_intervals:meta.num_intervals]
-        [new_meta, pileup]
-    }
-*/
     FREEC_SOMATIC(controlfreec_input,
                 fasta,
                 fasta_fai,

--- a/subworkflows/nf-core/variantcalling/mpileup/main.nf
+++ b/subworkflows/nf-core/variantcalling/mpileup/main.nf
@@ -1,0 +1,56 @@
+include { CAT_CAT as CAT_MPILEUP_NORMAL                   } from '../../../../modules/nf-core/modules/cat/cat/main.nf'
+include { CAT_CAT as CAT_MPILEUP_TUMOR                    } from '../../../../modules/nf-core/modules/cat/cat/main.nf'
+include { SAMTOOLS_MPILEUP as MPILEUP_NORMAL              } from '../../../../modules/nf-core/modules/samtools/mpileup/main'
+include { SAMTOOLS_MPILEUP as MPILEUP_TUMOR               } from '../../../../modules/nf-core/modules/samtools/mpileup/main'
+
+workflow MPILEUP {
+    take:
+    cram_normal              // channel: [mandatory] [meta, cram, crai, interval]
+    cram_tumor               // channel: [mandatory]
+    fasta                    // channel: [mandatory]
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    MPILEUP_NORMAL(cram_normal, fasta)
+
+    MPILEUP_NORMAL.out.mpileup.branch{
+            intervals:    it[0].num_intervals > 1
+            no_intervals: it[0].num_intervals <= 1
+        }.set{mpileup_normal}
+
+    MPILEUP_TUMOR(cram_tumor, fasta)
+
+    MPILEUP_TUMOR.out.mpileup.branch{
+            intervals:    it[0].num_intervals > 1
+            no_intervals: it[0].num_intervals <= 1
+        }.set{mpileup_tumor}
+        //TODO: Strelka anschauen? Single wird sowohl für tumor only und dingens verwendet
+    //Merge mpileup only when intervals and natural order sort them
+    CAT_MPILEUP_NORMAL(mpileup_normal.intervals
+        .map{ meta, pileup ->
+            new_meta = [patient:meta.patient, normal_id:meta.normal_id, tumor_id:meta.tumor_id, gender:meta.gender, id:meta.tumor_id + "_vs_" + meta.normal_id, num_intervals:meta.num_intervals]
+            [groupKey(new_meta, meta.num_intervals), pileup]
+            }
+        .groupTuple(sort:true))
+
+    CAT_MPILEUP_TUMOR(mpileup_tumor.intervals
+        .map{ meta, pileup ->
+            new_meta = [patient:meta.patient, normal_id:meta.normal_id, tumor_id:meta.tumor_id, gender:meta.gender, id:meta.tumor_id + "_vs_" + meta.normal_id, num_intervals:meta.num_intervals]
+            [groupKey(new_meta, meta.num_intervals), pileup]
+            }
+        .groupTuple(sort:true))
+
+
+    ch_versions = ch_versions.mix(MPILEUP_NORMAL.out.versions)
+    ch_versions = ch_versions.mix(MPILEUP_TUMOR.out.versions)
+    ch_versions = ch_versions.mix(CAT_MPILEUP_NORMAL.out.versions)
+    ch_versions = ch_versions.mix(CAT_MPILEUP_TUMOR.out.versions)
+    emit:
+    versions = ch_versions
+    cat_mpileup_normal = CAT_MPILEUP_NORMAL.out.file_out
+    cat_mpileup_tumor = CAT_MPILEUP_TUMOR.out.file_out
+    mpileup_normal_no_intervals = mpileup_normal.no_intervals
+    mpileup_tumor_no_intervals = mpileup_tumor.no_intervals
+}

--- a/subworkflows/nf-core/variantcalling/mpileup/main.nf
+++ b/subworkflows/nf-core/variantcalling/mpileup/main.nf
@@ -26,7 +26,7 @@ workflow MPILEUP {
             intervals:    it[0].num_intervals > 1
             no_intervals: it[0].num_intervals <= 1
         }.set{mpileup_tumor}
-        //TODO: Strelka anschauen? Single wird sowohl für tumor only und dingens verwendet
+
     //Merge mpileup only when intervals and natural order sort them
     CAT_MPILEUP_NORMAL(mpileup_normal.intervals
         .map{ meta, pileup ->

--- a/subworkflows/nf-core/variantcalling/mpileup/main.nf
+++ b/subworkflows/nf-core/variantcalling/mpileup/main.nf
@@ -1,56 +1,35 @@
-include { CAT_CAT as CAT_MPILEUP_NORMAL                   } from '../../../../modules/nf-core/modules/cat/cat/main.nf'
-include { CAT_CAT as CAT_MPILEUP_TUMOR                    } from '../../../../modules/nf-core/modules/cat/cat/main.nf'
-include { SAMTOOLS_MPILEUP as MPILEUP_NORMAL              } from '../../../../modules/nf-core/modules/samtools/mpileup/main'
-include { SAMTOOLS_MPILEUP as MPILEUP_TUMOR               } from '../../../../modules/nf-core/modules/samtools/mpileup/main'
+include { CAT_CAT as CAT_MPILEUP                    } from '../../../../modules/nf-core/modules/cat/cat/main'
+include { SAMTOOLS_MPILEUP as MPILEUP               } from '../../../../modules/nf-core/modules/samtools/mpileup/main'
 
-workflow MPILEUP {
+workflow RUN_MPILEUP {
     take:
-    cram_normal              // channel: [mandatory] [meta, cram, crai, interval]
-    cram_tumor               // channel: [mandatory]
-    fasta                    // channel: [mandatory]
+        cram                    // channel: [mandatory] [meta, cram, crai, interval]
+        fasta                   // channel: [mandatory]
 
     main:
 
     ch_versions = Channel.empty()
 
-    MPILEUP_NORMAL(cram_normal, fasta)
+    MPILEUP(cram, fasta)
 
-    MPILEUP_NORMAL.out.mpileup.branch{
+    MPILEUP.out.mpileup.branch{
             intervals:    it[0].num_intervals > 1
             no_intervals: it[0].num_intervals <= 1
-        }.set{mpileup_normal}
-
-    MPILEUP_TUMOR(cram_tumor, fasta)
-
-    MPILEUP_TUMOR.out.mpileup.branch{
-            intervals:    it[0].num_intervals > 1
-            no_intervals: it[0].num_intervals <= 1
-        }.set{mpileup_tumor}
+        }
+            .set{mpileup}
 
     //Merge mpileup only when intervals and natural order sort them
-    CAT_MPILEUP_NORMAL(mpileup_normal.intervals
+    CAT_MPILEUP(mpileup.intervals
         .map{ meta, pileup ->
-            new_meta = [patient:meta.patient, normal_id:meta.normal_id, tumor_id:meta.tumor_id, gender:meta.gender, id:meta.tumor_id + "_vs_" + meta.normal_id, num_intervals:meta.num_intervals]
+            new_meta = meta.tumor_id ? [patient:meta.patient, normal_id:meta.normal_id, tumor_id:meta.tumor_id, gender:meta.gender, id:meta.tumor_id + "_vs_" + meta.normal_id, num_intervals:meta.num_intervals] // not annotated, so no variantcaller necessary
+                                        : [patient:meta.patient, sample:meta.sample, status:meta.status, gender:meta.gender, id:new_id, num_intervals:meta.num_intervals]
             [groupKey(new_meta, meta.num_intervals), pileup]
             }
-        .groupTuple(sort:true))
+                .groupTuple(sort:true))
 
-    CAT_MPILEUP_TUMOR(mpileup_tumor.intervals
-        .map{ meta, pileup ->
-            new_meta = [patient:meta.patient, normal_id:meta.normal_id, tumor_id:meta.tumor_id, gender:meta.gender, id:meta.tumor_id + "_vs_" + meta.normal_id, num_intervals:meta.num_intervals]
-            [groupKey(new_meta, meta.num_intervals), pileup]
-            }
-        .groupTuple(sort:true))
-
-
-    ch_versions = ch_versions.mix(MPILEUP_NORMAL.out.versions)
-    ch_versions = ch_versions.mix(MPILEUP_TUMOR.out.versions)
-    ch_versions = ch_versions.mix(CAT_MPILEUP_NORMAL.out.versions)
-    ch_versions = ch_versions.mix(CAT_MPILEUP_TUMOR.out.versions)
+    ch_versions = ch_versions.mix(MPILEUP.out.versions)
+    ch_versions = ch_versions.mix(CAT_MPILEUP.out.versions)
     emit:
     versions = ch_versions
-    cat_mpileup_normal = CAT_MPILEUP_NORMAL.out.file_out
-    cat_mpileup_tumor = CAT_MPILEUP_TUMOR.out.file_out
-    mpileup_normal_no_intervals = mpileup_normal.no_intervals
-    mpileup_tumor_no_intervals = mpileup_tumor.no_intervals
+    mpileup = Channel.empty().mix(CAT_MPILEUP.out.file_out, mpileup.no_intervals)
 }


### PR DESCRIPTION
This PR extracts the mpileup code from the somatic controlfreec subworkflow into a separate subworkflow.

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
