### PR TITLE
FIX: VCFTOOLS public ecr registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1043](https://github.com/nf-core/sarek/pull/1043) - Fix typo in the tags.yml files from [#978](https://github.com/nf-core/sarek/pull/978)
 - [#1048](https://github.com/nf-core/sarek/pull/1048) - Skip tool validation on annotation to fix [#949](https://github.com/nf-core/sarek/issues/949), check that bam is bam and cram is cram [#895](https://github.com/nf-core/sarek/issues/895)
 - [#1050](https://github.com/nf-core/sarek/pull/1050) - Disable GATK VCF filters when joint calling to fix [#1025](https://github.com/nf-core/sarek/issues/1025)
+- [#1058](https://github.com/nf-core/sarek/pull/1058) - Fix container declaration for VCFTOOLS as it has been updated in the registry
 
 ### Removed
 

--- a/conf/public_aws_ecr.config
+++ b/conf/public_aws_ecr.config
@@ -54,7 +54,4 @@ process {
     withName: 'UNZIP' {
         container = 'quay.io/biocontainers/p7zip:16.02'
     }
-    withName: 'VCFTOOLS' {
-        container = 'public.ecr.aws/biocontainers/vcftools:0.1.16--pl5321hd03093a_7'
-    }
 }


### PR DESCRIPTION
No need to revert to an older version anymore