### PR TITLE
Using modules_testdata_base_path instead of test_data in nf-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,6 @@ jobs:
         exclude:
           - tags: "bwamem2/mem"
           - tags: "custom/dumpsoftwareversions"
-          - tags: "dragmap/align"
           - tags: "fastp"
           - tags: "fastqc"
           - tags: "gatk4/applybqsr"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
           - "23.04.0"
           - "latest-everything"
         exclude:
-          - tags: "bwa/index
+          - tags: "bwa/index"
           - tags: "bwamem2/mem"
           - tags: "cat/cat"
           - tags: "cat/fastq"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,6 @@ jobs:
           - "latest-everything"
         exclude:
           - tags: "bwamem2/mem"
-          - tags: "cat/cat"
           - tags: "cat/fastq"
           - tags: "custom/dumpsoftwareversions"
           - tags: "dragmap/align"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,6 @@ jobs:
           - tags: "custom/dumpsoftwareversions"
           - tags: "fastp"
           - tags: "fastqc"
-          - tags: "gatk4/applybqsr"
           - tags: "gatk4/baserecalibrator"
           - tags: "gatk4/genomicsdbimport"
           - tags: "gatk4/haplotypecaller"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,6 @@ jobs:
           - tags: "custom/dumpsoftwareversions"
           - tags: "fastp"
           - tags: "fastqc"
-          - tags: "gatk4/baserecalibrator"
           - tags: "gatk4/genomicsdbimport"
           - tags: "gatk4/haplotypecaller"
           - tags: "gatk4/markduplicates"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,6 @@ jobs:
           - "latest-everything"
         exclude:
           - tags: "bwamem2/mem"
-          - tags: "cat/fastq"
           - tags: "custom/dumpsoftwareversions"
           - tags: "dragmap/align"
           - tags: "fastp"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,7 @@ jobs:
           - "23.04.0"
           - "latest-everything"
         exclude:
-          - tags: "bwa/index"
-          - tags: "bwa/mem"
+          - tags: "bwa/index
           - tags: "bwamem2/mem"
           - tags: "cat/cat"
           - tags: "cat/fastq"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,6 @@ jobs:
           - "23.04.0"
           - "latest-everything"
         exclude:
-          - tags: "bwa/index"
           - tags: "bwamem2/mem"
           - tags: "cat/cat"
           - tags: "cat/fastq"

--- a/modules/nf-core/bwa/index/tests/main.nf.test
+++ b/modules/nf-core/bwa/index/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
                 """
             }
@@ -29,5 +29,5 @@ nextflow_process {
         }
 
     }
-    
+
 }

--- a/modules/nf-core/bwa/mem/tests/main.nf.test
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test
@@ -18,7 +18,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id: 'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -31,7 +31,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:true ], // meta map
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = BWA_INDEX.out.index
@@ -58,7 +58,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id: 'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -152,8 +152,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = BWA_INDEX.out.index

--- a/modules/nf-core/bwa/mem/tests/main.nf.test
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test
@@ -71,7 +71,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:true ], // meta map
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = BWA_INDEX.out.index
@@ -98,7 +98,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id: 'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -111,8 +111,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = BWA_INDEX.out.index
@@ -139,7 +139,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id: 'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }

--- a/modules/nf-core/cat/cat/tests/main.nf.test
+++ b/modules/nf-core/cat/cat/tests/main.nf.test
@@ -19,8 +19,8 @@ nextflow_process {
                     [
                         [ id:'test', single_end:true ],
                         [
-                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
-                            file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.sizes', checkIfExists: true)
                         ]
                     ]
                 """
@@ -46,8 +46,8 @@ nextflow_process {
                     [
                         [ id:'test', single_end:true ],
                         [
-                            file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
-                            file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
                         ]
                     ]
                 """
@@ -76,8 +76,8 @@ nextflow_process {
                     [
                         [ id:'test', single_end:true ],
                         [
-                            file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
-                            file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
                         ]
                     ]
                 """
@@ -105,8 +105,8 @@ nextflow_process {
                     [
                         [ id:'test', single_end:true ],
                         [
-                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
-                            file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.sizes', checkIfExists: true)
                         ]
                     ]
                 """
@@ -134,7 +134,7 @@ nextflow_process {
                     [
                         [ id:'test', single_end:true ],
                         [
-                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                         ]
                     ]
                 """
@@ -150,4 +150,3 @@ nextflow_process {
         }
     }
 }
-

--- a/modules/nf-core/cat/fastq/tests/main.nf.test
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test
@@ -18,8 +18,8 @@ nextflow_process {
                 """
                 input[0] = [
                             [ id:'test', single_end:true ], // meta map
-                            [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                            file(params.test_data['sarscov2']['illumina']['test2_1_fastq_gz'], checkIfExists: true) ]
+                            [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true) ]
                         ]
                 """
             }
