### PR TITLE
Added TABIX call to the SVDB_MERGE output in pair_vc

### DIFF
--- a/subworkflows/local/pair_variant_calling.nf
+++ b/subworkflows/local/pair_variant_calling.nf
@@ -14,6 +14,7 @@ include { RUN_ASCAT_SOMATIC                         } from '../nf-core/variantca
 include { RUN_TIDDIT as RUN_TIDDIT_NORMAL           } from '../nf-core/variantcalling/tiddit/main.nf'
 include { RUN_TIDDIT as RUN_TIDDIT_TUMOR            } from '../nf-core/variantcalling/tiddit/main.nf'
 include { SVDB_MERGE                                } from '../../modules/nf-core/modules/svdb/merge/main.nf'
+include { TABIX_TABIX                               } from '../../modules/nf-core/modules/tabix/tabix/main.nf'
 
 workflow PAIR_VARIANT_CALLING {
     take:
@@ -231,10 +232,12 @@ workflow PAIR_VARIANT_CALLING {
                                                         [meta, [vcf_normal, vcf_tumor]]
                                                     }, false)
         tiddit_vcf = SVDB_MERGE.out.vcf
+        TABIX_TABIX(tiddit_vcf)
 
         ch_versions = ch_versions.mix(RUN_TIDDIT_NORMAL.out.versions)
         ch_versions = ch_versions.mix(RUN_TIDDIT_TUMOR.out.versions)
         ch_versions = ch_versions.mix(SVDB_MERGE.out.versions)
+        ch_versions = ch_versions.mix(TABIX_TABIX.out.versions)
     }
 
     emit:


### PR DESCRIPTION
This PR indexes the SVDB output in pair_variantcalling

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
