### PR TITLE
Fix call to SENTIEON_DEDUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Balgattjåhkkå is the other top peak (over 2k m) in the Pårte massif, the othe
 - [#1422](https://github.com/nf-core/sarek/pull/1422) - Fix `Cannot serialize context map` warning
 - [#1462](https://github.com/nf-core/sarek/pull/1462) - Fix ascat input channels
 - [#1463](https://github.com/nf-core/sarek/pull/1463) - Add `spark` profile to all gatk4spark tests
+- [#1465](https://github.com/nf-core/sarek/pull/1465) - Fix input channels for `SENTIEON_DEDUP`
 
 ### Removed
 

--- a/subworkflows/local/bam_sentieon_dedup/main.nf
+++ b/subworkflows/local/bam_sentieon_dedup/main.nf
@@ -19,7 +19,7 @@ workflow BAM_SENTIEON_DEDUP {
     bam = bam.map{ meta, bam -> [ meta - meta.subMap('data_type'), bam ] }
     bai = bai.map{ meta, bai -> [ meta - meta.subMap('data_type'), bai ] }
     bam_bai = bam.join(bai, failOnMismatch:true, failOnDuplicate:true)
-    SENTIEON_DEDUP(bam_bai, fasta.map{fa -> [[:], fa]}, fasta_fai.map{fai -> [[:], fai]})
+    SENTIEON_DEDUP(bam_bai, fasta, fasta_fai)
 
     // Join with the crai file
     cram = SENTIEON_DEDUP.out.cram.join(SENTIEON_DEDUP.out.crai, failOnDuplicate: true, failOnMismatch: true)


### PR DESCRIPTION
I got:
```
ERROR ~ Error executing process > 'NFCORE_SAREK:sarek:BAM_SENTIEON_DEDUP:SENTIEON_DEDUP (1)'

Caused by:
  Not a valid path value type: java.util.LinkedHashMap ([id:genome])
```
on
```
nextflow run main.nf -profile test_cache,sentieon_dedup_bam,singularity --outdir results  -c ngc_pbs.config
```

Fix tested manually.

https://nfcore.slack.com/archives/C05V9FRJYMV/p1713173654428819?thread_ts=1713164739.053059&cid=C05V9FRJYMV


<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
