### PR TITLE
Dummy PR : testing docker container options in GATK Spark modules

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -108,7 +108,7 @@ if (System.getenv('PROFILE')) {
     } else if ("$PROFILE" == "docker") {
         conda.enabled                            = false
         docker.enabled                           = true
-        docker.runOptions                        = { params.use_gatk_spark ? '' : '-u $(id -u):$(id -g)' }.call()
+        docker.runOptions                        = '-u $(id -u):$(id -g)'
         charliecloud.enabled                     = false
         podman.enabled                           = false
         shifter.enabled                          = false

--- a/conf/test/cache.config
+++ b/conf/test/cache.config
@@ -116,7 +116,7 @@ if (System.getenv('PROFILE')) {
     } else if ("$PROFILE" == "docker") {
         conda.enabled                            = false
         docker.enabled                           = true
-        docker.runOptions                        = { params.use_gatk_spark ? '' : '-u $(id -u):$(id -g)' }.call()
+        docker.runOptions                        = '-u $(id -u):$(id -g)'
         charliecloud.enabled                     = false
         podman.enabled                           = false
         shifter.enabled                          = false

--- a/conf/test/use_gatk_spark.config
+++ b/conf/test/use_gatk_spark.config
@@ -14,5 +14,3 @@ params {
     use_gatk_spark = 'baserecalibrator,markduplicates'
     input          = "${projectDir}/tests/csv/3.0/fastq_tumor_only.csv"
 }
-
-docker.runOptions      = ''

--- a/modules/nf-core/gatk4spark/applybqsr/main.nf
+++ b/modules/nf-core/gatk4spark/applybqsr/main.nf
@@ -7,6 +7,10 @@ process GATK4SPARK_APPLYBQSR {
         'https://depot.galaxyproject.org/singularity/gatk4-spark:4.4.0.0--hdfd78af_0':
         'biocontainers/gatk4-spark:4.4.0.0--hdfd78af_0' }"
 
+    if (workflow.containerEngine == 'docker') {
+        containerOptions = '-u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro'
+    }
+
     input:
     tuple val(meta), path(input), path(input_index), path(bqsr_table), path(intervals)
     path  fasta

--- a/modules/nf-core/gatk4spark/baserecalibrator/main.nf
+++ b/modules/nf-core/gatk4spark/baserecalibrator/main.nf
@@ -7,6 +7,10 @@ process GATK4SPARK_BASERECALIBRATOR {
         'https://depot.galaxyproject.org/singularity/gatk4-spark:4.4.0.0--hdfd78af_0':
         'biocontainers/gatk4-spark:4.4.0.0--hdfd78af_0' }"
 
+    if (workflow.containerEngine == 'docker') {
+        containerOptions = '-u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro'
+    }
+
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)
     path  fasta

--- a/modules/nf-core/gatk4spark/markduplicates/main.nf
+++ b/modules/nf-core/gatk4spark/markduplicates/main.nf
@@ -7,6 +7,10 @@ process GATK4SPARK_MARKDUPLICATES {
         'https://depot.galaxyproject.org/singularity/gatk4-spark:4.4.0.0--hdfd78af_0':
         'biocontainers/gatk4-spark:4.4.0.0--hdfd78af_0' }"
 
+    if (workflow.containerEngine == 'docker') {
+        containerOptions = '-u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro'
+    }
+
     input:
     tuple val(meta), path(bam)
     path  fasta

--- a/nextflow.config
+++ b/nextflow.config
@@ -192,7 +192,7 @@ profiles {
         docker.enabled         = true
         podman.enabled         = false
         shifter.enabled        = false
-        docker.runOptions      = { params.use_gatk_spark ? '' : '-u $(id -u):$(id -g)' }.call()
+        docker.runOptions      = '-u $(id -u):$(id -g)'
         singularity.enabled    = false
     }
     arm {

--- a/tests/test_joint_germline.yml
+++ b/tests/test_joint_germline.yml
@@ -4,6 +4,7 @@
     - germline
     - joint_germline
     - variant_calling
+    - foo
   files:
     - path: results/csv/variantcalled.csv
       md5sum: d2dffdbd2b4f1f26a06637592d24dab3


### PR DESCRIPTION
Testing docker container options in GATK Spark modules. - Just a dummy PR for discussion and triggering CI-tests.

In this PR, I made changes to the modules (like Jonas did). However, I would prefer a solution where we don't change the modules but just alter the containerOptions in the corresponding config.

If we're to update the modules, then I guess they should first be updated in the modules-repo?  (Or are we perhaps going to make a "local" patch of the Spark modules?)

Note that the following (silly) test of joint-germline with profile `use_gatk_spark` also work on this PR: 
```
NXF_VER=24.01.0-edge PROFILE=docker nextflow run main.nf -profile test_cache,targeted,use_gatk_spark --input ./tests/csv/3.0/mapped_joint_bam.csv --tools haplotypecaller --step variant_calling --joint_germline --outdir results --known_snps_vqsr false --known_indels_vqsr false
```
(The test is "silly" because it doesn't actually call any Spark modules.) 