### PR TITLE
Increase default time for all processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [1682](https://github.com/nf-core/sarek/pull/1682) - Edit vcf_concatenate_germline subworkflow
 - [1810](https://github.com/nf-core/sarek/pull/1810) - Move non-informative information in the CHANGELOG for the end user to its own Developer section
+- [](https://github.com/nf-core/sarek/pull/) - Double the default `time` for all processes
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [1682](https://github.com/nf-core/sarek/pull/1682) - Edit vcf_concatenate_germline subworkflow
 - [1810](https://github.com/nf-core/sarek/pull/1810) - Move non-informative information in the CHANGELOG for the end user to its own Developer section
-- [](https://github.com/nf-core/sarek/pull/) - Double the default `time` for all processes
+- [1903](https://github.com/nf-core/sarek/pull/1903) - Double the default `time` for all processes
 
 ### Fixed
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -13,7 +13,7 @@ process {
     // TODO nf-core: Check the defaults for all processes
     cpus   = { 1      * task.attempt }
     memory = { 6.GB   * task.attempt }
-    time   = { 4.h    * task.attempt }
+    time   = { 8.h    * task.attempt }
 
     // memory errors which should be retried. otherwise error out
     errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
@@ -32,25 +32,25 @@ process {
     withLabel:process_single {
         cpus   = { 1                   }
         memory = { 6.GB * task.attempt }
-        time   = { 4.h  * task.attempt }
+        time   = { 8.h  * task.attempt }
     }
     withLabel:process_low {
         cpus   = { 2     * task.attempt }
         memory = { 12.GB * task.attempt }
-        time   = { 4.h   * task.attempt }
+        time   = { 8.h   * task.attempt }
     }
     withLabel:process_medium {
         cpus   = { 6     * task.attempt }
         memory = { 36.GB * task.attempt }
-        time   = { 8.h   * task.attempt }
+        time   = { 16.h   * task.attempt }
     }
     withLabel:process_high {
         cpus   = { 12    * task.attempt }
         memory = { 72.GB * task.attempt }
-        time   = { 16.h  * task.attempt }
+        time   = { 32.h  * task.attempt }
     }
     withLabel:process_long {
-        time   = { 20.h  * task.attempt }
+        time   = { 40.h  * task.attempt }
     }
     withLabel:process_high_memory {
         memory = { 200.GB * task.attempt }


### PR DESCRIPTION
Doubles the time for all processes to avoid job cancellation due to time outs. The time limit should just serve as a safe guard against orphaned long-running jobs. It should not be too restrictive to avoid jobs timing out 80% through their computation. Restarting them is more expensive and time consuming

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
