### PR TITLE
Fixing names of published dedup-related files

### DIFF
--- a/conf/modules/markduplicates.config
+++ b/conf/modules/markduplicates.config
@@ -107,7 +107,7 @@ process {
             publishDir       = [
                 enabled: params.save_output_as_bam,
                 mode: params.publish_dir_mode,
-                path: { "${params.outdir}/preprocessing/sentieno_dedup/${meta.id}/" },
+                path: { "${params.outdir}/preprocessing/sentieon_dedup/${meta.id}/" },
                 pattern: "*{dedup.bam,dedup.bam.bai}"
             ]
         } else {

--- a/conf/modules/markduplicates.config
+++ b/conf/modules/markduplicates.config
@@ -100,15 +100,24 @@ process {
         ]
     }
 
-
     withName: 'NFCORE_SAREK:SAREK:CRAM_TO_BAM' {
-        ext.prefix       = { "${meta.id}.md" }
         ext.when         = { params.save_output_as_bam }
-        publishDir       = [
-            enabled: params.save_output_as_bam,
-            mode: params.publish_dir_mode,
-            path: { "${params.outdir}/preprocessing/markduplicates/${meta.id}/" },
-            pattern: "*{md.bam,md.bam.bai}"
-        ]
+        if (params.tools && params.tools.split(',').contains('sentieon_dedup')) {
+            ext.prefix       = { "${meta.id}.dedup" }
+            publishDir       = [
+                enabled: params.save_output_as_bam,
+                mode: params.publish_dir_mode,
+                path: { "${params.outdir}/preprocessing/sentieno_dedup/${meta.id}/" },
+                pattern: "*{dedup.bam,dedup.bam.bai}"
+            ]
+        } else {
+            ext.prefix       = { "${meta.id}.md" }
+            publishDir       = [
+                enabled: params.save_output_as_bam,
+                mode: params.publish_dir_mode,
+                path: { "${params.outdir}/preprocessing/markduplicates/${meta.id}/" },
+                pattern: "*{md.bam,md.bam.bai}"
+            ]
+        }
     }
 }

--- a/conf/modules/modules.config
+++ b/conf/modules/modules.config
@@ -40,9 +40,19 @@ process {
         ]
     }
 
