### PR TITLE
Remove usages of deprecated Channel.from method

### DIFF
--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -1153,7 +1153,7 @@ workflow SAREK {
         ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
         ch_multiqc_files = ch_multiqc_files.mix(ch_reports.collect().ifEmpty([]))
 
-        ch_multiqc_configs = Channel.from(ch_multiqc_config).mix(ch_multiqc_custom_config).ifEmpty([])
+        ch_multiqc_configs = ch_multiqc_config.mix(ch_multiqc_custom_config).ifEmpty([])
 
         MULTIQC (
             ch_multiqc_files.collect(),
@@ -1206,7 +1206,7 @@ def extract_csv(csv_file) {
     def patient_sample_lane_combinations_in_samplesheet = []
     def sample2patient = [:]
 
-    Channel.from(csv_file).splitCsv(header: true)
+    Channel.of(csv_file).splitCsv(header: true)
         .map{ row ->
             if (params.step == "mapping") {
                 if ( !row.lane ) {  // This also handles the case where the lane is left as an empty string
@@ -1233,7 +1233,7 @@ def extract_csv(csv_file) {
     sample_count_normal = 0
     sample_count_tumor = 0
 
-    Channel.from(csv_file).splitCsv(header: true)
+    Channel.of(csv_file).splitCsv(header: true)
         //Retrieves number of lanes by grouping together by patient and sample and counting how many entries there are for this combination
         .map{ row ->
             sample_count_all++


### PR DESCRIPTION
This method should be removed in favour of Channel.of

This also fixes a bug where in newer versions of Nextflow, passing a channel name into Channel.from causes an errror:

```nextflow
Channel.from(ch_multiqc_config).mix(ch_multiqc_custom_config)
```

... which is now 

```nextflow
ch_multiqc_config.mix(ch_multiqc_custom_config)
```

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
