### PR TITLE
Fix input channels for variantrecalibrator

### DIFF
--- a/subworkflows/local/bam_joint_calling_germline_gatk/main.nf
+++ b/subworkflows/local/bam_joint_calling_germline_gatk/main.nf
@@ -56,8 +56,8 @@ workflow BAM_JOINT_CALLING_GERMLINE_GATK {
     MERGE_GENOTYPEGVCFS(gvcf_to_merge, dict.map{ it -> [ [ id:'dict' ], it ] } )
 
     vqsr_input = MERGE_GENOTYPEGVCFS.out.vcf.join(MERGE_GENOTYPEGVCFS.out.tbi, failOnDuplicate: true)
-    indels_resource_label = known_indels_vqsr.mix(dbsnp_vqsr).collect()
-    snps_resource_label = known_snps_vqsr.mix(dbsnp_vqsr).collect()
+    snps_resource_label = [known_snps_vqsr, dbsnp_vqsr]
+    indels_resource_label = [known_indels_vqsr, dbsnp_vqsr]
 
     // Recalibrate INDELs and SNPs separately
     VARIANTRECALIBRATOR_INDEL(


### PR DESCRIPTION
Fix input channels for variantrecalibrator in the joint-germline workflow.

There is currently no pytest testing that this works. I tested it manually with downsampled versions of the giab-samples HG002 and HG003.
 

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
