### PR TITLE
Getting mapped bam and bai published in the same folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1521](https://github.com/nf-core/sarek/pull/1521) - Minor code refactoring to simplify syntax in args handling
 
 ### Fixed
+
 - [#1541](https://github.com/nf-core/sarek/pull/1541) - Getting bam and bai published in the same folder
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-<<<<<<< fix_1540
 - [#1541](https://github.com/nf-core/sarek/pull/1541) - Getting bam and bai published in the same folder
-=======
 - [#1542](https://github.com/nf-core/sarek/pull/1542) - Removing legacy configs of `CUSTOM_DUMPSOFTWAREVERSIONS`
->>>>>>> dev
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1521](https://github.com/nf-core/sarek/pull/1521) - Minor code refactoring to simplify syntax in args handling
 
 ### Fixed
+- [#1541](https://github.com/nf-core/sarek/pull/1541) - Getting bam and bai published in the same folder
 
 ### Removed
 

--- a/workflows/sarek/main.nf
+++ b/workflows/sarek/main.nf
@@ -253,6 +253,12 @@ workflow SAREK {
             }
             .set { reads_grouping_key }
 
+        reads_for_alignment = reads_for_alignment.map{ meta, reads ->
+            // Update meta.id to meta.sample no multiple lanes or splitted fastqs
+            if (meta.size * meta.num_lanes == 1) [ meta + [ id:meta.sample ], reads ]
+            else [ meta, reads ]
+        }
+
         // reads will be sorted
         sort_bam = true
         FASTQ_ALIGN_BWAMEM_MEM2_DRAGMAP_SENTIEON(reads_for_alignment, index_alignment, sort_bam, fasta, fasta_fai)


### PR DESCRIPTION
Issue #1540 

QUESTION : Should I add a pytest covering this bug? (It should be super easy to add such a test using the below-mentioned ntest-cmd.)

------------
The following test works on this PR:
```
nextflow run main.nf -profile test,alignment_to_fastq,docker,debug --outdir results --save_mapped --save_output_as_bam
````
and gives
```
├── mapped
│   └── test
│       ├── test.sorted.bam
│       └── test.sorted.bam.bai
```

I also tried fixing the problem by setting

https://github.com/nf-core/sarek/blob/b5b766d3b4ac89864f2fa07441cdc8844e70a79e/conf/modules/aligner.config#L52C21-L52C52

to `) { "mapped/${meta.sample}/${it}" }`, but then I got
```
results/preprocessing/mapped/<meta.sample>/<meta.id>.sorted.bam
results/preprocessing/mapped/<meta.sample>/<meta.id>.sorted.bam.bai
```
that is, the above-mentioned test gave:
```
├── mapped
│   └── test
│       ├── test-1.sorted.bam
│       └── test-1.sorted.bam.bai
```

I suggest that we add the above-mentioned test as a pytest.

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test tests/ --verbose --profile +docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
