### PR TITLE
Fix schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [1797](https://github.com/nf-core/sarek/pull/1797) - Use `file-path-pattern` over `file-path` to hanlde glob for `known_indels` and `known_indels_tbi` to fix [1785](https://github.com/nf-core/sarek/issues/1785)
+
 ### Removed
 
 ### Dependencies

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -706,7 +706,7 @@
                 "known_indels": {
                     "type": "string",
                     "fa_icon": "fas fa-copy",
-                    "format": "file-path",
+                    "format": "file-path-pattern",
                     "exists": true,
                     "mimetype": "text/plain",
                     "description": "Path to known indels file.",
@@ -715,7 +715,7 @@
                 "known_indels_tbi": {
                     "type": "string",
                     "fa_icon": "fas fa-copy",
-                    "format": "file-path",
+                    "format": "file-path-pattern",
                     "exists": true,
                     "mimetype": "text/plain",
                     "description": "Path to known indels file index.",


### PR DESCRIPTION
Glob were present in igenomes.config but not in the schema which is preventing from using the globs when not using igenomes.
close #1785 

<!--
# nf-core/sarek pull request

Many thanks for contributing to nf-core/sarek!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
