### PR TITLE
WIP: Adding option for setting file-output-format for VEP

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1028,11 +1028,19 @@ process{
             (params.vep_spliceai && params.spliceai_snv && params.spliceai_indel) ? '--plugin SpliceAI,snv=spliceai_scores.raw.snv.hg38.vcf.gz,indel=spliceai_scores.raw.indel.hg38.vcf.gz'                     : '',
             (params.vep_spliceregion)                                             ? '--plugin SpliceRegion'                                                                                                     : ''
         ].join(' ').trim()
+        ext.suffix = '_VEP'
         if (!params.vep_cache)    container = { params.vep_genome ? "nfcore/vep:104.3.${params.vep_genome}" : "nfcore/vep:104.3.${params.genome}" }
         publishDir       = [
-            mode: params.publish_dir_mode,
-            path: { "${params.outdir}/reports/EnsemblVEP/${meta.id}/${meta.variantcaller}" },
-            pattern: "*html"
+            [
+                mode: params.publish_dir_mode,
+                path: { "${params.outdir}/reports/EnsemblVEP/${meta.id}/${meta.variantcaller}" },
+                pattern: "*html"
+            ],
+            [
+                mode: params.publish_dir_mode,
+                path: { "${params.outdir}/annotation/${meta.id}/${meta.variantcaller}" },
+                pattern: "*{json,tab}"
+            ]
         ]
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,6 +69,7 @@ params {
     joint_germline = false //
 
     // Annotation
+    vep_output = 'vcf'
     vep_dbnsfp = null // dbnsfp plugin disabled within VEP
     dbnsfp = null // No dbnsfp processed file
     dbnsfp_tbi = null // No dbnsfp processed file index

--- a/subworkflows/local/annotate.nf
+++ b/subworkflows/local/annotate.nf
@@ -12,6 +12,7 @@ workflow ANNOTATE {
     tools
     snpeff_db
     snpeff_cache
+    vep_output
     vep_genome
     vep_species
     vep_cache_version
@@ -41,15 +42,19 @@ workflow ANNOTATE {
     }
 
     if (tools.contains('vep')) {
-        ANNOTATION_ENSEMBLVEP(vcf, vep_genome, vep_species, vep_cache_version, vep_cache, vep_extra_files)
+        ANNOTATION_ENSEMBLVEP(vcf, vep_output, vep_genome, vep_species, vep_cache_version, vep_cache, vep_extra_files)
 
-        ch_reports  = ch_reports.mix(ANNOTATION_ENSEMBLVEP.out.reports)
-        ch_vcf_ann  = ch_vcf_ann.mix(ANNOTATION_ENSEMBLVEP.out.vcf_tbi)
-        ch_versions = ch_versions.mix(ANNOTATION_ENSEMBLVEP.out.versions.first())
+        ch_reports   = ch_reports.mix(ANNOTATION_ENSEMBLVEP.out.reports)
+        ch_vcf_ann   = ch_vcf_ann.mix(ANNOTATION_ENSEMBLVEP.out.vcf_tbi)
+        ch_tab_ann   = ch_vcf_ann.mix(ANNOTATION_ENSEMBLVEP.out.tab)
+        ch_json_ann  = ch_vcf_ann.mix(ANNOTATION_ENSEMBLVEP.out.json)
+        ch_versions  = ch_versions.mix(ANNOTATION_ENSEMBLVEP.out.versions.first())
     }
 
     emit:
-    vcf_ann  = ch_vcf_ann      // channel: [ val(meta), vcf.gz, vcf.gz.tbi ]
-    reports  = ch_reports      //    path: *.html
-    versions = ch_versions     //    path: versions.yml
+    vcf_ann   = ch_vcf_ann      // channel: [ val(meta), vcf.gz, vcf.gz.tbi ]
+    tab_ann   = ch_tab_ann
+    json_ann  = ch_json_ann
+    reports   = ch_reports      //    path: *.html
+    versions  = ch_versions     //    path: versions.yml
 }

--- a/subworkflows/nf-core/annotation/ensemblvep/main.nf
+++ b/subworkflows/nf-core/annotation/ensemblvep/main.nf
@@ -8,6 +8,7 @@ include { TABIX_BGZIPTABIX } from '../../../../modules/nf-core/modules/tabix/bgz
 workflow ANNOTATION_ENSEMBLVEP {
     take:
     vcf               // channel: [ val(meta), vcf ]
+    vep_output
     vep_genome        //   value: genome to use
     vep_species       //   value: species to use
     vep_cache_version //   value: cache version to use
@@ -17,7 +18,7 @@ workflow ANNOTATION_ENSEMBLVEP {
     main:
     ch_versions = Channel.empty()
 
-    ENSEMBLVEP(vcf, vep_genome, vep_species, vep_cache_version, vep_cache, vep_extra_files)
+    ENSEMBLVEP(vcf, vep_output, vep_genome, vep_species, vep_cache_version, vep_cache, vep_extra_files)
     TABIX_BGZIPTABIX(ENSEMBLVEP.out.vcf)
 
     // Gather versions of all tools used
@@ -26,6 +27,8 @@ workflow ANNOTATION_ENSEMBLVEP {
 
     emit:
     vcf_tbi  = TABIX_BGZIPTABIX.out.gz_tbi // channel: [ val(meta), vcf.gz, vcf.gz.tbi ]
+    json     = ENSEMBLVEP.out.json
+    tab      = ENSEMBLVEP.out.tab
     reports  = ENSEMBLVEP.out.report       //    path: *.html
     versions = ch_versions                 //    path: versions.yml
 }

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -867,6 +867,7 @@ workflow SAREK {
                 params.tools,
                 snpeff_db,
                 snpeff_cache,
+                params.vep_output,
                 vep_genome,
                 vep_species,
                 vep_cache_version,


### PR DESCRIPTION
DRAFT

WIP on #575. The solution presented here works, but it might not be a good solution :-/   

I made certain changes to  the nf-core-module `modules/nf-core/modules/ensemblvep/main.nf`, which might not be to everyone's liking. (Of course, if we go with this solution, then the changes to that module should be made in the modules-repo.)

The VEP-output files get names like
```
sample_VEP.ann.vcf.gz
sample_VEP.ann.vcf.gz.tbi
sample_VEP.ann.json
sample_VEP.ann.tab
```

The json-file and the tab-file are not compressed, but perhaps they should be?

No tests updated yet.

I made some changes to 

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