@@ -44,10 +44,10 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test2_1_fastq_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test2_2_fastq_gz'], checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_2.fastq.gz', checkIfExists: true) ]
                 ]
                 """
             }
@@ -72,8 +72,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ]
                 """
             }
@@ -98,10 +98,10 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
                 ]
                 """
             }
@@ -126,7 +126,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
                 ]
                 """
             }

--- a/modules/nf-core/dragmap/align/tests/main.nf.test
+++ b/modules/nf-core/dragmap/align/tests/main.nf.test
@@ -17,7 +17,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id:'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -29,7 +29,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:true ], // meta map
-                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                 ]
                 input[1] = DRAGMAP_HASHTABLE.out.hashmap
                 input[2] = false //sort
@@ -59,7 +59,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id:'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -71,7 +71,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:true ], // meta map
-                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                 ]
                 input[1] = DRAGMAP_HASHTABLE.out.hashmap
                 input[2] = true //sort
@@ -101,7 +101,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id:'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -114,8 +114,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = DRAGMAP_HASHTABLE.out.hashmap
@@ -146,7 +146,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id:'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -159,8 +159,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = DRAGMAP_HASHTABLE.out.hashmap
@@ -191,7 +191,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id:'test'],
-                        file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -204,8 +204,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = DRAGMAP_HASHTABLE.out.hashmap
@@ -237,7 +237,7 @@ nextflow_process {
                     """
                     input[0] = [
                         [id:'test'],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -250,8 +250,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = DRAGMAP_HASHTABLE.out.hashmap

--- a/modules/nf-core/gatk4/applybqsr/tests/main.nf.test
+++ b/modules/nf-core/gatk4/applybqsr/tests/main.nf.test
@@ -16,14 +16,14 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/gatk/test.baserecalibrator.table', checkIfExists: true),
                     []
                 ]
-                input[1] = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-                input[2] = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
-                input[3] = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.dict', checkIfExists: true)
                 """
             }
         }
@@ -44,14 +44,14 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/gatk/test.baserecalibrator.table', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                 ]
-                input[1] = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-                input[2] = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
-                input[3] = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.dict', checkIfExists: true)
                 """
             }
         }
@@ -71,14 +71,14 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
-                    file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true),
-                    file(params.test_data['homo_sapiens']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
-                    file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/test.baserecalibrator.table', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
                 ]
-                input[1] = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
-                input[2] = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
-                input[3] = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
+                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
                 """
             }
         }

--- a/modules/nf-core/gatk4/applybqsr/tests/main.nf.test.snap
+++ b/modules/nf-core/gatk4/applybqsr/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.bam:md5,096d269e17f4ae53f765013479240db8"
+                        "test.recal.bam:md5,2dcc50c3dd8bfbb5dc02bd362d9ddca3"
                     ]
                 ],
                 "1": [
@@ -21,7 +21,7 @@
                         {
                             "id": "test"
                         },
-                        "test.bam:md5,096d269e17f4ae53f765013479240db8"
+                        "test.recal.bam:md5,2dcc50c3dd8bfbb5dc02bd362d9ddca3"
                     ]
                 ],
                 "cram": [
@@ -34,9 +34,9 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-02-13T16:21:48.144461"
+        "timestamp": "2024-02-24T21:46:13.440473512"
     },
     "sarscov2 - cram": {
         "content": [
@@ -52,13 +52,13 @@
     },
     "test.cram": {
         "content": [
-            "test.cram"
+            "test.recal.cram"
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2023-12-09T03:10:46.70859771"
+        "timestamp": "2024-02-24T21:46:28.711851595"
     },
     "sarscov2 - bam": {
         "content": [
@@ -68,7 +68,7 @@
                         {
                             "id": "test"
                         },
-                        "test.bam:md5,022271b9ce0a07579282a2a5c1186513"
+                        "test.recal.bam:md5,93fee40ff233e2d22e3379e253c423cf"
                     ]
                 ],
                 "1": [
@@ -82,7 +82,7 @@
                         {
                             "id": "test"
                         },
-                        "test.bam:md5,022271b9ce0a07579282a2a5c1186513"
+                        "test.recal.bam:md5,93fee40ff233e2d22e3379e253c423cf"
                     ]
                 ],
                 "cram": [
@@ -95,8 +95,8 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-02-13T16:21:28.719225"
+        "timestamp": "2024-02-24T21:45:58.992053831"
     }
 }

