### PR TITLE
Allow dbsnp if null in germline variant calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [1623](https://github.com/nf-core/sarek/pull/1623) - Update docs to clarify vep cache folder organisation
-- [1628](https://github.com/nf-core/sarek/pull/1628) - fix dbsnp channel mapping in germline variant calling subworkflow
+- [1628](https://github.com/nf-core/sarek/pull/1628) - Fix dbsnp channel mapping in germline variant calling subworkflow
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [1623](https://github.com/nf-core/sarek/pull/1623) - Update docs to clarify vep cache folder organisation
+- [1628](https://github.com/nf-core/sarek/pull/1628) - fix dbsnp channel mapping in germline variant calling subworkflow
 
 ### Removed
 

--- a/subworkflows/local/bam_variant_calling_germline_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_germline_all/main.nf
@@ -130,8 +130,8 @@ workflow BAM_VARIANT_CALLING_GERMLINE_ALL {
             fasta,
             fasta_fai,
             dict,
-            dbsnp.map{ it -> [[id:it[0].baseName], it] },
-            dbsnp_tbi.map{ it -> [[id:it[0].baseName], it] },
+            dbsnp.map{it -> [[:], it]},
+            dbsnp_tbi.map{it -> [[:], it]},
             intervals)
 
         vcf_haplotypecaller = BAM_VARIANT_CALLING_HAPLOTYPECALLER.out.vcf


### PR DESCRIPTION
closes #1550

This adjusts the channel mapping of dbsnp and dbsnp_tbi in the germline variant calling subworkflow to match the same call int he sentieon subworkflow.

This fixes a bug when doing at least single sample variant calling (rather than joint) on a run/organism that does not have a dbsnp file provided.