### PR TITLE
Remove exists validation from snpeff_cache and vep_cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#2077](https://github.com/nf-core/sarek/pull/2077) - Remove re-indexed bam from `indexcov` from publishing into top level `outdir` directory
+- [#2083](https://github.com/nf-core/sarek/pull/2083) - Remove `exists` validation from `snpeff_cache` and `vep_cache` parameters to fix workflow launch failures when annotation tools are not used
 
 ### Removed
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1025,7 +1025,6 @@
                 "snpeff_cache": {
                     "type": "string",
                     "format": "directory-path",
-                    "exists": true,
                     "fa_icon": "fas fa-cloud-download-alt",
                     "default": "s3://annotation-cache/snpeff_cache/",
                     "description": "Path to snpEff cache.",
@@ -1040,7 +1039,6 @@
                 "vep_cache": {
                     "type": "string",
                     "format": "directory-path",
-                    "exists": true,
                     "fa_icon": "fas fa-cloud-download-alt",
                     "default": "s3://annotation-cache/vep_cache/",
                     "description": "Path to VEP cache.",


### PR DESCRIPTION
## Summary

- Removes `exists: true` validation from `snpeff_cache` and `vep_cache` parameters in `nextflow_schema.json`
- Fixes workflow launch failures when default S3 annotation cache paths are not accessible

## Details

Fixes #2079

The `exists: true` validation on `snpeff_cache` and `vep_cache` parameters causes workflow launches to fail when the default S3 annotation cache paths (`s3://annotation-cache/snpeff_cache/` and `s3://annotation-cache/vep_cache/`) are not accessible, even when users don't intend to use snpEff or VEP for annotation.

This is the same fix applied in #1858 for other optional reference files (germline_resource, mappability, ngscheckmate_bed, sentieon_dnascope_model), but `snpeff_cache` and `vep_cache` were missed at that time.

## Test plan

- [ ] Verify pipeline launches without annotation tools when cache paths don't exist
- [ ] Verify annotation tools still work when valid cache paths are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)