### PR TITLE
ci: Skip nf-test on docs changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,14 @@ on:
     paths-ignore:
       - "docs/**"
       - "**/*.md"
+      - "**/*.png"
+      - "**/*.svg"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "**/*.md"
+      - "**/*.png"
+      - "**/*.svg"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - dev
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "**/*.md"
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Skips nf-test on any docs changes.

We can probably cut `docs/**` if we want to save lines 🙃 