### PR TITLE
add test full config to aws s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#594](https://github.com/nf-core/sarek/pull/594) - Add parameter `--save_output_as_bam` to allow output of result files in BAM format
 - [#597](https://github.com/nf-core/sarek/pull/597) - Added tiddit for tumor variant calling
 - [#600](https://github.com/nf-core/sarek/pull/600) - Added description for UMI related params in schema
-- [#604](https://github.com/nf-core/sarek/pull/604) - Added full size tests WGS 30x NA12878
+- [#604](https://github.com/nf-core/sarek/pull/604), [#617](https://github.com/nf-core/sarek/pull/617) - Added full size tests WGS 30x NA12878
 
 ### Changed
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -15,7 +15,7 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
-    input = '${projectDir}/tests/csv/3.0/test_full_data.csv'
+    input = 's3://nf-core-awsmegatests/sarek/input/test_NA12878_WES_30x.csv'
 
     // Other params
     tools = 'strelka,freebayes,haplotypecaller,deepvariant,manta,tiddit,cnvkit,vep'

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -15,7 +15,7 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
-    input = 's3://nf-core-awsmegatests/sarek/input/test_NA12878_WES_30x.csv'
+    input = 'https://raw.githubusercontent.com/nf-core/test-datasets/sarek/testdata/csv/NA12878_WGS_30x_full_test.csv'
 
     // Other params
     tools = 'strelka,freebayes,haplotypecaller,deepvariant,manta,tiddit,cnvkit,vep'

--- a/tests/csv/3.0/test_full_data.csv
+++ b/tests/csv/3.0/test_full_data.csv
@@ -1,2 +1,0 @@
-patient,status,sample,lane,fastq_1,fastq_2
-NA12878,0,NA12878,1,s3://nf-core-awsmegatests/sarek/input/NA12878_1.merged.fastq.gz,s3://nf-core-awsmegatests/sarek/input/NA12878_2.merged.fastq.gz


### PR DESCRIPTION
Sorry, I didn't remember that the test full metadata sheet should actually be added to s3 or it can't be staged when running tests

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
