### PR TITLE
FIX: join duplication for manta/strelka annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Bierikjávrre is one of the largest lake in Sarek.
 - [#1055](https://github.com/nf-core/sarek/pull/1055) - Fix pattern for fasta file in the json schema
 - [#1058](https://github.com/nf-core/sarek/pull/1058) - Fix container declaration for VCFTOOLS as it has been updated in the registry
 - [#1062](https://github.com/nf-core/sarek/pull/1062) - Fix automatic restart from steps
+- [#1063](https://github.com/nf-core/sarek/pull/1063) - Fix join duplication for manta/strelka
 
 ### Removed
 

--- a/subworkflows/local/bam_variant_calling_single_strelka/main.nf
+++ b/subworkflows/local/bam_variant_calling_single_strelka/main.nf
@@ -42,7 +42,7 @@ workflow BAM_VARIANT_CALLING_SINGLE_STRELKA {
     MERGE_STRELKA_GENOME(genome_vcf_to_merge, dict)
 
     // Mix intervals and no_intervals channels together
-    // Only strelka variant vcf SV should get annotated
+    // Only strelka variant vcf should get annotated
     vcf = Channel.empty().mix(MERGE_STRELKA.out.vcf, vcf.no_intervals)
         // add variantcaller to meta map and remove no longer necessary field: num_intervals
         .map{ meta, vcf -> [ meta - meta.subMap('num_intervals') + [ variantcaller:'strelka' ], vcf ] }

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -1040,7 +1040,7 @@ workflow SAREK {
             vep_fasta = (params.vep_include_fasta) ? fasta.map{ fasta -> [ [ id:fasta.baseName ], fasta ] } : [[], []]
 
             VCF_ANNOTATE_ALL(
-                vcf_to_annotate,
+                vcf_to_annotate.map{meta, vcf -> [ meta + [ file_name: vcf.baseName ], vcf ] },
                 vep_fasta,
                 params.tools,
                 params.snpeff_genome ? "${params.snpeff_genome}.${params.snpeff_db}" : "${params.genome}.${params.snpeff_db}",


### PR DESCRIPTION
Added a unique key based on filename since these tools are producing multiple files we annotate