### PR TITLE
Fix `MapReads` caching bug (#555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1a](https://github.com/nf-core/sarek/releases/tag/2.7.1a) - Áhkká
+
+Áhkká is one of the massifs just outside of the Sarek National Park.
+
+This patch release is a hotfix that doesn't change how the containers are used, so it will continue to use `sarek:2.7.1`,  `sarekvep:2.7.1.*`, and `sareksnpeff:2.7.1.*`.
+
+### Added
+
+### Changed
+
+### Fixed
+
+- [#566](https://github.com/nf-core/sarek/pull/566) - Fix caching bug affecting a variable number of `MapReads` jobs due to non-deterministic state of `statusMap` during caching evaluation
+
+### Deprecated
+
+### Removed
+
 ## [2.7.1](https://github.com/nf-core/sarek/releases/tag/2.7.1) - Pårtejekna
 
 Pårtejekna is one of glaciers of the Pårte Massif.

--- a/docs/images/sarek_workflow.svg
+++ b/docs/images/sarek_workflow.svg
@@ -3457,7 +3457,7 @@
                width="150"
                id="rect2357-0" /></flowRegion><flowPara
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro'"
-             id="flowPara2359-7">2.7.1</flowPara></flowRoot></g></g></g><g
+             id="flowPara2359-7">2.7.1a</flowPara></flowRoot></g></g></g><g
      id="g2024"><g
        id="g557-5"
        transform="matrix(0.63891071,0,0,-0.63891071,1686.6721,2304.9241)"><path

--- a/main.nf
+++ b/main.nf
@@ -4168,6 +4168,9 @@ def extractInfos(channel) {
         statusMap[idPatient, idSample] = status
         [idPatient] + it[3..-1]
     }
+    // This forces a roundtrip as a list to ensure that genderMap and
+    // statusMap are fully populated before being used downstream
+    channel = Channel.fromList(channel.toList().val)
     [genderMap, statusMap, channel]
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -246,7 +246,7 @@ manifest {
   description = 'An open-source analysis pipeline to detect germline or somatic variants from whole genome or targeted sequencing'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.04.0'
-  version = '2.7.1'
+  version = '2.7.1a'
 }
 
 // Return the minimum between requirements and a maximum limit to ensure that resource requirements don't go over


### PR DESCRIPTION
I'm opening a PR for what I consider is an important hotfix for Sarek 2.7.1. I understand that there is a shift towards the Sarek 3.0 release, but Sage Bionetworks has pressing needs to start processing data for long-term projects, and we need to use a stable release, precluding the use of the current `dev` branch. 

We have been able to use Sarek 2.7.1 successfully with the exception of the bug described in #555. This PR aims at addressing this bug in an unobtrusive way. 

I suggest increasing the version to `2.7.1a` instead of `2.7.2` to avoid having to regenerate the container images for no reason since this PR doesn't require it. That said, if you prefer sticking to strict semantic version, I'm happy to edit all of the other files containing references to `2.7.1` (mostly related to containers) and update this PR. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
  - Skipped since the `nf-core` tool has moved on to DSL2
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] `CHANGELOG.md` is updated.