### PR TITLE
build: Set process arch for arm64

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -178,7 +178,7 @@ profiles {
         docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
-        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        process.arch = 'arm64'
     }
     singularity {
         singularity.enabled     = true


### PR DESCRIPTION
This should use arm64 based images on macos and linux.
For the nf-core arm profile we were use x86 emulation. This "translates" the instructions with rosetta under the hood.
Docker runs in a linux vm on Mac so it should be able to use the arm64
images natively.
