### PR TITLE
Issue 950: samplesheet validation - no spaces in sample or patient names

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -55,6 +55,10 @@ jobs:
             tags: concatenate_vcfs
           - profile: "singularity"
             tags: merge
+          - profile: "singularity"
+            tags: validation_checks
+          - profile: "conda"
+            tags: validation_checks
     env:
       NXF_ANSI_LOG: false
       TEST_DATA_BASE: "${{ github.workspace }}/test-datasets"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#954](https://github.com/nf-core/sarek/pull/954) - Adding keys for annotation with snpeff and ensemblvep for `hg19`, `hg38` and `mm10`
 - [#967](https://github.com/nf-core/sarek/pull/967) - Adding new `outdir_cache` params
 - [#971](https://github.com/nf-core/sarek/pull/971) - Subtle bugfix to correct mutation of FASTP output channel objects.
+- [#978](https://github.com/nf-core/sarek/pull/978) - Validate that patient/sample does not contain spaces.
 
 ### Changed
 

--- a/tests/config/tags.yml
+++ b/tests/config/tags.yml
@@ -50,6 +50,16 @@ skip_markduplicates:
   - tests/test_skip_markduplicates.yml
   - workflows/**
 
+validation_checks:
+  - conf/modules/**
+  - main.nf
+  - modules/**
+  - nextflow.config
+  - nextflow_schema.json
+  - subworkflows/**
+  - tests/test_skip_markduplicates.yml
+  - workflows/**
+
 # preprocessing
 
 ## alignment_to_fastq

--- a/tests/csv/3.0/sample_with_space.csv
+++ b/tests/csv/3.0/sample_with_space.csv
@@ -1,0 +1,3 @@
+patient,sex,status,sample,lane,fastq_1,fastq_2
+test,XX,0,test,test_L1,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/illumina/fastq/test_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/illumina/fastq/test_2.fastq.gz
+test,XX,1,test 2,test_L1,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/illumina/fastq/test2_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/illumina/fastq/test2_2.fastq.gz

--- a/tests/test_samplesheet_validation_spaces.yml
+++ b/tests/test_samplesheet_validation_spaces.yml
@@ -1,0 +1,8 @@
+- name: Test that pipeline fail when sample/patient name contain space
+  command: nextflow run main.nf -profile test --input ./tests/csv/3.0/sample_with_space.csv --outdir results
+  tags:
+    - sample_with_space
+  exit_code: 1
+  stdout:
+    contains:
+      - "Invalid value in csv file. Values for 'patient' and 'sample' can not contain space"

--- a/tests/test_samplesheet_validation_spaces.yml
+++ b/tests/test_samplesheet_validation_spaces.yml
@@ -2,6 +2,7 @@
   command: nextflow run main.nf -profile test --input ./tests/csv/3.0/sample_with_space.csv --outdir results
   tags:
     - sample_with_space
+    - validation_checks
   exit_code: 1
   stdout:
     contains:

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -1149,6 +1149,10 @@ def extract_csv(csv_file) {
                 log.error "Missing field in csv file header. The csv file must have fields named 'patient' and 'sample'."
                 System.exit(1)
             }
+            else if (row.patient.contains(" ") || row.sample.contains(" ")) {
+                log.error "Invalid value in csv file. Values for 'patient' and 'sample' can not contain space."
+                System.exit(1)
+            }
             [ [ row.patient.toString(), row.sample.toString() ], row ]
         }.groupTuple()
         .map{ meta, rows ->


### PR DESCRIPTION
This fixes #950 

Note that the pipeline is terminated using System.exit() which isn't recommended (https://github.com/nf-core/tools/issues/1840). But I leave that for another PR since it has to be changed in multiple places.

Tested successfully (locally) with: 
```
TMPDIR=~ PROFILE=docker pytest --tag sample_with_space  --symlink --kwdof --git-aware --color=yes
```

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
