### PR TITLE
Fix join mismatch error for joint tumor only Mutect2

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -70,18 +70,9 @@ process {
         }
     }
 
-    if (params.joint_mutect2) {
-        withName: 'MUTECT2_PAIRED' {
-            ext.args         = { params.ignore_soft_clipped_bases ?
-                                    "--dont-use-soft-clipped-bases true --f1r2-tar-gz ${task.ext.prefix}.f1r2.tar.gz --normal-sample ${meta.normal_id}" :
-                                    "--f1r2-tar-gz ${task.ext.prefix}.f1r2.tar.gz --normal-sample ${meta.normal_id}" }
-        }
-    }
-    else {
-        withName: 'MUTECT2_PAIRED'{
-            //sample name from when the test data was generated
-            ext.args = { "--f1r2-tar-gz ${task.ext.prefix}.f1r2.tar.gz --normal-sample normal " }
-        }
+    withName: '.*:MUTECT2_PAIRED'{
+        //sample name from when the test data was generated
+        ext.args = { "--f1r2-tar-gz ${task.ext.prefix}.f1r2.tar.gz --normal-sample normal " }
     }
 
     withName: 'FILTERVARIANTTRANCHES'{

--- a/conf/test/cache.config
+++ b/conf/test/cache.config
@@ -87,7 +87,7 @@ process {
         }
     }
 
-    withName: 'MUTECT2_PAIRED'{
+    withName: '.*:MUTECT2_PAIRED'{
         //sample name from when the test data was generated
         ext.args = { "--f1r2-tar-gz ${task.ext.prefix}.f1r2.tar.gz --normal-sample normal " }
     }

--- a/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
@@ -161,6 +161,13 @@ workflow BAM_VARIANT_CALLING_SOMATIC_MUTECT2 {
         ch_cont_to_filtermutectcalls = CALCULATECONTAMINATION.out.contamination
     }
 
+    // vcf.view(it -> ["vcfs", it])
+    // tbi.view(it -> ["tbis", it])
+    // stats.view(it -> ["stats", it])
+    // LEARNREADORIENTATIONMODEL.out.artifactprior.view(it -> ["priors", it])
+    // ch_seg_to_filtermutectcalls.view(it -> ["segs", it])
+    // ch_cont_to_filtermutectcalls.view(it -> ["conts", it])
+
     // Mutect2 calls filtered by filtermutectcalls using the artifactpriors, contamination and segmentation tables
     vcf_to_filter = vcf.join(tbi, failOnDuplicate: true, failOnMismatch: true)
         .join(stats, failOnDuplicate: true, failOnMismatch: true)

--- a/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
@@ -161,13 +161,6 @@ workflow BAM_VARIANT_CALLING_SOMATIC_MUTECT2 {
         ch_cont_to_filtermutectcalls = CALCULATECONTAMINATION.out.contamination
     }
 
-    // vcf.view(it -> ["vcfs", it])
-    // tbi.view(it -> ["tbis", it])
-    // stats.view(it -> ["stats", it])
-    // LEARNREADORIENTATIONMODEL.out.artifactprior.view(it -> ["priors", it])
-    // ch_seg_to_filtermutectcalls.view(it -> ["segs", it])
-    // ch_cont_to_filtermutectcalls.view(it -> ["conts", it])
-
     // Mutect2 calls filtered by filtermutectcalls using the artifactpriors, contamination and segmentation tables
     vcf_to_filter = vcf.join(tbi, failOnDuplicate: true, failOnMismatch: true)
         .join(stats, failOnDuplicate: true, failOnMismatch: true)


### PR DESCRIPTION
Fixes the sporadic `Join mismatch` [error](https://github.com/nextflow-io/nextflow/issues/3939) by removing unnecessary metadata in tumor only mutect2 subworkflow.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
