### PR TITLE
Correct tower snpeff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [1627](https://github.com/nf-core/sarek/pull/1627) - Correct tower reports/snpeff format
+
 ### Fixed
 
 - [1623](https://github.com/nf-core/sarek/pull/1623) - Update docs to clarify vep cache folder organisation

--- a/tower.yml
+++ b/tower.yml
@@ -51,9 +51,9 @@ reports:
     display: "Control-FREEC: parsable file with information about FREEC run"
   "**/reports/bcftools/*.bcftools_stats.txt":
     display: "All samples raw statistics"
-  "**/reports/SnpEff/*/*/*_snpEff.html":
+  "**/reports/snpeff/*/*/*_snpEff.html":
     display: "Statistics and plots for the SnpEff run"
-  "**/reports/SnpEff/*/*/*_snpEff.genes.txt":
+  "**/reports/snpeff/*/*/*_snpEff.genes.txt":
     display: "TXT (tab separated) summary counts for variants affecting each transcript and gene"
   "**/reports/EnsemblVEP/*/*/*_VEP.summary.html":
     display: "Summary of the VEP run"


### PR DESCRIPTION
closes #1569

This just changes the capitalization of snpeff in the tower.yml to match the outdir formatting in `reports/` 