### PR TITLE
Change vep_version to vep_cache_version in ENSEMBLVEP_VEP-config

### DIFF
--- a/conf/modules/annotate.config
+++ b/conf/modules/annotate.config
@@ -35,12 +35,12 @@ process {
     if (params.tools && (params.tools.split(',').contains('vep') || params.tools.split(',').contains('merge'))) {
         withName: 'ENSEMBLVEP_VEP' {
             ext.args         = { [
-                (params.vep_dbnsfp && params.dbnsfp && !params.dbnsfp_consequence)    ? "--plugin dbNSFP,${params.dbnsfp.split("/")[-1]},${params.dbnsfp_fields}"                                              : '',
-                (params.vep_dbnsfp && params.dbnsfp && params.dbnsfp_consequence)     ? "--plugin dbNSFP,'consequence=${params.dbnsfp_consequence}',${params.dbnsfp.split("/")[-1]},${params.dbnsfp_fields}"   : '',
-                (params.vep_loftee)                                                   ? "--plugin LoF,loftee_path:/opt/conda/envs/nf-core-vep-${params.vep_version}/share/ensembl-vep-${params.vep_version}-0" : '',
-                (params.vep_spliceai && params.spliceai_snv && params.spliceai_indel) ? "--plugin SpliceAI,snv=${params.spliceai_snv.split("/")[-1]},indel=${params.spliceai_indel.split("/")[-1]}"            : '',
-                (params.vep_spliceregion)                                             ? '--plugin SpliceRegion'                                                                                                : '',
-                (params.vep_out_format)                                               ? "--${params.vep_out_format}"                                                                                           : '--vcf',
+                (params.vep_dbnsfp && params.dbnsfp && !params.dbnsfp_consequence)    ? "--plugin dbNSFP,${params.dbnsfp.split("/")[-1]},${params.dbnsfp_fields}"                                                          : '',
+                (params.vep_dbnsfp && params.dbnsfp && params.dbnsfp_consequence)     ? "--plugin dbNSFP,'consequence=${params.dbnsfp_consequence}',${params.dbnsfp.split("/")[-1]},${params.dbnsfp_fields}"               : '',
+                (params.vep_loftee)                                                   ? "--plugin LoF,loftee_path:/opt/conda/envs/nf-core-vep-${params.vep_cache_version}/share/ensembl-vep-${params.vep_cache_version}-0" : '',
+                (params.vep_spliceai && params.spliceai_snv && params.spliceai_indel) ? "--plugin SpliceAI,snv=${params.spliceai_snv.split("/")[-1]},indel=${params.spliceai_indel.split("/")[-1]}"                        : '',
+                (params.vep_spliceregion)                                             ? '--plugin SpliceRegion'                                                                                                            : '',
+                (params.vep_out_format)                                               ? "--${params.vep_out_format}"                                                                                                       : '--vcf',
                 (params.vep_custom_args)                                              ?: ''
             ].join(' ').trim() }
             // If just VEP: <vcf prefix>_VEP.ann.vcf


### PR DESCRIPTION
Just changing `params.vep_version` to `params.vep_cache_version` in config of `ENSEMBLVEP_VEP` since `params.vep_version` is depricated.

TO-DO: Update changelog ;-) 

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
