### PR TITLE
Fix missing params prefix for umi_tag in MarkDuplicates config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Fix missing `params.` prefix for `umi_tag` in markduplicates config
 - [#2143](https://github.com/nf-core/sarek/pull/2143) - Varlociraptor collecting multiple scenario files for one sample
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Fix missing `params.` prefix for `umi_tag` in markduplicates config
+- [#2152](https://github.com/nf-core/sarek/pull/2152) - Fix missing `params.` prefix for `umi_tag` in markduplicates config
 - [#2143](https://github.com/nf-core/sarek/pull/2143) - Varlociraptor collecting multiple scenario files for one sample
 
 ### Removed

--- a/conf/modules/markduplicates.config
+++ b/conf/modules/markduplicates.config
@@ -75,7 +75,7 @@ process {
             "--REMOVE_DUPLICATES false",
             "--VALIDATION_STRINGENCY LENIENT",
             params.markduplicates_pixel_distance ? "--OPTICAL_DUPLICATE_PIXEL_DISTANCE ${params.markduplicates_pixel_distance}" : '',
-            params.umi_tag ? "--BARCODE_TAG ${umi_tag}" :
+            params.umi_tag ? "--BARCODE_TAG ${params.umi_tag}" :
                 (params.umi_in_read_header || params.umi_length ? "--BARCODE_TAG RX" : "")
         ].join(" ").trim() }
         ext.prefix = { "${meta.id}.md.cram" }


### PR DESCRIPTION
## Summary

Fixes #2151

When running the pipeline with UMI parameters, GATK MarkDuplicates fails because the command line receives `--BARCODE_TAG [:]` instead of the actual UMI tag string.

The root cause is a missing `params.` prefix in `conf/modules/markduplicates.config`: `${umi_tag}` is undefined in that scope, so Groovy evaluates it as an empty map (`[:]`). Changed to `${params.umi_tag}`.

## Changes

- Fix `${umi_tag}` → `${params.umi_tag}` in `conf/modules/markduplicates.config`

## Test plan

- [ ] Run with `--umi_read_structure` and verify `--BARCODE_TAG` gets the correct tag value

🤖 Generated with [Claude Code](https://claude.com/claude-code)