### PR TITLE
Remove "None" definition from schema

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -278,7 +278,6 @@
                 },
                 "cf_chrom_len": {
                     "type": "string",
-                    "default": "None",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "description": "Specify a custom chromosome length file.",
                     "help_text": "Control-FREEC requires a file containing all chromosome lenghts. By default the fasta.fai is used. If the fasta.fai file contains chromosomes not present in the intervals, it fails (see: https://github.com/BoevaLab/FREEC/issues/106).\n\nIn this case, a custom chromosome length can be specified. It must be of the same format as the fai, but only contain the relevant chromosomes.\n\n\n\n",


### PR DESCRIPTION
Specifying "None" here in the schema breaks the config resolution on Tower meaning we are unable to use the pipeline from the Launchpad. The error that is generated is below:

```
If you use nf-core/sarek for your analysis please cite:
* The pipeline
  https://doi.org/10.12688/f1000research.16665.2
  https://doi.org/10.5281/zenodo.4468605
* The nf-core framework
  https://doi.org/10.1038/s41587-020-0439-x
* Software dependencies
  https://github.com/nf-core/sarek/blob/master/CITATIONS.md
-[2m----------------------------------------------------[0m-
Unable to read script: '/.nextflow/assets/nf-core/sarek/./workflows/sarek.nf' -- cause: /None
```

This was added in https://github.com/nf-core/sarek/commit/6fd00e1554fbebf1706a82cf7d4f4de8ccaf9b66 by @FriederikeHanssen ! Figuring this out has consumed my entire day 😅 You're welcome!