-    withName: 'NFCORE_SAREK:SAREK:(BAM_MARKDUPLICATES|BAM_MARKDUPLICATES_SPARK|BAM_SENTIEON_DEDUP):CRAM_QC_MOSDEPTH_SAMTOOLS:SAMTOOLS_STATS' {
+    withName: 'NFCORE_SAREK:SAREK:(BAM_MARKDUPLICATES|BAM_MARKDUPLICATES_SPARK):CRAM_QC_MOSDEPTH_SAMTOOLS:SAMTOOLS_STATS' {
         ext.when         = { !(params.skip_tools && params.skip_tools.split(',').contains('samtools')) }
         ext.prefix       = { "${meta.id}.md.cram" }
+        publishDir       = [
+            mode: params.publish_dir_mode,
+            path: { "${params.outdir}/reports/samtools/${meta.id}" },
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'NFCORE_SAREK:SAREK:BAM_SENTIEON_DEDUP:CRAM_QC_MOSDEPTH_SAMTOOLS:SAMTOOLS_STATS' {
+        ext.when         = { !(params.skip_tools && params.skip_tools.split(',').contains('samtools')) }
+        ext.prefix       = { "${meta.id}.dedup.cram" }
         publishDir       = [
             mode: params.publish_dir_mode,
             path: { "${params.outdir}/reports/samtools/${meta.id}" },
@@ -62,7 +72,15 @@ process {
 
     withName: 'MOSDEPTH' {
         ext.args = { !params.wes ? "-n --fast-mode --by 500" : ""}
-        ext.prefix       = { params.skip_tools && params.skip_tools.split(',').contains('markduplicates') ? "${meta.id}.sorted" : "${meta.id}.md" }
+        ext.prefix       = {
+            if (params.tools && params.tools.split(',').contains('sentieon_dedup')) {
+                "${meta.id}.dedup"
+            } else if (params.skip_tools && params.skip_tools.split(',').contains('markduplicates')) {
+                "${meta.id}.sorted"
+            } else {
+                "${meta.id}.md"
+            }
+        }
         ext.when         = { !(params.skip_tools && params.skip_tools.split(',').contains('mosdepth')) }
         publishDir = [
             mode: params.publish_dir_mode,

--- a/conf/modules/sentieon_dedup.config
+++ b/conf/modules/sentieon_dedup.config
@@ -16,7 +16,7 @@
 process {
 
     withName: 'SENTIEON_DEDUP' {
-        ext.prefix       = { "${meta.id}.md" }
+        ext.prefix       = { "${meta.id}.dedup" }
         ext.when         = { params.tools && params.tools.split(',').contains('sentieon_dedup') }
         publishDir       = [
             [

--- a/tests/test_sentieon_dedup_from_bam.yml
+++ b/tests/test_sentieon_dedup_from_bam.yml
@@ -7,17 +7,17 @@
     - sentieon/dedup
   files:
     - path: results/csv/markduplicates.csv
-      md5sum: 00272d06fc1bc6a5aceb3ff8cf1bcc00
+      md5sum: b06889d5be3ec1be6f5dd278ccc8f28e
     - path: results/csv/markduplicates_no_table.csv
-      md5sum: 901ee046403f4e44ff592ee68b79afb3
+      md5sum: 49661e56662d74f3a3db269387cbd9bf
     - path: results/csv/recalibrated.csv
       md5sum: 1888a924bc70bd80165a96ad641e22d6
     - path: results/multiqc
     - path: results/multiqc/multiqc_report.html
       contains: ["Sentieon Dedup Metrics", "PERCENT_DUPLICATION", "ESTIMATED_LIBRARY_SIZE"]
-    - path: results/preprocessing/sentieon_dedup/test/test.md.cram
+    - path: results/preprocessing/sentieon_dedup/test/test.dedup.cram
     # binary changes md5sums on reruns
-    - path: results/preprocessing/sentieon_dedup/test/test.md.cram.crai
+    - path: results/preprocessing/sentieon_dedup/test/test.dedup.cram.crai
     # binary changes md5sums on reruns
     - path: results/preprocessing/recal_table/test/test.recal.table
       md5sum: 9603b69fdc3b5090de2e0dd78bfcc4bf
@@ -25,17 +25,17 @@
     # binary changes md5sums on reruns
     - path: results/preprocessing/recalibrated/test/test.recal.cram.crai
     # binary changes md5sums on reruns
-    - path: results/reports/sentieon_dedup/test/test.md.cram.metrics
+    - path: results/reports/sentieon_dedup/test/test.dedup.cram.metrics
       contains: ["testN	0	2820	2	2	0	828	0	0.293617	3807", "1.0	0.999986", "100.0	1.911145"]
-    - path: results/reports/mosdepth/test/test.md.mosdepth.global.dist.txt
+    - path: results/reports/mosdepth/test/test.dedup.mosdepth.global.dist.txt
       md5sum: 8e875e20e3fb9cf288d68c1d223f6fd5
-    - path: results/reports/mosdepth/test/test.md.mosdepth.region.dist.txt
+    - path: results/reports/mosdepth/test/test.dedup.mosdepth.region.dist.txt
       md5sum: 75e1ce7e55af51f4985fa91654a5ea2d
-    - path: results/reports/mosdepth/test/test.md.mosdepth.summary.txt
+    - path: results/reports/mosdepth/test/test.dedup.mosdepth.summary.txt
       md5sum: b23cf96942b2ada3f41172a9349a1175
-    - path: results/reports/mosdepth/test/test.md.regions.bed.gz
+    - path: results/reports/mosdepth/test/test.dedup.regions.bed.gz
     # binary changes md5sums on reruns
-    - path: results/reports/mosdepth/test/test.md.regions.bed.gz.csi
+    - path: results/reports/mosdepth/test/test.dedup.regions.bed.gz.csi
     # binary changes md5sums on reruns
     - path: results/reports/mosdepth/test/test.recal.mosdepth.global.dist.txt
       md5sum: 8e875e20e3fb9cf288d68c1d223f6fd5
@@ -47,7 +47,7 @@
     # binary changes md5sums on reruns
     - path: results/reports/mosdepth/test/test.recal.regions.bed.gz.csi
     # binary changes md5sums on reruns
-    - path: results/reports/samtools/test/test.md.cram.stats
+    - path: results/reports/samtools/test/test.dedup.cram.stats
     # conda changes md5sums for test
     - path: results/reports/samtools/test/test.recal.cram.stats
     # conda changes md5sums for test

--- a/tests/test_sentieon_dedup_from_cram.yml
+++ b/tests/test_sentieon_dedup_from_cram.yml
@@ -7,17 +7,17 @@
     - sentieon/dedup
   files:
     - path: results/csv/markduplicates.csv
-      md5sum: 00272d06fc1bc6a5aceb3ff8cf1bcc00
+      md5sum: b06889d5be3ec1be6f5dd278ccc8f28e
     - path: results/csv/markduplicates_no_table.csv
-      md5sum: 901ee046403f4e44ff592ee68b79afb3
+      md5sum: 49661e56662d74f3a3db269387cbd9bf
     - path: results/csv/recalibrated.csv
       md5sum: 1888a924bc70bd80165a96ad641e22d6
     - path: results/multiqc
     - path: results/multiqc/multiqc_report.html
       contains: ["Sentieon Dedup Metrics", "PERCENT_DUPLICATION", "ESTIMATED_LIBRARY_SIZE"]
-    - path: results/preprocessing/sentieon_dedup/test/test.md.cram
+    - path: results/preprocessing/sentieon_dedup/test/test.dedup.cram
     # binary changes md5sums on reruns
-    - path: results/preprocessing/sentieon_dedup/test/test.md.cram.crai
+    - path: results/preprocessing/sentieon_dedup/test/test.dedup.cram.crai
     # binary changes md5sums on reruns
     - path: results/preprocessing/recal_table/test/test.recal.table
       md5sum: 9603b69fdc3b5090de2e0dd78bfcc4bf
@@ -25,17 +25,17 @@
     # binary changes md5sums on reruns
     - path: results/preprocessing/recalibrated/test/test.recal.cram.crai
     # binary changes md5sums on reruns
-    - path: results/reports/sentieon_dedup/test/test.md.cram.metrics
+    - path: results/reports/sentieon_dedup/test/test.dedup.cram.metrics
       contains: ["testN	0	2820	2	2	0	828	0	0.293617	3807", "1.0	0.999986", "2.0	1.476740", "3.0	1.704038"]
-    - path: results/reports/mosdepth/test/test.md.mosdepth.global.dist.txt
+    - path: results/reports/mosdepth/test/test.dedup.mosdepth.global.dist.txt
       md5sum: 8e875e20e3fb9cf288d68c1d223f6fd5
-    - path: results/reports/mosdepth/test/test.md.mosdepth.region.dist.txt
+    - path: results/reports/mosdepth/test/test.dedup.mosdepth.region.dist.txt
       md5sum: 75e1ce7e55af51f4985fa91654a5ea2d
-    - path: results/reports/mosdepth/test/test.md.mosdepth.summary.txt
+    - path: results/reports/mosdepth/test/test.dedup.mosdepth.summary.txt
       md5sum: b23cf96942b2ada3f41172a9349a1175
-    - path: results/reports/mosdepth/test/test.md.regions.bed.gz
+    - path: results/reports/mosdepth/test/test.dedup.regions.bed.gz
     # binary changes md5sums on reruns
-    - path: results/reports/mosdepth/test/test.md.regions.bed.gz.csi
+    - path: results/reports/mosdepth/test/test.dedup.regions.bed.gz.csi
     # binary changes md5sums on reruns
     - path: results/reports/mosdepth/test/test.recal.mosdepth.global.dist.txt
       md5sum: 8e875e20e3fb9cf288d68c1d223f6fd5
@@ -47,7 +47,7 @@
     # binary changes md5sums on reruns
     - path: results/reports/mosdepth/test/test.recal.regions.bed.gz.csi
     # binary changes md5sums on reruns
-    - path: results/reports/samtools/test/test.md.cram.stats
+    - path: results/reports/samtools/test/test.dedup.cram.stats
     # conda changes md5sums for test
     - path: results/reports/samtools/test/test.recal.cram.stats
     # conda changes md5sums for test


### PR DESCRIPTION
Replacing the substring `.md.` with `.dedup.` in the names of the dedup-related output-files