### PR TITLE
Remove empty outdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Loametjåhkkå is another one of the main peaks of the Pårte massif.
 - [#1570](https://github.com/nf-core/sarek/pull/1570) - Remove duplicated notes in FASTQC output docs
 - [#1596](https://github.com/nf-core/sarek/pull/1596) - Fix haplotypecaller tests
 - [#1597](https://github.com/nf-core/sarek/pull/1597) - Fix deepvariant tests
+- [#](https://github.com/nf-core/sarek/pull/) - Remove empty output directories
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Loametjåhkkå is another one of the main peaks of the Pårte massif.
 - [#1570](https://github.com/nf-core/sarek/pull/1570) - Remove duplicated notes in FASTQC output docs
 - [#1596](https://github.com/nf-core/sarek/pull/1596) - Fix haplotypecaller tests
 - [#1597](https://github.com/nf-core/sarek/pull/1597) - Fix deepvariant tests
-- [#](https://github.com/nf-core/sarek/pull/) - Remove empty output directories
+- [#1612](https://github.com/nf-core/sarek/pull/1612) - Remove empty output directories
 
 ### Removed
 

--- a/conf/modules/prepare_genome.config
+++ b/conf/modules/prepare_genome.config
@@ -39,9 +39,9 @@ process {
         ext.when         = { params.tools && params.tools.split(',').contains('cnvkit') }
         publishDir       = [
             mode: params.publish_dir_mode,
-            path: { "${params.outdir}/reference/cnvkit" },
+            path: { "${params.outdir}/reference" },
             pattern: "*{bed}",
-            saveAs: { params.save_reference || params.build_only_index ? it : null }
+            saveAs: { params.save_reference || params.build_only_index ? "cnvkit/${it}" : null }
         ]
     }
 
@@ -50,9 +50,9 @@ process {
         ext.when         = { params.tools && params.tools.split(',').contains('cnvkit') && !params.cnvkit_reference }
         publishDir       = [
             mode: params.publish_dir_mode,
-            path: { "${params.outdir}/reference/cnvkit" },
+            path: { "${params.outdir}/reference" },
             pattern: "*{cnn}",
-            saveAs: { params.save_reference || params.build_only_index ? it : null }
+            saveAs: { params.save_reference || params.build_only_index ? "cnvkit/${it}" : null }
         ]
     }
 

--- a/conf/modules/prepare_intervals.config
+++ b/conf/modules/prepare_intervals.config
@@ -23,18 +23,18 @@ process {
     withName: 'CREATE_INTERVALS_BED' {
         publishDir       = [
             mode: params.publish_dir_mode,
-            path: { "${params.outdir}/reference/intervals" },
+            path: { "${params.outdir}/reference" },
             pattern: "*bed",
-            saveAs: { params.save_reference || params.build_only_index ? it : null }
+            saveAs: { params.save_reference || params.build_only_index ? "intervals/${it}" : null }
         ]
     }
 
     withName: 'GATK4_INTERVALLISTTOBED' {
         publishDir       = [
             mode: params.publish_dir_mode,
-            path: { "${params.outdir}/reference/intervals" },
+            path: { "${params.outdir}/reference" },
             pattern: "*bed",
-            saveAs: { params.save_reference || params.build_only_index ? it : null }
+            saveAs: { params.save_reference || params.build_only_index ? "intervals/${it}" : null }
         ]
     }
 
@@ -42,9 +42,9 @@ process {
         ext.prefix       = {"${meta.id}"}
         publishDir       = [
             mode: params.publish_dir_mode,
-            path: { "${params.outdir}/reference/intervals" },
+            path: { "${params.outdir}/reference" },
             pattern: "*bed.gz",
-            saveAs: { params.save_reference || params.build_only_index ? it : null }
+            saveAs: { params.save_reference || params.build_only_index ? "intervals/${it}" : null }
         ]
     }
 }

--- a/conf/modules/trimming.config
+++ b/conf/modules/trimming.config
@@ -32,10 +32,10 @@ process {
                 pattern: "*.{html,json,log}"
             ],
             [
-                path: { "${params.outdir}/preprocessing/fastp/${meta.sample}/" },
+                path: { "${params.outdir}/preprocessing/" },
                 mode: params.publish_dir_mode,
                 pattern: "*.fastp.fastq.gz",
-                saveAs: { params.save_trimmed || params.save_split_fastqs ? it : null }
+                saveAs: { params.save_trimmed || params.save_split_fastqs ?  "fastp/${meta.sample}/${it}" : null }
             ]
         ]
     }

--- a/subworkflows/local/bam_variant_calling_cnvkit/main.nf
+++ b/subworkflows/local/bam_variant_calling_cnvkit/main.nf
@@ -37,8 +37,8 @@ workflow BAM_VARIANT_CALLING_CNVKIT {
 
     versions = versions.mix(CNVKIT_BATCH.out.versions)
     versions = versions.mix(CNVKIT_GENEMETRICS.out.versions)
- versions = versions.mix( CNVKIT_CALL.out.versions)
- versions = versions.mix(  CNVKIT_EXPORT.out.versions)
+    versions = versions.mix(CNVKIT_CALL.out.versions)
+    versions = versions.mix(CNVKIT_EXPORT.out.versions)
     emit:
     cnv_calls_raw    = CNVKIT_CALL.out.cns      // channel: [ meta, cns ]
     cnv_calls_export = CNVKIT_EXPORT.out.output // channel: [ meta, export_format ]


### PR DESCRIPTION
Nextflow creates output directory folders, if they are present in `publishDir.path` even if `saveAs` prevents actual publishing of the files. This PR moves parts of th results directory logic to `saveAs` to prevent empty output directories from being created. 