### PR TITLE
Don't mutate channel elements in-place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#945](https://github.com/nf-core/sarek/pull/945) - Adding Adam Talbot to contributor list
 - [#954](https://github.com/nf-core/sarek/pull/954) - Adding keys for annotation with snpeff and ensemblvep for `hg19`, `hg38` and `mm10`
 - [#967](https://github.com/nf-core/sarek/pull/967) - Adding new `outdir_cache` params
+- [#971](https://github.com/nf-core/sarek/pull/971) - Subtle bugfix to correct mutation of FASTP output channel objects.
 
 ### Changed
 

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -497,7 +497,7 @@ workflow SAREK {
 
             if (params.split_fastq) {
                 reads_for_alignment = FASTP.out.reads.map{ meta, reads ->
-                    read_files = reads.sort{ a,b -> a.getName().tokenize('.')[0] <=> b.getName().tokenize('.')[0] }.collate(2)
+                    read_files = reads.sort(false) { a,b -> a.getName().tokenize('.')[0] <=> b.getName().tokenize('.')[0] }.collate(2)
                     [ meta + [ size:read_files.size() ], read_files ]
                 }.transpose()
             } else reads_for_alignment = FASTP.out.reads


### PR DESCRIPTION
As recommended by Paolo here: https://github.com/nextflow-io/nextflow/issues/3768

Calling `.sort()` on the `reads` object mutates the object in-place, which has complicated flow-on effects. Adding the boolean false to the sort method returns a new object.