### PR TITLE
More checks of sample-sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#613](https://github.com/nf-core/sarek/pull/613) - Added params `--vep_version` to allow more configuration on the vep container definition
 - [#620](https://github.com/nf-core/sarek/pull/620) - Added checks for sex information when running a CNV tools
 - [#623](https://github.com/nf-core/sarek/pull/623) - Additional checks of data in the input sample sheet.
+- [#629](https://github.com/nf-core/sarek/pull/629) - Added checks to catch inconsistency between supplied samples and requested tools.
 
 ### Changed
 

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -1079,13 +1079,13 @@ def extract_csv(csv_file) {
         // 1. the sample-sheet only contains normal-samples, but some of the requested tools require tumor-samples, and
         // 2. the sample-sheet only contains tumor-samples, but some of the requested tools require normal-samples.
         if ((sample_count_normal == sample_count_all) && params.tools) { // In this case, the sample-sheet contains no tumor-samples
-            def tools_requiring_tumor_samples = ['ascat', 'controlfreec', 'mutect2', 'msisensorpro']
-            def requested_tools_requiring_tumor_samples = []
-            tools_requiring_tumor_samples.each{ tool_requiring_tumor_samples ->
-                if (params.tools.contains(tool_requiring_tumor_samples)) requested_tools_requiring_tumor_samples.add(tool_requiring_tumor_samples)
+            def tools_tumor = ['ascat', 'controlfreec', 'mutect2', 'msisensorpro']
+            def tools_tumor_asked = []
+            tools_tumor.each{ tool ->
+                if (params.tools.contains(tool)) tools_tumor_asked.add(tool)
             }
-            if (!requested_tools_requiring_tumor_samples.isEmpty()) {
-                log.error('The sample-sheet only contains normal-samples, but the following tools, which were requested by the option "tools", expect at least one tumor-sample : ' + requested_tools_requiring_tumor_samples.join(", "))
+            if (!tools_tumor_asked.isEmpty()) {
+                log.error('The sample-sheet only contains normal-samples, but the following tools, which were requested with "--tools", expect at least one tumor-sample : ' + tools_tumor_asked.join(", "))
                 System.exit(1)
             }
         } else if ((sample_count_tumor == sample_count_all) && params.tools) {  // In this case, the sample-sheet contains no normal/germline-samples

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -1028,7 +1028,7 @@ def extract_csv(csv_file) {
             }
             if (!sample2patient.containsKey(row.sample.toString())) {
                 sample2patient[row.sample.toString()] = row.patient.toString()
-            } else if (sample2patient[row.sample.toString()] !== row.patient.toString()) {
+            } else if (sample2patient[row.sample.toString()] != row.patient.toString()) {
                 log.error('The sample "' + row.sample.toString() + '" is registered for both patient "' + row.patient.toString() + '" and "' + sample2patient[row.sample.toString()] + '" in the sample sheet.')
                 System.exit(1)
             }

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -1034,9 +1034,14 @@ def extract_csv(csv_file) {
             }
         }
 
+    numberOfSamples = 0
+    numberOfNormalSamples = 0
+    numberOfTumorSamples = 0
+
     Channel.from(csv_file).splitCsv(header: true)
         //Retrieves number of lanes by grouping together by patient and sample and counting how many entries there are for this combination
         .map{ row ->
+            numberOfSamples++
             if (!(row.patient && row.sample)){
                 log.error "Missing field in csv file header. The csv file must have fields named 'patient' and 'sample'."
                 System.exit(1)
@@ -1048,6 +1053,7 @@ def extract_csv(csv_file) {
             [rows, size]
         }.transpose()
         .map{ row, numLanes -> //from here do the usual thing for csv parsing
+
         def meta = [:]
 
         // Meta data to identify samplesheet
@@ -1065,6 +1071,34 @@ def extract_csv(csv_file) {
         // If no status specified, sample is assumed normal
         if (row.status) meta.status = row.status.toInteger()
         else meta.status = 0
+
+        if (meta.status == 0) numberOfNormalSamples++
+        else numberOfTumorSamples++
+
+        // Two checks for ensuring that the pipeline stops with a meaningful error message if
+        // 1. the sample-sheet only contains normal-samples, but some of the requested tools require tumor-samples, and
+        // 2. the sample-sheet only contains tumor-samples, but some of the requested tools require normal/germline-samples.
+        if ((numberOfNormalSamples == numberOfSamples) && params.tools) { // In this case, the sample-sheet contains no tumor-samples
+            def tools_requiring_tumor_samples = ['ascat', 'controlfreec', 'mutect2', 'msisensorpro']
+            def requested_tools_requiring_tumor_samples = []
+            tools_requiring_tumor_samples.each{ tool_requiring_tumor_samples ->
+                if (params.tools.contains(tool_requiring_tumor_samples)) requested_tools_requiring_tumor_samples.add(tool_requiring_tumor_samples)
+            }
+            if (!requested_tools_requiring_tumor_samples.isEmpty()) {
+                log.error('The sample-sheet only contains normal-samples, but the following tools, which were requested by the option "tools", expect at least one tumor-sample : ' + requested_tools_requiring_tumor_samples.join(", "))
+                System.exit(1)
+            }
+        } else if ((numberOfTumorSamples == numberOfSamples) && params.tools) {  // In this case, the sample-sheet contains no normal/germline-samples
+            def tools_requiring_normal_samples = ['ascat', 'deepvariant', 'haplotypecaller']
+            def requested_tools_requiring_normal_samples = []
+            tools_requiring_normal_samples.each{ tool_requiring_normal_samples ->
+                if (params.tools.contains(tool_requiring_normal_samples)) requested_tools_requiring_normal_samples.add(tool_requiring_normal_samples)
+            }
+            if (!requested_tools_requiring_normal_samples.isEmpty()) {
+                log.error('The sample-sheet only contains tumor-samples, but the following tools, which were requested by the option "tools", expect at least one normal-sample : ' + requested_tools_requiring_normal_samples.join(", "))
+                System.exit(1)
+            }
+        }
 
         // mapping with fastq
         if (row.lane && row.fastq_2) {


### PR DESCRIPTION
Two checks for ensuring that the pipeline stops with a meaningful error message if

1. the sample-sheet only contains normal-samples, but some of the requested tools require tumor-samples, and
2. the sample-sheet only contains tumor-samples, but some of the requested tools require normal-samples.

I did some test-runs of the this with sample-sheet containing

1. only normal-samples,
2. only tumor-samples, and
3. a mix of normal samples and tumor-samples.

@lassefolkersen might also do some test-runs for these new checks.

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
