### PR TITLE
[DRAFT] Changes to UMI processing

### DIFF
--- a/conf/modules/sentieon_dedup.config
+++ b/conf/modules/sentieon_dedup.config
@@ -18,6 +18,11 @@ process {
     withName: 'SENTIEON_DEDUP' {
         ext.prefix       = { "${meta.id}.dedup.cram" }
         ext.when         = { params.tools && params.tools.split(',').contains('sentieon_dedup') }
+        ext.args2        = [
+            params.umi_in_read_header ? '--umi_tag RX' : '', // UMI based deduplication using RX tag from fgbio/copyumifromreadname
+            params.sentieon_consensus ? '--consensus'  : ''  // Generate consensus reads instead of just deduplication
+            ].join(' ').trim()
+
         publishDir       = [
             [
                 mode: params.publish_dir_mode,

--- a/conf/modules/trimming.config
+++ b/conf/modules/trimming.config
@@ -25,6 +25,9 @@ process {
             params.trim_nextseq            ? '--trim_poly_g'                              : '', // Apply the --nextseq=X option, to trim based on quality after removing poly-G tails
             params.split_fastq > 0         ? "--split_by_lines ${params.split_fastq * 4}" : '', // Output by limiting lines of each file with this option
             params.length_required > 0     ? "--length_required ${params.length_required}": '', // Reads shorter will be discarded
+            params.umi_location            ? "-U --umi_loc ${params.umi_location}"        : '', // Location of the UMI(s) 
+            params.umi_length              ? "--umi_len ${params.umi_length}"             : '', // Length of the UMI(s)
+            params.umi_base_skip           ? "--umi_skip ${params.umi_base_skip}"         : '', // Number of bases to ignore after the UMI (e.g. constant bases present after the UMI)
         ].join(' ').trim()
         publishDir = [
             [

--- a/conf/modules/umi.config
+++ b/conf/modules/umi.config
@@ -16,7 +16,11 @@
 process {
 
     withName: 'FASTQTOBAM' {
-        ext.args   = { "--read-structures $params.umi_read_structure" }
+        // if UMIs are in read header, read structure should be "+T +T" (for paired end)
+        ext.args   = [
+            "--read-structures $params.umi_read_structure",
+            umi_in_read_header ? '--extract-umis-from-read-names' : ''
+        ].join(' ').trim()
         ext.prefix = {"${meta.id}"}
         publishDir = [
             //specify to avoid publishing, overwritten otherwise

--- a/docs/output.md
+++ b/docs/output.md
@@ -152,7 +152,7 @@ These files are intermediate and by default not placed in the output-folder kept
 
 #### UMI consensus
 
-Sarek can process UMI-reads, using [fgbio](http://fulcrumgenomics.github.io/fgbio/tools/latest/) tools.
+Sarek can create consensus reads when Unique Molecular Identifiers (UMIs) exist, using [fgbio](http://fulcrumgenomics.github.io/fgbio/tools/latest/) tools. Please note that if your UMIs are part of additional index fastq files then you can use [nf-core/fastquorum](https://nf-co.re/fastquorum) to process them.
 
 These files are intermediate and by default not placed in the output-folder kept in the final files delivered to users. Set `--save_split` to enable publishing of these files to:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -889,25 +889,29 @@ Command error:
 
 Please be aware that `--use_gatk_spark` is not compatible with `--save_output_as_bam --save_mapped` because merging the reads to export them to bam files only works when they are coordinate sorted - spark works with name-sorting the reads.
 
-## How to handle UMIs
+## How to handle Unique Molecular Identifiers (UMIs)
+Unique Molecular Identifiers (UMIs) are used to identify which reads came from the same original DNA molecule prior to any amplification steps. This is important when sequencing to a high depth on targetted loci, as the likelihood of having the same positions (start/end in the case of paired-end reads) for reads coming from distinct molecules increases with depth.
+They may be used to generate consensus reads, where if two or more reads are considered to be part of the same group a novel read is created based on averaging over the individual reads, or solely to help distinguish while marking or removing duplicates.
 
-Sarek can process UMI-reads, using [fgbio](http://fulcrumgenomics.github.io/fgbio/tools/latest/) tools.
+Depending on the precise library preparation method the UMIs may exist in several difference places. They may be within the read structure (R1 and/or R2 for paired ends), or they may have been in the index reads for Illumina sequencing. If the UMIs were in the index reads, then sarek can only process these UMIs if they have been already transferred to the read header, for instance using the OverrideCycles option inside `bclconvert`; this may be specified by using the option `--umi_in_read_header true`.
 
-In order to use reads containing UMI tags as your initial input, you need to include `--umi_read_structure [structure]` in your parameters.
+As an example: if your reads contain a UMI only on the forward read, the string can only represent one structure (i.e. "2M11S+T"); should your reads contain a UMI on both reads, the string will contain two structures separated by a blank space (i.e. "2M11S+T 2M11S+T"); should your reads contain a UMI only on the reverse read, your structure must represent the template only for the forward read and template plus UMI for the reverse read (i.e. +T 12M11S+T). Please refer to FGBIO documentation for more details, as providing the correct structure is essential and specific to the UMI kit used. This structure can be passed to `--umi_read_structure`, and will enable the fgbio consensus read generation as detailed below.
 
-This will enable pre-processing of the reads and UMI consensus reads calling, which will then be used to continue the workflow from the mapping steps. For post-UMI processing depending on the experimental setup, duplicate marking and base quality recalibration can be skipped with [`--skip_tools`].
+Alternatively, the tool `fastp` may be used to extract UMIs from the template read by setting the parameters `--umi_loc` and `--umi_len` (and optionally `--umi_skip`) as [detailed in its documentation](https://github.com/OpenGene/fastp?tab=readme-ov-file#unique-molecular-identifier-umi-processing).
 
-### UMI Read Structure
+We therefore have two parallel workflows:
 
-This parameter is a string, which follows a [convention](https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures) to describe the structure of the umi.
+### UMI-aware Deduplication
+GATK MarkDuplicates will automatially use UMI aware deduplication provided the UMIs are present on the `RX` tag inside the bam/cram file; this is the case when either `--umi_in_read_header` or `--umi_loc` is specified. The appropriate flag for Sentieon dedup will be set provided one of these two parameters is set.
 
-As an example: if your reads contain a UMI only on the forward read, the string can only represent one structure (i.e. "2M11S+T"); should your reads contain a UMI on both reas, the string will contain two structures separated by a blank space (i.e. "2M11S+T 2M11S+T"); should your reads contain a UMI only on the reverse read, your structure must represent the template only for the forward read and template plus UMI for the reverse read (i.e. +T 12M11S+T). Please do refer to FGBIO documentation for more details, as providing the correct structure is essential and specific to the UMI kit used.
+### Consensus read generation 
+Sarek will generate consensus reads using [fgbio](http://fulcrumgenomics.github.io/fgbio/tools/latest/) tools if `--umi_read_structure` is specified. For post-UMI processing depending on the experimental setup, duplicate marking and base quality recalibration can be skipped with [`--skip_tools`].
+
+Separately, the commercial Sentieon tool can perform consensus building within the `sentieon_dedup` step; this can be enabled by setting `--sentieon_consensus true`. This may be done with or without UMIs (specified via `--umi_loc` and `--umi_len` or via `--umi_in_read_header`).
 
 ### Limitations and future updates
-
 Recent updates to Samtools have been introduced, which can speed-up performance of fgbio tools used in this workflow.
-The current workflow does not handle duplex UMIs (i.e. where opposite strands of a duplex molecule have been tagged with a different UMI), and best practices have been proposed to process this type of data.
-Both changes will be implemented in a future release.
+The current workflow does not handle duplex UMIs (i.e. where opposite strands of a duplex molecule have been tagged with a different UMI), please use [nf-core/fastquorum](https://nf-co.re/fastquorum) for this case, as well as the case where the UMIs are present in additional FASTQ files.
 
 ## How to run sarek when no(t all) reference files are in igenomes
 

--- a/modules.json
+++ b/modules.json
@@ -167,6 +167,11 @@
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
                         "installed_by": ["modules"]
                     },
+                    "fgbio/copyumifromreadname": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
                     "fgbio/fastqtobam": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",

--- a/modules/nf-core/fgbio/copyumifromreadname/environment.yml
+++ b/modules/nf-core/fgbio/copyumifromreadname/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/copyumifromreadname/main.nf
+++ b/modules/nf-core/fgbio/copyumifromreadname/main.nf
@@ -1,0 +1,64 @@
+process FGBIO_COPYUMIFROMREADNAME {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
+
+    input:
+    tuple val(meta), path(bam), path(bai)
+
+    output:
+    tuple val(meta), path("*.bam"), emit: bam
+    tuple val(meta), path("*.bai"), emit: bai
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}_umi_extracted"
+    def mem_gb = 8
+    if (!task.memory) {
+        log.info '[fgbio CopyUmiFromReadName] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.'
+    } else if (mem_gb > task.memory.giga) {
+        if (task.memory.giga < 2) {
+            mem_gb = 1
+        } else {
+            mem_gb = task.memory.giga - 1
+        }
+    }
+    """
+    fgbio \\
+        -Xmx${mem_gb}g \\
+        --tmp-dir=. \\
+        --async-io=true \\
+        CopyUmiFromReadName \\
+        ${args} \\
+        --input ${bam} \\
+        --output ${prefix}.bam
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
+    END_VERSIONS
+    """
+
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}_umi_extracted"
+    """
+
+    touch ${prefix}.bam
+    touch ${prefix}.bai
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fgbio: \$(fgbio --version)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/fgbio/copyumifromreadname/meta.yml
+++ b/modules/nf-core/fgbio/copyumifromreadname/meta.yml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "fgbio_copyumifromreadname"
+description: Copies the UMI at the end of a bam files read name to the RX tag.
+keywords:
+  - sort
+  - example
+  - genomics
+tools:
+  - "fgbio":
+      description: "A set of tools for working with genomic and high throughput sequencing
+        data, including UMIs"
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/CallDuplexConsensusReads.html
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+      identifier: biotools:fgbio
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+
+    - bam:
+        type: file
+        description: Sorted BAM/CRAM/SAM file
+        pattern: "*.{bam,cram,sam}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # CRAM
+          - edam: "http://edamontology.org/format_3462" # SAM
+
+    - bai:
+        type: file
+        description: Index for bam file
+        pattern: "*.{bai}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # CRAM
+          - edam: "http://edamontology.org/format_3462" # SAM
+
+output:
+  bam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.bam":
+          type: file
+          description: Sorted BAM file
+          pattern: "*.{bam}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2572" # BAM
+  bai:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.bai":
+          type: file
+          description: Index for bam file
+          pattern: "*.{bai}"
+          ontologies:
+            - edam: "http://edamontology.org/format_3327" # BAI
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@sppearce"
+maintainers:
+  - "@sppearce"

--- a/nextflow.config
+++ b/nextflow.config
@@ -43,8 +43,12 @@ params {
     save_trimmed        = false
     save_split_fastqs   = false
 
-    // UMI tagged reads
-    umi_read_structure    = null        // no UMI
+    // UMI handling options 
+    umi_in_read_header    = false       // No UMI in read header by default
+    umi_location          = null        // No UMI location by default
+    umi_length            = null        // No UMI length by default
+    umi_base_skip         = null        // No UMI base skip by default
+    umi_read_structure    = null        // no UMI for fgbio consensus read generation
     group_by_umi_strategy = 'Adjacency' // default strategy when running with UMI for GROUPREADSBYUMI
 
     // Preprocessing
@@ -54,7 +58,8 @@ params {
     save_output_as_bam            = false      // Output files from preprocessing are saved as bam and not as cram files
     seq_center                    = null       // No sequencing center to be written in read group CN field by aligner
     seq_platform                  = 'ILLUMINA' // Default platform written in read group PL field by aligner
-    markduplicates_pixel_distance = null        // Use default value for GATK MarkDuplicates
+    markduplicates_pixel_distance = null       // Use default value for GATK MarkDuplicates
+    sentieon_consensus            = false      // Use consensus read generation inside Sentieon deduplication step
 
     // Variant Calling
     ascat_ploidy                      = null  // default value for ASCAT

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -11,7 +11,10 @@
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
             "help_text": "Specify input samplesheet, step and output folder.",
-            "required": ["step", "outdir"],
+            "required": [
+                "step",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",
@@ -186,23 +189,74 @@
                     "fa_icon": "fas fa-save",
                     "description": "Save trimmed FastQ file intermediates."
                 },
+                "save_split_fastqs": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-vial",
+                    "description": "If set, publishes split FASTQ files. Intended for testing purposes."
+                }
+            }
+        },
+        "umi_processing": {
+            "title": "Unique Molecular Identifiers",
+            "type": "object",
+            "description": "Parameters related to the handling of Unique Molecular Identifiers (UMIs)",
+            "fa_icon": "fas fa-cut",
+            "properties": {
                 "umi_read_structure": {
                     "type": "string",
                     "fa_icon": "fas fa-tape",
-                    "description": "Specify UMI read structure",
+                    "description": "Specify UMI read structure for fgbio UMI consensus read generation",
                     "help_text": "One structure if UMI is present on one end (i.e. '+T 2M11S+T'), or two structures separated by a blank space if UMIs a present on both ends (i.e. '2M11S+T 2M11S+T'); please note, this does not handle duplex-UMIs.\n\nFor more info on UMI usage in the pipeline, also check docs [here](./docs/usage/#how-to-handle-umis)."
                 },
                 "group_by_umi_strategy": {
                     "type": "string",
                     "default": "Adjacency",
                     "fa_icon": "fas fa-tape",
-                    "description": "Default strategy with UMI",
-                    "enum": ["Identity", "Edit", "Adjacency", "Paired"]
+                    "description": "Default strategy for fgbio UMI-based consensus read generation ",
+                    "enum": [
+                        "Identity",
+                        "Edit",
+                        "Adjacency",
+                        "Paired"
+                    ]
                 },
-                "save_split_fastqs": {
+                "umi_in_read_header": {
                     "type": "boolean",
-                    "fa_icon": "fas fa-vial",
-                    "description": "If set, publishes split FASTQ files. Intended for testing purposes."
+                    "default": false,
+                    "fa_icon": "fas fa-tape",
+                    "description": "Move UMIs from fastq read headers to a tag prior to deduplication.",
+                    "help_text": "Set to true if UMIs are already present in the header of the read, for instance from using OverrideCycles in bclconvert or umi_tools/extract."
+                },
+                "umi_location": {
+                    "type": "string",
+                    "default": null,
+                    "fa_icon": "fas fa-tape",
+                    "description": "Location of the UMI(s) to be extracted with fastp.",
+                    "help_text": "Use if UMIs are not present in the read header, but in a specific location within the reads/fastq header index. This will be used to extract UMIs from reads or index in the fastq header and store them in the RX tag.",
+                    "enum": [
+                        "read1",
+                        "read2",
+                        "per_read",
+                        "index1",
+                        "index2",
+                        "per_index"
+                    ]
+                },
+                "umi_length": {
+                    "type": "integer",
+                    "default": null,
+                    "minimum": 1,
+                    "fa_icon": "fas fa-tape",
+                    "description": "Length of the UMI(s) in the read.",
+                    "help_text": "If UMIs are being extracted using fastp, specify the length of the UMI here. This will be used to extract UMIs from reads and store them in the RX tag."
+                },
+                "umi_base_skip": {
+                    "type": "integer",
+                    "default": null,
+                    "minimum": 0,
+                    "fa_icon": "fas fa-tape",
+                    "description": "Number of bases to skip after the UMI(s) in the read when extracting with fastp.",
+                    "help_text": "If UMIs are being extracted using fastp, specify the number of bases to skip after the UMI here. This will trim some bases after the UMI."
                 }
             }
         },
@@ -217,7 +271,13 @@
                     "type": "string",
                     "default": "bwa-mem",
                     "fa_icon": "fas fa-puzzle-piece",
-                    "enum": ["bwa-mem", "bwa-mem2", "dragmap", "sentieon-bwamem", "parabricks"],
+                    "enum": [
+                        "bwa-mem",
+                        "bwa-mem2",
+                        "dragmap",
+                        "sentieon-bwamem",
+                        "parabricks"
+                    ],
                     "description": "Specify aligner to be used to map reads to reference genome.",
                     "help_text": "Sarek will build missing indices automatically if not provided. Set `--bwa false` if indices should be (re-)built.\nIf DragMap is selected as aligner, it is recommended to skip baserecalibration with `--skip_tools baserecalibrator`. For more info see [here](https://gatk.broadinstitute.org/hc/en-us/articles/4407897446939--How-to-Run-germline-single-sample-short-variant-discovery-in-DRAGEN-mode)."
                 },
@@ -242,6 +302,13 @@
                 "markduplicates_pixel_distance": {
                     "type": "integer",
                     "help_text": "Pixel distance for GATK MarkDuplicates."
+                },
+                "sentieon_consensus": {
+                    "type": "boolean",
+                    "default": false,
+                    "fa_icon": "fas fa-tape",
+                    "description": "Generate consensus reads with Sentieon dedup rather than choosing one best read.",
+                    "help_text": "If set, the Sentieon dedup output will combine duplicate reads into single consensus read. This is only relevant if `--tools` contains `sentieon_dedup`."
                 }
             }
         },
@@ -567,7 +634,11 @@
                     "type": "string",
                     "default": "vcf",
                     "description": "VEP output-file format.",
-                    "enum": ["json", "tab", "vcf"],
+                    "enum": [
+                        "json",
+                        "tab",
+                        "vcf"
+                    ],
                     "help_text": "Sets the format of the output-file from VEP. Available formats: json, tab and vcf.",
                     "fa_icon": "fas fa-table"
                 },
@@ -651,7 +722,10 @@
                     "type": "string",
                     "description": "ASCAT genome.",
                     "help_text": "Must be set to run ASCAT, either hg19 or hg38.\n\nIf you use AWS iGenomes, this has already been set for you appropriately.",
-                    "enum": ["hg19", "hg38"]
+                    "enum": [
+                        "hg19",
+                        "hg38"
+                    ]
                 },
                 "ascat_alleles": {
                     "type": "string",
@@ -1003,7 +1077,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email": {
@@ -1103,6 +1184,9 @@
         },
         {
             "$ref": "#/$defs/fastq_preprocessing"
+        },
+        {
+            "$ref": "#/$defs/umi_processing"
         },
         {
             "$ref": "#/$defs/preprocessing"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -11,10 +11,7 @@
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
             "help_text": "Specify input samplesheet, step and output folder.",
-            "required": [
-                "step",
-                "outdir"
-            ],
+            "required": ["step", "outdir"],
             "properties": {
                 "input": {
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",
@@ -213,16 +210,10 @@
                     "default": "Adjacency",
                     "fa_icon": "fas fa-tape",
                     "description": "Default strategy for fgbio UMI-based consensus read generation ",
-                    "enum": [
-                        "Identity",
-                        "Edit",
-                        "Adjacency",
-                        "Paired"
-                    ]
+                    "enum": ["Identity", "Edit", "Adjacency", "Paired"]
                 },
                 "umi_in_read_header": {
                     "type": "boolean",
-                    "default": false,
                     "fa_icon": "fas fa-tape",
                     "description": "Move UMIs from fastq read headers to a tag prior to deduplication.",
                     "help_text": "Set to true if UMIs are already present in the header of the read, for instance from using OverrideCycles in bclconvert or umi_tools/extract."
@@ -233,18 +224,10 @@
                     "fa_icon": "fas fa-tape",
                     "description": "Location of the UMI(s) to be extracted with fastp.",
                     "help_text": "Use if UMIs are not present in the read header, but in a specific location within the reads/fastq header index. This will be used to extract UMIs from reads or index in the fastq header and store them in the RX tag.",
-                    "enum": [
-                        "read1",
-                        "read2",
-                        "per_read",
-                        "index1",
-                        "index2",
-                        "per_index"
-                    ]
+                    "enum": ["read1", "read2", "per_read", "index1", "index2", "per_index"]
                 },
                 "umi_length": {
                     "type": "integer",
-                    "default": null,
                     "minimum": 1,
                     "fa_icon": "fas fa-tape",
                     "description": "Length of the UMI(s) in the read.",
@@ -252,7 +235,6 @@
                 },
                 "umi_base_skip": {
                     "type": "integer",
-                    "default": null,
                     "minimum": 0,
                     "fa_icon": "fas fa-tape",
                     "description": "Number of bases to skip after the UMI(s) in the read when extracting with fastp.",
@@ -271,13 +253,7 @@
                     "type": "string",
                     "default": "bwa-mem",
                     "fa_icon": "fas fa-puzzle-piece",
-                    "enum": [
-                        "bwa-mem",
-                        "bwa-mem2",
-                        "dragmap",
-                        "sentieon-bwamem",
-                        "parabricks"
-                    ],
+                    "enum": ["bwa-mem", "bwa-mem2", "dragmap", "sentieon-bwamem", "parabricks"],
                     "description": "Specify aligner to be used to map reads to reference genome.",
                     "help_text": "Sarek will build missing indices automatically if not provided. Set `--bwa false` if indices should be (re-)built.\nIf DragMap is selected as aligner, it is recommended to skip baserecalibration with `--skip_tools baserecalibrator`. For more info see [here](https://gatk.broadinstitute.org/hc/en-us/articles/4407897446939--How-to-Run-germline-single-sample-short-variant-discovery-in-DRAGEN-mode)."
                 },
@@ -305,7 +281,6 @@
                 },
                 "sentieon_consensus": {
                     "type": "boolean",
-                    "default": false,
                     "fa_icon": "fas fa-tape",
                     "description": "Generate consensus reads with Sentieon dedup rather than choosing one best read.",
                     "help_text": "If set, the Sentieon dedup output will combine duplicate reads into single consensus read. This is only relevant if `--tools` contains `sentieon_dedup`."
@@ -634,11 +609,7 @@
                     "type": "string",
                     "default": "vcf",
                     "description": "VEP output-file format.",
-                    "enum": [
-                        "json",
-                        "tab",
-                        "vcf"
-                    ],
+                    "enum": ["json", "tab", "vcf"],
                     "help_text": "Sets the format of the output-file from VEP. Available formats: json, tab and vcf.",
                     "fa_icon": "fas fa-table"
                 },
@@ -722,10 +693,7 @@
                     "type": "string",
                     "description": "ASCAT genome.",
                     "help_text": "Must be set to run ASCAT, either hg19 or hg38.\n\nIf you use AWS iGenomes, this has already been set for you appropriately.",
-                    "enum": [
-                        "hg19",
-                        "hg38"
-                    ]
+                    "enum": ["hg19", "hg38"]
                 },
                 "ascat_alleles": {
                     "type": "string",
@@ -1077,14 +1045,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email": {

--- a/subworkflows/local/bam_merge_index_samtools/main.nf
+++ b/subworkflows/local/bam_merge_index_samtools/main.nf
@@ -6,6 +6,7 @@
 
 include { SAMTOOLS_INDEX as INDEX_MERGE_BAM } from '../../../modules/nf-core/samtools/index/main'
 include { SAMTOOLS_MERGE as MERGE_BAM       } from '../../../modules/nf-core/samtools/merge/main'
+include { FGBIO_COPYUMIFROMREADNAME         } from '../../../modules/nf-core/fgbio/copyumifromreadname/main'
 
 workflow BAM_MERGE_INDEX_SAMTOOLS {
     take:
@@ -14,12 +15,18 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
     main:
     versions = Channel.empty()
 
+    // If UMIs started in read header, copy to RX tag
+    if (params.umi_in_read_header ) {
+        FGBIO_COPYUMIFROMREADNAME(bam)
+        bam = FGBIO_COPYUMIFROMREADNAME.out.bam
+    }
+
     // Figuring out if there is one or more bam(s) from the same sample
-    bam_to_merge = bam.branch{ meta, bam ->
+    bam_to_merge = bam.branch{ meta, bam_ ->
         // bam is a list, so use bam.size() to asses number of intervals
-        single:   bam.size() <= 1
-            return [ meta, bam[0] ]
-        multiple: bam.size() > 1
+        single:   bam_.size() <= 1
+            return [ meta, bam_[0] ]
+        multiple: bam_.size() > 1
     }
 
     // Only when using intervals
@@ -37,6 +44,7 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
     // Gather versions of all tools used
     versions = versions.mix(INDEX_MERGE_BAM.out.versions)
     versions = versions.mix(MERGE_BAM.out.versions)
+    versions = versions.mix(FGBIO_COPYUMIFROMREADNAME.out.versions)
 
     emit:
     bam_bai


### PR DESCRIPTION
Initial draft of changes to UMI processing.
Introduces:

- fastp for UMI extraction from reads (R1/R2/both or index reads in fastq header)
- movement of UMIs from read name to RX: tag on bam/cram files, allowing MarkDuplicates and Sentieon to get at them
- sentieon consensus mode (technically a different thing, but while I was fiddling with the config...)

Not tested at all at the moment. As in, not even a little bit.