### PR TITLE
Parallel CRAM creation during GATK MarkDuplicates

### DIFF
--- a/modules/nf-core/gatk4/markduplicates/main.nf
+++ b/modules/nf-core/gatk4/markduplicates/main.nf
@@ -61,9 +61,12 @@ process GATK4_MARKDUPLICATES {
 
     # If cram files are wished as output, the run samtools for conversion
     if [[ ${prefix} == *.cram ]]; then
+        echo "$(date -Iseconds) - converting output to cram"
         samtools view -@ ${avail_cpu} -Ch -T ${fasta} -o ${prefix} ${prefix_bam}
         rm ${prefix_bam}
+        echo "$(date -Iseconds) - indexing cram file"
         samtools index -@ ${avail_cpu} ${prefix}
+        echo "$(date -Iseconds) - cram conversion complete"
     fi
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
After running GATK MarkDuplicates, the BAM file is converted to CRAM via samtools. This task gets 6 cores by default and using all those available when doing the CRAM conversion should give a reasonable speedup on most systems. It falls back to a single core if `task.cpus` is not set, which just gives the same performance seen currently.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`). _NB: passes to the same degree that master does_
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
