### PR TITLE
Fix: Correct vep_cache_path_full when refseq/merged option is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1542](https://github.com/nf-core/sarek/pull/1542) - Removing legacy configs of `CUSTOM_DUMPSOFTWAREVERSIONS`
 - [#1547](https://github.com/nf-core/sarek/pull/1547) - Correct typo in help text in nextflow_schema.json
 - [#1556](https://github.com/nf-core/sarek/pull/1556) - Fix display of some commands in `docs/usage.md`
+- [#1563](https://github.com/nf-core/sarek/pull/1563) - Fix `vep_cache_path_full` so that `--refseq/--merged` will work for ENSEMBLVEP
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ We thank the following people for their extensive assistance in the development 
 - [Grant Neilson](https://github.com/grantn5)
 - [gulfshores](https://github.com/gulfshores)
 - [Harshil Patel](https://github.com/drpatelh)
+- [Hongwei Ye](https://github.com/YeHW)
 - [James A. Fellows Yates](https://github.com/jfy133)
 - [Jesper Eisfeldt](https://github.com/J35P312)
 - [Johannes Alneberg](https://github.com/alneberg)

--- a/main.nf
+++ b/main.nf
@@ -253,6 +253,7 @@ workflow NFCORE_SAREK {
             params.vep_species,
             params.vep_cache_version,
             params.vep_genome,
+            params.vep_custom_args,
             "Please refer to https://nf-co.re/sarek/docs/usage/#how-to-customise-snpeff-and-vep-annotation for more information.")
 
             snpeff_cache = ANNOTATION_CACHE_INITIALISATION.out.snpeff_cache

--- a/subworkflows/local/annotation_cache_initialisation/main.nf
+++ b/subworkflows/local/annotation_cache_initialisation/main.nf
@@ -19,6 +19,7 @@ workflow ANNOTATION_CACHE_INITIALISATION {
     vep_species
     vep_cache_version
     vep_genome
+    vep_custom_args
     help_message
 
     main:

--- a/subworkflows/local/annotation_cache_initialisation/main.nf
+++ b/subworkflows/local/annotation_cache_initialisation/main.nf
@@ -39,7 +39,8 @@ workflow ANNOTATION_CACHE_INITIALISATION {
 
     if (vep_enabled) {
         def vep_annotation_cache_key = (vep_cache == "s3://annotation-cache/vep_cache/") ? "${vep_cache_version}_${vep_genome}/" : ""
-        def vep_cache_dir = "${vep_annotation_cache_key}${vep_species}/${vep_cache_version}_${vep_genome}"
+        def vep_species_suffix = vep_custom_args.contains("--merged") ? '_merged' : (vep_custom_args.contains("--refseq") ? '_refseq' : '')
+        def vep_cache_dir = "${vep_annotation_cache_key}${vep_species}${vep_species_suffix}/${vep_cache_version}_${vep_genome}"
         def vep_cache_path_full = file("$vep_cache/$vep_cache_dir", type: 'dir')
         if ( !vep_cache_path_full.exists() || !vep_cache_path_full.isDirectory() ) {
             if (vep_cache == "s3://annotation-cache/vep_cache/") {


### PR DESCRIPTION
<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->

In this PR, I'm trying to fix this issue: [ensembl-vep refseq/merged option broken](https://github.com/nf-core/sarek/issues/1559).

Let's assume these param values:
```yaml
vep_cache: path/to/vep_cache_dir
vep_cache_version: "111"
vep_genome: GRCh37
vep_species: homo_sapiens
vep_custom_args: "--everything --format vcf"
```

As of sarek 3.4.2, we can feed custom VEP options via `params.vep_custom_args` to the pipeline.

If `--refseq` or `--merged` is in `params.vep_custom_args`, it will be passed to VEP's final command, and result in the following effects:
- If `--refseq` is provided, VEP will use `${vep_cache}/${vep_species}_refseq/${vep_cache_version}_${vep_genome}` as the annotation source
- If `--merged` is provided, VEP will use `${vep_cache}/${vep_species}_merged/${vep_cache_version}_${vep_genome}` as the annotation source

Reference: https://useast.ensembl.org/info/docs/tools/vep/script/vep_options.html

When this happens (Let's assume `--refseq` is in `params.vep_custom_args`), in the `ANNOTATION_CACHE_INITIALISATION` workflow, a wrong `vep_cache_path_full` path will be tested if exists, because it won't check if `params.vep_custom_args` contains `--refseq`.

I modified the related code such that in the `ANNOTATION_CACHE_INITIALISATION` workflow, `vep_cache_path_full` will be built correctly by taking into consideration if `--refseq` or `--merged` is present in `params.vep_custom_args`.

I've tested with in-house data, and it worked as expected: when `--refseq` is present, VCF files will be annotated with RefSeq cache (e.g. "homo_sapiens_refseq/111_GRCh37"); when neither `--refseq` nor `--merged` is present, they will be annotated with normal cache (e.g. "homo_sapiens/111_GRCh37).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test tests/ --verbose --profile +docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
