### PR TITLE
Remove errorStrategy in modules.config

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -578,7 +578,6 @@ process {
 // QC
 
     withName: 'FASTQC' {
-        errorStrategy    = {task.exitStatus == 143 ? 'retry' : 'ignore'}
         ext.args         = '--quiet'
         ext.when         = { !(params.skip_tools && params.skip_tools.split(',').contains('fastqc')) }
         publishDir       = [
@@ -1366,10 +1365,5 @@ process{
                 saveAs: { params.tools.split(',').contains('snpeff') ? it : null }
             ]
         }
-    }
-
-    // MULTIQC
-    withName:'MULTIQC' {
-        errorStrategy = {task.exitStatus == 143 ? 'retry' : 'ignore'}
     }
 }


### PR DESCRIPTION
Not sure why this was added in `modules.config` but it prevents using `process.errorStrategy` via an external config due to the priority with `withName` selectors.