--- a/modules/nf-core/gatk4/baserecalibrator/tests/main.nf.test
+++ b/modules/nf-core/gatk4/baserecalibrator/tests/main.nf.test
@@ -15,15 +15,15 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
                     []
                 ]
-                input[1] = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-                input[2] = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
-                input[3] = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
-                input[4] = file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true)
-                input[5] = file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true)
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.dict', checkIfExists: true)
+                input[4] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true)
+                input[5] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
 
                 """
             }
@@ -45,15 +45,15 @@ nextflow_process {
 
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                 ]
-                input[1] = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-                input[2] = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
-                input[3] = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
-                input[4] = file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true)
-                input[5] = file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true)
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.dict', checkIfExists: true)
+                input[4] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true)
+                input[5] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
 
                 """
             }
@@ -75,20 +75,20 @@ nextflow_process {
 
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
                     []
                 ]
-                input[1] = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-                input[2] = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
-                input[3] = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.dict', checkIfExists: true)
                 input[4] = [
-                    file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test2_vcf_gz'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true)
                 ]
                 input[5] = [
-                    file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test2_vcf_gz_tbi'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true)
                 ]
 
                 """
@@ -141,15 +141,15 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
-                    file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
                     []
                 ]
-                input[1] = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
-                input[2] = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
-                input[3] = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
-                input[4] = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz'], checkIfExists: true)
-                input[5] = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz_tbi'], checkIfExists: true)
+                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
+                input[4] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz', checkIfExists: true)
+                input[5] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz.tbi', checkIfExists: true)
                 """
             }
         }

--- a/modules/nf-core/gatk4/baserecalibrator/tests/main.nf.test.snap
+++ b/modules/nf-core/gatk4/baserecalibrator/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.recal.table:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -18,7 +18,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.recal.table:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -28,9 +28,9 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-02-13T16:16:00.04396"
+        "timestamp": "2024-02-26T07:59:09.802474612"
     },
     "sarscov2 - bam - intervals": {
         "content": [
@@ -40,7 +40,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,9ecb5f00a2229291705addc09c0ec231"
+                        "test.recal.table:md5,9ecb5f00a2229291705addc09c0ec231"
                     ]
                 ],
                 "1": [
@@ -51,7 +51,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,9ecb5f00a2229291705addc09c0ec231"
+                        "test.recal.table:md5,9ecb5f00a2229291705addc09c0ec231"
                     ]
                 ],
                 "versions": [
@@ -61,9 +61,9 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-02-13T16:15:17.899391"
+        "timestamp": "2024-02-26T07:58:46.088383653"
     },
     "sarscov2 - bam - multiple sites": {
         "content": [
@@ -73,7 +73,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
+                        "test.recal.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
                     ]
                 ],
                 "1": [
@@ -84,7 +84,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
+                        "test.recal.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
                     ]
                 ],
                 "versions": [
@@ -94,9 +94,9 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-02-13T16:15:47.770383"
+        "timestamp": "2024-02-26T07:59:00.753963509"
     },
     "homo_sapiens - cram ": {
         "content": [
@@ -106,7 +106,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,35d89a3811aa31711fc9815b6b80e6ec"
+                        "test.recal.table:md5,35d89a3811aa31711fc9815b6b80e6ec"
                     ]
                 ],
                 "1": [
@@ -117,7 +117,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,35d89a3811aa31711fc9815b6b80e6ec"
+                        "test.recal.table:md5,35d89a3811aa31711fc9815b6b80e6ec"
                     ]
                 ],
                 "versions": [
@@ -127,9 +127,9 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-02-13T16:16:42.135898"
+        "timestamp": "2024-02-26T07:59:25.266531501"
     },
     "sarscov2 - bam": {
         "content": [
@@ -139,7 +139,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
+                        "test.recal.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
                     ]
                 ],
                 "1": [
@@ -150,7 +150,7 @@
                         {
                             "id": "test"
                         },
-                        "test.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
+                        "test.recal.table:md5,e2e43abdc0c943c1a54dae816d0b9ea7"
                     ]
                 ],
                 "versions": [
@@ -160,8 +160,8 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-02-13T16:14:57.629443"
+        "timestamp": "2024-02-26T07:58:31.908467001"
     }
 }


### PR DESCRIPTION
In Sarek, the nf-tests of the installed modules can't run with params.test_data. (That is seemingly not a problem over in the modules-repo.) 

Here I replace params.test_data with params.modules_testdata_base_path. If this works out, then I'll put the updated nf-tests back in the modules-repo.

NOTE: I had to update the snapshots for certain tests.

`dragmap/aligner` fails with `java.lang.NullPointerException: Cannot invoke method getAt() on null object`.