### PR TITLE
Fix regex patterns for dbnsfp_tbi and spliceai parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This patch release includes a bump to Nextflow 25.04.8.
 
 ### Fixed
 
+- [#2050](https://github.com/nf-core/sarek/issues/2050) - Fix regex patterns for `dbnsfp_tbi`, `spliceai_snv`, and `spliceai_snv_tbi` parameter validation
 - [2029](https://github.com/nf-core/sarek/pull/2029) - Correct intervals channel for parabricks
 
 ### Removed

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -563,7 +563,7 @@
                 "dbnsfp_tbi": {
                     "type": "string",
                     "format": "file-path",
-                    "pattern": "^\\S+\\.vcf\\.gz\\.(csi|tbi)$",
+                    "pattern": "^\\S+\\.gz\\.(csi|tbi)$",
                     "exists": true,
                     "fa_icon": "fas fa-file",
                     "description": "Path to dbNSFP tabix indexed file.",
@@ -597,7 +597,7 @@
                 "spliceai_snv": {
                     "type": "string",
                     "format": "file-path",
-                    "pattern": "^\\S+\\.\\vcf\\.gz$",
+                    "pattern": "^\\S+\\.vcf\\.gz$",
                     "exists": true,
                     "fa_icon": "fas fa-file",
                     "description": "Path to spliceai raw scores snv file.",
@@ -606,7 +606,7 @@
                 "spliceai_snv_tbi": {
                     "type": "string",
                     "format": "file-path",
-                    "pattern": "^\\S+\\\\.vcf\\.gz.(csi|tbi)$",
+                    "pattern": "^\\S+\\.vcf\\.gz\\.(csi|tbi)$",
                     "exists": true,
                     "fa_icon": "fas fa-file",
                     "description": "Path to spliceai raw scores snv tabix indexed file.",


### PR DESCRIPTION
## Summary

- Fix incorrect regex pattern for `dbnsfp_tbi` - dbNSFP files use `.gz` extension, not `.vcf.gz`
- Fix incorrect regex pattern for `spliceai_snv` - remove extra backslash before `vcf`
- Fix incorrect regex pattern for `spliceai_snv_tbi` - fix inconsistent escaping and missing escape before dot

Fixes #2050

## Test plan

- [ ] Verify parameter validation accepts valid file paths for `dbnsfp_tbi`, `spliceai_snv`, and `spliceai_snv_tbi`