### PR TITLE
Make -a a default argument for bcftools concat

### DIFF
--- a/conf/modules/post_variant_calling.config
+++ b/conf/modules/post_variant_calling.config
@@ -17,6 +17,7 @@
 process {
 
     withName: 'GERMLINE_VCFS_CONCAT'{
+        ext.args   = { "-a" }
         ext.when   = { params.concatenate_vcfs }
         publishDir = [
             //specify to avoid publishing, overwritten otherwise


### PR DESCRIPTION
I am running Sarek 3.4 for the first time, so maybe this is a classical example of  "_Just because you can do it with the pipeline, doesn't mean you should_" 😉, but I found that the `bfctools concat` typically errors out for the samples, when trying to merge the germline vcf-files from each applied variant-caller (`concatenate_vcfs : 'true'`).

```
Error executing process > 'NFCORE_SAREK:SAREK:POST_VARIANTCALLING:CONCATENATE_GERMLINE_VCFS:GERMLINE_VCFS_CONCAT (sample)'

Caused by:
  Process `NFCORE_SAREK:SAREK:POST_VARIANTCALLING:CONCATENATE_GERMLINE_VCFS:GERMLINE_VCFS_CONCAT (sample)` terminated with an error exit status (255)

Command executed:

  bcftools concat \
      --output sample.vcf.gz \
       \
      --threads 1 \
      sample.strelka.variants.added_info.vcf.gz sample.manta.diploid_sv.added_info.vcf.gz sample.freebayes.added_info.vcf.gz sample.tiddit.added_info.vcf.gz
  
  cat <<-END_VERSIONS > versions.yml
  "NFCORE_SAREK:SAREK:POST_VARIANTCALLING:CONCATENATE_GERMLINE_VCFS:GERMLINE_VCFS_CONCAT":
      bcftools: $(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*$//')
  END_VERSIONS

Command exit status:
  255

Command output:
  (empty)

Command error:
  Checking the headers and starting positions of 4 files
  [W::bcf_hdr_merge] Trying to combine "FT" tag definitions of different lengths
  Concatenating sample.strelka.variants.added_info.vcf.gz	14.703256 seconds
  Concatenating sample.manta.diploid_sv.added_info.vcf.gz
  The chromosome block chr1 is not contiguous, consider running with -a.

```
I looked up the effects of the `-a / --alow-overlaps` parameter and to me, it [seems there is no harm being done by making it the default](https://samtools.github.io/bcftools/bcftools.html#concat) (unless maybe the performance?)  

Therefore, I propose that this option becomes the default, or maybe even `-a -D` ? Since the latter is however more intrusive, that change might be over the top. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
