### PR TITLE
Fix FilterMutectCalls skipped without germline_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2146](https://github.com/nf-core/sarek/pull/2146) - Fail early when `--no_intervals` is used with joint germline HaplotypeCaller
 - [#2147](https://github.com/nf-core/sarek/pull/2147) - Fix empty fastp output folder created when trimmed reads are not saved
 - [#2152](https://github.com/nf-core/sarek/pull/2152) - Fix missing `params.` prefix for `umi_tag` in markduplicates config
-- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Fix FilterMutectCalls silently skipped for tumor-only and somatic Mutect2 when no germline resource is provided
+- [#2153](https://github.com/nf-core/sarek/pull/2153) - Fix FilterMutectCalls silently skipped for tumor-only and somatic Mutect2 when no germline resource is provided
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2146](https://github.com/nf-core/sarek/pull/2146) - Fail early when `--no_intervals` is used with joint germline HaplotypeCaller
 - [#2147](https://github.com/nf-core/sarek/pull/2147) - Fix empty fastp output folder created when trimmed reads are not saved
 - [#2152](https://github.com/nf-core/sarek/pull/2152) - Fix missing `params.` prefix for `umi_tag` in markduplicates config
+- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Fix FilterMutectCalls silently skipped for tumor-only and somatic Mutect2 when no germline resource is provided
 
 ### Removed
 

--- a/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
@@ -197,29 +197,19 @@ workflow BAM_VARIANT_CALLING_SOMATIC_MUTECT2 {
         calculatecontamination_out_cont = CALCULATECONTAMINATION.out.contamination
     }
 
-    // When no germline_resource is provided, contamination/segmentation channels are empty
-    // because GetPileupSummaries is skipped. Provide default empty values so FilterMutectCalls
-    // still runs — these inputs are optional for GATK FilterMutectCalls.
-    vcf_defaults = vcf.map { meta, _vcf -> [meta, []] }
-    seg_for_filter = calculatecontamination_out_seg
-        .mix(vcf_defaults)
-        .groupTuple()
-        .map { meta, seg_list -> [meta, seg_list.find { it -> it != [] } ?: []] }
-    cont_for_filter = calculatecontamination_out_cont
-        .mix(vcf_defaults)
-        .groupTuple()
-        .map { meta, cont_list -> [meta, cont_list.find { it -> it != [] } ?: []] }
-
     // Mutect2 calls filtered by filtermutectcalls using the artifactpriors, contamination and segmentation tables
     // meta joint calling:  [id:patient_id, patient, sex]
     // meta paired calling: [id:tumorID_vs_normalID, normal_ID, patient, sex, tumorID]
+    // When no germline_resource is provided, seg/cont channels are empty because GetPileupSummaries
+    // is skipped. Use remainder: true so the join still passes items through, defaulting to [].
+    // These inputs are optional for GATK FilterMutectCalls.
     vcf_to_filter = vcf
         .join(tbi, failOnDuplicate: true, failOnMismatch: true)
         .join(stats, failOnDuplicate: true, failOnMismatch: true)
         .join(LEARNREADORIENTATIONMODEL.out.artifactprior, failOnDuplicate: true, failOnMismatch: true)
-        .join(seg_for_filter, failOnDuplicate: true, failOnMismatch: true)
-        .join(cont_for_filter, failOnDuplicate: true, failOnMismatch: true)
-        .map { meta, vcf_, tbi_, stats_, orientation, seg, cont -> [meta, vcf_, tbi_, stats_, orientation, seg, cont, []] }
+        .join(calculatecontamination_out_seg, remainder: true)
+        .join(calculatecontamination_out_cont, remainder: true)
+        .map { meta, vcf_, tbi_, stats_, orientation, seg, cont -> [meta, vcf_, tbi_, stats_, orientation, seg ?: [], cont ?: [], []] }
 
     FILTERMUTECTCALLS(vcf_to_filter, fasta, fai, dict)
 

--- a/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_mutect2/main.nf
@@ -197,6 +197,19 @@ workflow BAM_VARIANT_CALLING_SOMATIC_MUTECT2 {
         calculatecontamination_out_cont = CALCULATECONTAMINATION.out.contamination
     }
 
+    // When no germline_resource is provided, contamination/segmentation channels are empty
+    // because GetPileupSummaries is skipped. Provide default empty values so FilterMutectCalls
+    // still runs — these inputs are optional for GATK FilterMutectCalls.
+    vcf_defaults = vcf.map { meta, _vcf -> [meta, []] }
+    seg_for_filter = calculatecontamination_out_seg
+        .mix(vcf_defaults)
+        .groupTuple()
+        .map { meta, seg_list -> [meta, seg_list.find { it -> it != [] } ?: []] }
+    cont_for_filter = calculatecontamination_out_cont
+        .mix(vcf_defaults)
+        .groupTuple()
+        .map { meta, cont_list -> [meta, cont_list.find { it -> it != [] } ?: []] }
+
     // Mutect2 calls filtered by filtermutectcalls using the artifactpriors, contamination and segmentation tables
     // meta joint calling:  [id:patient_id, patient, sex]
     // meta paired calling: [id:tumorID_vs_normalID, normal_ID, patient, sex, tumorID]
@@ -204,8 +217,8 @@ workflow BAM_VARIANT_CALLING_SOMATIC_MUTECT2 {
         .join(tbi, failOnDuplicate: true, failOnMismatch: true)
         .join(stats, failOnDuplicate: true, failOnMismatch: true)
         .join(LEARNREADORIENTATIONMODEL.out.artifactprior, failOnDuplicate: true, failOnMismatch: true)
-        .join(calculatecontamination_out_seg)
-        .join(calculatecontamination_out_cont)
+        .join(seg_for_filter, failOnDuplicate: true, failOnMismatch: true)
+        .join(cont_for_filter, failOnDuplicate: true, failOnMismatch: true)
         .map { meta, vcf_, tbi_, stats_, orientation, seg, cont -> [meta, vcf_, tbi_, stats_, orientation, seg, cont, []] }
 
     FILTERMUTECTCALLS(vcf_to_filter, fasta, fai, dict)

--- a/subworkflows/local/bam_variant_calling_tumor_only_mutect2/main.nf
+++ b/subworkflows/local/bam_variant_calling_tumor_only_mutect2/main.nf
@@ -136,27 +136,17 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_MUTECT2 {
         calculatecontamination_out_cont = CALCULATECONTAMINATION.out.contamination.map { meta, cont -> [meta - meta.subMap('num_intervals'), cont] }
     }
 
-    // When no germline_resource is provided, contamination/segmentation channels are empty
-    // because GetPileupSummaries is skipped. Provide default empty values so FilterMutectCalls
-    // still runs — these inputs are optional for GATK FilterMutectCalls.
-    vcf_defaults = vcf.map { meta, _vcf -> [meta, []] }
-    seg_for_filter = calculatecontamination_out_seg
-        .mix(vcf_defaults)
-        .groupTuple()
-        .map { meta, seg_list -> [meta, seg_list.find { it -> it != [] } ?: []] }
-    cont_for_filter = calculatecontamination_out_cont
-        .mix(vcf_defaults)
-        .groupTuple()
-        .map { meta, cont_list -> [meta, cont_list.find { it -> it != [] } ?: []] }
-
     // Mutect2 calls filtered by filtermutectcalls using the contamination and segmentation tables
+    // When no germline_resource is provided, seg/cont channels are empty because GetPileupSummaries
+    // is skipped. Use remainder: true so the join still passes items through, defaulting to [].
+    // These inputs are optional for GATK FilterMutectCalls.
     vcf_to_filter = vcf
         .join(tbi, failOnDuplicate: true, failOnMismatch: true)
         .join(stats, failOnDuplicate: true, failOnMismatch: true)
         .join(LEARNREADORIENTATIONMODEL.out.artifactprior, failOnDuplicate: true, failOnMismatch: true)
-        .join(seg_for_filter, failOnDuplicate: true, failOnMismatch: true)
-        .join(cont_for_filter, failOnDuplicate: true, failOnMismatch: true)
-        .map { meta, vcf_, tbi_, stats_, artifactprior, seg, cont -> [meta, vcf_, tbi_, stats_, artifactprior, seg, cont, []] }
+        .join(calculatecontamination_out_seg, remainder: true)
+        .join(calculatecontamination_out_cont, remainder: true)
+        .map { meta, vcf_, tbi_, stats_, artifactprior, seg, cont -> [meta, vcf_, tbi_, stats_, artifactprior, seg ?: [], cont ?: [], []] }
 
     FILTERMUTECTCALLS(vcf_to_filter, fasta, fai, dict)
 

--- a/subworkflows/local/bam_variant_calling_tumor_only_mutect2/main.nf
+++ b/subworkflows/local/bam_variant_calling_tumor_only_mutect2/main.nf
@@ -136,13 +136,26 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_MUTECT2 {
         calculatecontamination_out_cont = CALCULATECONTAMINATION.out.contamination.map { meta, cont -> [meta - meta.subMap('num_intervals'), cont] }
     }
 
+    // When no germline_resource is provided, contamination/segmentation channels are empty
+    // because GetPileupSummaries is skipped. Provide default empty values so FilterMutectCalls
+    // still runs — these inputs are optional for GATK FilterMutectCalls.
+    vcf_defaults = vcf.map { meta, _vcf -> [meta, []] }
+    seg_for_filter = calculatecontamination_out_seg
+        .mix(vcf_defaults)
+        .groupTuple()
+        .map { meta, seg_list -> [meta, seg_list.find { it -> it != [] } ?: []] }
+    cont_for_filter = calculatecontamination_out_cont
+        .mix(vcf_defaults)
+        .groupTuple()
+        .map { meta, cont_list -> [meta, cont_list.find { it -> it != [] } ?: []] }
+
     // Mutect2 calls filtered by filtermutectcalls using the contamination and segmentation tables
     vcf_to_filter = vcf
         .join(tbi, failOnDuplicate: true, failOnMismatch: true)
         .join(stats, failOnDuplicate: true, failOnMismatch: true)
         .join(LEARNREADORIENTATIONMODEL.out.artifactprior, failOnDuplicate: true, failOnMismatch: true)
-        .join(calculatecontamination_out_seg)
-        .join(calculatecontamination_out_cont)
+        .join(seg_for_filter, failOnDuplicate: true, failOnMismatch: true)
+        .join(cont_for_filter, failOnDuplicate: true, failOnMismatch: true)
         .map { meta, vcf_, tbi_, stats_, artifactprior, seg, cont -> [meta, vcf_, tbi_, stats_, artifactprior, seg, cont, []] }
 
     FILTERMUTECTCALLS(vcf_to_filter, fasta, fai, dict)

--- a/subworkflows/local/samplesheet_to_channel/main.nf
+++ b/subworkflows/local/samplesheet_to_channel/main.nf
@@ -380,7 +380,7 @@ workflow SAMPLESHEET_TO_CHANNEL {
             log.warn("No Panel-of-normal was specified for Mutect2.\nIt is highly recommended to use one: https://gatk.broadinstitute.org/hc/en-us/articles/5358911630107-Mutect2\nFor more information on how to create one: https://gatk.broadinstitute.org/hc/en-us/articles/5358921041947-CreateSomaticPanelOfNormals-BETA-")
         }
         if (!germline_resource) {
-            log.warn("If Mutect2 is specified without a germline resource, no filtering will be done.\nIt is recommended to use one: https://gatk.broadinstitute.org/hc/en-us/articles/5358911630107-Mutect2")
+            log.warn("Mutect2 is specified without a germline resource. Filtering will still be performed, but without contamination estimation.\nIt is recommended to provide one: https://gatk.broadinstitute.org/hc/en-us/articles/5358911630107-Mutect2")
         }
         if (pon && pon.contains("/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000g_pon.hg38.vcf.gz")) {
             log.warn("The default Panel-of-Normals provided by GATK is used for Mutect2.\nIt is highly recommended to generate one from normal samples that are technical similar to the tumor ones.\nFor more information: https://gatk.broadinstitute.org/hc/en-us/articles/360035890631-Panel-of-Normals-PON-")

--- a/tests/joint_calling_mutect2.nf.test
+++ b/tests/joint_calling_mutect2.nf.test
@@ -40,6 +40,25 @@ nextflow_pipeline {
                 tools: 'mutect2',
                 wes: true
             ]
+        ],
+        [
+            name: "-profile test --tools mutect2 --joint_mutect2 somatic --germline_resource",
+            params: [
+                genome: null,
+                igenomes_ignore: true,
+                dbsnp: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz',
+                dbsnp_tbi: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz.tbi',
+                fasta: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta',
+                fasta_fai: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai',
+                germline_resource: modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/gnomAD.r2.1.1.vcf.gz',
+                germline_resource_tbi: modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/gnomAD.r2.1.1.vcf.gz.tbi',
+                input: "${projectDir}/tests/csv/3.0/recalibrated_somatic_joint.csv",
+                intervals: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/multi_intervals.bed',
+                joint_mutect2: true,
+                step: "variant_calling",
+                tools: 'mutect2',
+                wes: true
+            ]
         ]
     ]
 

--- a/tests/variant_calling_mutect2.nf.test
+++ b/tests/variant_calling_mutect2.nf.test
@@ -71,6 +71,41 @@ nextflow_pipeline {
                 tools: 'mutect2',
                 wes: true
             ]
+        ],
+        [
+            name: "-profile test --tools mutect2 somatic --germline_resource",
+            params: [
+                genome: null,
+                igenomes_ignore: true,
+                dbsnp: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz',
+                dbsnp_tbi: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz.tbi',
+                fasta: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta',
+                fasta_fai: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai',
+                germline_resource: modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/gnomAD.r2.1.1.vcf.gz',
+                germline_resource_tbi: modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/gnomAD.r2.1.1.vcf.gz.tbi',
+                input: "${projectDir}/tests/csv/3.0/recalibrated_somatic.csv",
+                intervals: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/multi_intervals.bed',
+                step: "variant_calling",
+                tools: 'mutect2',
+                wes: true
+            ]
+        ],
+        [
+            name: "-profile test --tools mutect2 tumoronly --germline_resource",
+            params: [
+                genome: null,
+                igenomes_ignore: true,
+                dbsnp: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz',
+                dbsnp_tbi: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz.tbi',
+                fasta: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta',
+                fasta_fai: modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai',
+                germline_resource: modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/gnomAD.r2.1.1.vcf.gz',
+                germline_resource_tbi: modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/gnomAD.r2.1.1.vcf.gz.tbi',
+                input: "${projectDir}/tests/csv/3.0/recalibrated_tumoronly.csv",
+                step: "variant_calling",
+                tools: 'mutect2',
+                wes: true
+            ]
         ]
     ]
 

--- a/tests/variant_calling_mutect2.nf.test.snap
+++ b/tests/variant_calling_mutect2.nf.test.snap
@@ -1,10 +1,13 @@
 {
     "-profile test --tools mutect2 --no_intervals tumoronly": {
         "content": [
-            11,
+            12,
             {
                 "BCFTOOLS_STATS": {
                     "bcftools": 1.21
+                },
+                "FILTERMUTECTCALLS": {
+                    "gatk4": "4.6.1.0"
                 },
                 "GATK4_CREATESEQUENCEDICTIONARY": {
                     "gatk4": "4.6.1.0"
@@ -62,56 +65,8 @@
                 "multiqc/multiqc_data/vcftools_tstv_by_qual.txt",
                 "multiqc/multiqc_plots",
                 "multiqc/multiqc_plots/pdf",
-                "multiqc/multiqc_plots/pdf/bcftools-stats-subtypes-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools-stats-subtypes-pct.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_indel-lengths-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_indel-lengths-log.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_variant_depths.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Indels.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_SNP.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Transitions.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Transversions.pdf",
-                "multiqc/multiqc_plots/pdf/mosdepth-coverage-per-contig-single-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/mosdepth-coverage-per-contig-single-pct.pdf",
-                "multiqc/multiqc_plots/pdf/mosdepth-cumcoverage-dist-id.pdf",
-                "multiqc/multiqc_plots/pdf/samtools-stats-dp.pdf",
-                "multiqc/multiqc_plots/pdf/samtools_alignment_plot-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/samtools_alignment_plot-pct.pdf",
-                "multiqc/multiqc_plots/pdf/vcftools_tstv_by_count.pdf",
                 "multiqc/multiqc_plots/png",
-                "multiqc/multiqc_plots/png/bcftools-stats-subtypes-cnt.png",
-                "multiqc/multiqc_plots/png/bcftools-stats-subtypes-pct.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_indel-lengths-cnt.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_indel-lengths-log.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_variant_depths.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Indels.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_SNP.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Transitions.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Transversions.png",
-                "multiqc/multiqc_plots/png/mosdepth-coverage-per-contig-single-cnt.png",
-                "multiqc/multiqc_plots/png/mosdepth-coverage-per-contig-single-pct.png",
-                "multiqc/multiqc_plots/png/mosdepth-cumcoverage-dist-id.png",
-                "multiqc/multiqc_plots/png/samtools-stats-dp.png",
-                "multiqc/multiqc_plots/png/samtools_alignment_plot-cnt.png",
-                "multiqc/multiqc_plots/png/samtools_alignment_plot-pct.png",
-                "multiqc/multiqc_plots/png/vcftools_tstv_by_count.png",
                 "multiqc/multiqc_plots/svg",
-                "multiqc/multiqc_plots/svg/bcftools-stats-subtypes-cnt.svg",
-                "multiqc/multiqc_plots/svg/bcftools-stats-subtypes-pct.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_indel-lengths-cnt.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_indel-lengths-log.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_variant_depths.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Indels.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_SNP.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Transitions.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Transversions.svg",
-                "multiqc/multiqc_plots/svg/mosdepth-coverage-per-contig-single-cnt.svg",
-                "multiqc/multiqc_plots/svg/mosdepth-coverage-per-contig-single-pct.svg",
-                "multiqc/multiqc_plots/svg/mosdepth-cumcoverage-dist-id.svg",
-                "multiqc/multiqc_plots/svg/samtools-stats-dp.svg",
-                "multiqc/multiqc_plots/svg/samtools_alignment_plot-cnt.svg",
-                "multiqc/multiqc_plots/svg/samtools_alignment_plot-pct.svg",
-                "multiqc/multiqc_plots/svg/vcftools_tstv_by_count.svg",
                 "multiqc/multiqc_report.html",
                 "no_intervals.bed",
                 "no_intervals.bed.gz",
@@ -124,7 +79,7 @@
                 "reports/bcftools",
                 "reports/bcftools/mutect2",
                 "reports/bcftools/mutect2/sample2",
-                "reports/bcftools/mutect2/sample2/sample2.mutect2.bcftools_stats.txt",
+                "reports/bcftools/mutect2/sample2/sample2.mutect2.filtered.bcftools_stats.txt",
                 "reports/mosdepth",
                 "reports/mosdepth/sample2",
                 "reports/mosdepth/sample2/sample2.recal.mosdepth.global.dist.txt",
@@ -137,13 +92,16 @@
                 "reports/vcftools",
                 "reports/vcftools/mutect2",
                 "reports/vcftools/mutect2/sample2",
-                "reports/vcftools/mutect2/sample2/sample2.mutect2.FILTER.summary",
-                "reports/vcftools/mutect2/sample2/sample2.mutect2.TsTv.count",
-                "reports/vcftools/mutect2/sample2/sample2.mutect2.TsTv.qual",
+                "reports/vcftools/mutect2/sample2/sample2.mutect2.filtered.FILTER.summary",
+                "reports/vcftools/mutect2/sample2/sample2.mutect2.filtered.TsTv.count",
+                "reports/vcftools/mutect2/sample2/sample2.mutect2.filtered.TsTv.qual",
                 "variant_calling",
                 "variant_calling/mutect2",
                 "variant_calling/mutect2/sample2",
                 "variant_calling/mutect2/sample2/sample2.mutect2.artifactprior.tar.gz",
+                "variant_calling/mutect2/sample2/sample2.mutect2.filtered.vcf.gz",
+                "variant_calling/mutect2/sample2/sample2.mutect2.filtered.vcf.gz.filteringStats.tsv",
+                "variant_calling/mutect2/sample2/sample2.mutect2.filtered.vcf.gz.tbi",
                 "variant_calling/mutect2/sample2/sample2.mutect2.vcf.gz",
                 "variant_calling/mutect2/sample2/sample2.mutect2.vcf.gz.stats",
                 "variant_calling/mutect2/sample2/sample2.mutect2.vcf.gz.tbi"
@@ -155,30 +113,29 @@
                 "multiqc_citations.txt:md5,d40980f61eb64026d58102841b7f3860",
                 "samtools-stats-dp.txt:md5,6618ece77181051a58275f504f67ea5b",
                 "samtools_alignment_plot.txt:md5,6136e5e1d072f166f280fb79424c392f",
-                "sample2.mutect2.bcftools_stats.txt:md5,c275ee76762a37053d43f4e290485af8",
+                "sample2.mutect2.filtered.bcftools_stats.txt:md5,b204196dee0fc69cbdabc35c805f8b73",
                 "sample2.recal.mosdepth.global.dist.txt:md5,f2dcd00a64947c49e8e4b93c2f4fbf27",
                 "sample2.recal.mosdepth.summary.txt:md5,0a7300e56eda6fba7c7564f00aa000f0",
                 "sample2.recal.per-base.bed.gz:md5,39a1bc436aa8546c26faedbe94cb676c",
                 "sample2.recal.per-base.bed.gz.csi:md5,cfb07b0ba46e8468b4342edb243536f3",
-                "sample2.mutect2.FILTER.summary:md5,08f06620a8dcc70115bdde9137a91008",
-                "sample2.mutect2.TsTv.count:md5,0d59dcbdb127be60909111958ff7b5f5",
+                "sample2.mutect2.filtered.FILTER.summary:md5,ab6f85de19646115fb226a1b69cf47f1",
+                "sample2.mutect2.filtered.TsTv.count:md5,0d59dcbdb127be60909111958ff7b5f5",
+                "sample2.mutect2.filtered.vcf.gz.filteringStats.tsv:md5,1112e7ab1ede97f77561dae02e9f2af1",
                 "sample2.mutect2.vcf.gz.stats:md5,76f749c53212d72e98801f6030fbf8a6"
             ],
             "No BAM files",
             "No CRAM files",
             [
+                "sample2.mutect2.filtered.vcf.gz:md5,c5002fcbcf76c8af2593eb062487d0f4",
                 "sample2.mutect2.vcf.gz:md5,4a803cf2687fc368a8c4eef5e2fc8c9c"
             ],
-            [
-                "WARN: If Mutect2 is specified without a germline resource, no filtering will be done.",
-                "WARN: No Panel-of-normal was specified for Mutect2."
-            ]
+            "No warnings"
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2025-12-15T23:34:19.18363343"
+        "timestamp": "2026-03-09T18:04:13.645477"
     },
     "-profile test --tools mutect2 somatic": {
         "content": [
@@ -582,7 +539,7 @@
     },
     "-profile test --tools mutect2 tumoronly": {
         "content": [
-            14,
+            15,
             {
                 "BCFTOOLS_STATS": {
                     "bcftools": 1.21
@@ -592,6 +549,9 @@
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
+                },
+                "FILTERMUTECTCALLS": {
+                    "gatk4": "4.6.1.0"
                 },
                 "GATK4_CREATESEQUENCEDICTIONARY": {
                     "gatk4": "4.6.1.0"
@@ -653,56 +613,8 @@
                 "multiqc/multiqc_data/vcftools_tstv_by_qual.txt",
                 "multiqc/multiqc_plots",
                 "multiqc/multiqc_plots/pdf",
-                "multiqc/multiqc_plots/pdf/bcftools-stats-subtypes-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools-stats-subtypes-pct.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_indel-lengths-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_indel-lengths-log.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_variant_depths.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Indels.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_SNP.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Transitions.pdf",
-                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Transversions.pdf",
-                "multiqc/multiqc_plots/pdf/mosdepth-coverage-per-contig-single-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/mosdepth-coverage-per-contig-single-pct.pdf",
-                "multiqc/multiqc_plots/pdf/mosdepth-cumcoverage-dist-id.pdf",
-                "multiqc/multiqc_plots/pdf/samtools-stats-dp.pdf",
-                "multiqc/multiqc_plots/pdf/samtools_alignment_plot-cnt.pdf",
-                "multiqc/multiqc_plots/pdf/samtools_alignment_plot-pct.pdf",
-                "multiqc/multiqc_plots/pdf/vcftools_tstv_by_count.pdf",
                 "multiqc/multiqc_plots/png",
-                "multiqc/multiqc_plots/png/bcftools-stats-subtypes-cnt.png",
-                "multiqc/multiqc_plots/png/bcftools-stats-subtypes-pct.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_indel-lengths-cnt.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_indel-lengths-log.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_variant_depths.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Indels.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_SNP.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Transitions.png",
-                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Transversions.png",
-                "multiqc/multiqc_plots/png/mosdepth-coverage-per-contig-single-cnt.png",
-                "multiqc/multiqc_plots/png/mosdepth-coverage-per-contig-single-pct.png",
-                "multiqc/multiqc_plots/png/mosdepth-cumcoverage-dist-id.png",
-                "multiqc/multiqc_plots/png/samtools-stats-dp.png",
-                "multiqc/multiqc_plots/png/samtools_alignment_plot-cnt.png",
-                "multiqc/multiqc_plots/png/samtools_alignment_plot-pct.png",
-                "multiqc/multiqc_plots/png/vcftools_tstv_by_count.png",
                 "multiqc/multiqc_plots/svg",
-                "multiqc/multiqc_plots/svg/bcftools-stats-subtypes-cnt.svg",
-                "multiqc/multiqc_plots/svg/bcftools-stats-subtypes-pct.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_indel-lengths-cnt.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_indel-lengths-log.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_variant_depths.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Indels.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_SNP.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Transitions.svg",
-                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Transversions.svg",
-                "multiqc/multiqc_plots/svg/mosdepth-coverage-per-contig-single-cnt.svg",
-                "multiqc/multiqc_plots/svg/mosdepth-coverage-per-contig-single-pct.svg",
-                "multiqc/multiqc_plots/svg/mosdepth-cumcoverage-dist-id.svg",
-                "multiqc/multiqc_plots/svg/samtools-stats-dp.svg",
-                "multiqc/multiqc_plots/svg/samtools_alignment_plot-cnt.svg",
-                "multiqc/multiqc_plots/svg/samtools_alignment_plot-pct.svg",
-                "multiqc/multiqc_plots/svg/vcftools_tstv_by_count.svg",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",
                 "pipeline_info/nf_core_sarek_software_mqc_versions.yml",
@@ -712,7 +624,7 @@
                 "reports/bcftools",
                 "reports/bcftools/mutect2",
                 "reports/bcftools/mutect2/sample2",
-                "reports/bcftools/mutect2/sample2/sample2.mutect2.bcftools_stats.txt",
+                "reports/bcftools/mutect2/sample2/sample2.mutect2.filtered.bcftools_stats.txt",
                 "reports/mosdepth",
                 "reports/mosdepth/sample2",
                 "reports/mosdepth/sample2/sample2.recal.mosdepth.global.dist.txt",
@@ -728,13 +640,16 @@
                 "reports/vcftools",
                 "reports/vcftools/mutect2",
                 "reports/vcftools/mutect2/sample2",
-                "reports/vcftools/mutect2/sample2/sample2.mutect2.FILTER.summary",
-                "reports/vcftools/mutect2/sample2/sample2.mutect2.TsTv.count",
-                "reports/vcftools/mutect2/sample2/sample2.mutect2.TsTv.qual",
+                "reports/vcftools/mutect2/sample2/sample2.mutect2.filtered.FILTER.summary",
+                "reports/vcftools/mutect2/sample2/sample2.mutect2.filtered.TsTv.count",
+                "reports/vcftools/mutect2/sample2/sample2.mutect2.filtered.TsTv.qual",
                 "variant_calling",
                 "variant_calling/mutect2",
                 "variant_calling/mutect2/sample2",
                 "variant_calling/mutect2/sample2/sample2.mutect2.artifactprior.tar.gz",
+                "variant_calling/mutect2/sample2/sample2.mutect2.filtered.vcf.gz",
+                "variant_calling/mutect2/sample2/sample2.mutect2.filtered.vcf.gz.filteringStats.tsv",
+                "variant_calling/mutect2/sample2/sample2.mutect2.filtered.vcf.gz.tbi",
                 "variant_calling/mutect2/sample2/sample2.mutect2.vcf.gz",
                 "variant_calling/mutect2/sample2/sample2.mutect2.vcf.gz.stats",
                 "variant_calling/mutect2/sample2/sample2.mutect2.vcf.gz.tbi"
@@ -746,7 +661,7 @@
                 "multiqc_citations.txt:md5,d40980f61eb64026d58102841b7f3860",
                 "samtools-stats-dp.txt:md5,6618ece77181051a58275f504f67ea5b",
                 "samtools_alignment_plot.txt:md5,6136e5e1d072f166f280fb79424c392f",
-                "sample2.mutect2.bcftools_stats.txt:md5,c275ee76762a37053d43f4e290485af8",
+                "sample2.mutect2.filtered.bcftools_stats.txt:md5,b204196dee0fc69cbdabc35c805f8b73",
                 "sample2.recal.mosdepth.global.dist.txt:md5,f2dcd00a64947c49e8e4b93c2f4fbf27",
                 "sample2.recal.mosdepth.region.dist.txt:md5,f2dcd00a64947c49e8e4b93c2f4fbf27",
                 "sample2.recal.mosdepth.summary.txt:md5,b0b47739dcafeeb1a9e6218b8abca1e0",
@@ -754,24 +669,23 @@
                 "sample2.recal.per-base.bed.gz.csi:md5,cfb07b0ba46e8468b4342edb243536f3",
                 "sample2.recal.regions.bed.gz:md5,fb0efeba20ea272b7b709cf65246689e",
                 "sample2.recal.regions.bed.gz.csi:md5,e8452848671e9e5c147ff4cceee944af",
-                "sample2.mutect2.FILTER.summary:md5,08f06620a8dcc70115bdde9137a91008",
-                "sample2.mutect2.TsTv.count:md5,0d59dcbdb127be60909111958ff7b5f5",
+                "sample2.mutect2.filtered.FILTER.summary:md5,ab6f85de19646115fb226a1b69cf47f1",
+                "sample2.mutect2.filtered.TsTv.count:md5,0d59dcbdb127be60909111958ff7b5f5",
+                "sample2.mutect2.filtered.vcf.gz.filteringStats.tsv:md5,1112e7ab1ede97f77561dae02e9f2af1",
                 "sample2.mutect2.vcf.gz.stats:md5,76f749c53212d72e98801f6030fbf8a6"
             ],
             "No BAM files",
             "No CRAM files",
             [
+                "sample2.mutect2.filtered.vcf.gz:md5,c5002fcbcf76c8af2593eb062487d0f4",
                 "sample2.mutect2.vcf.gz:md5,4a803cf2687fc368a8c4eef5e2fc8c9c"
             ],
-            [
-                "WARN: If Mutect2 is specified without a germline resource, no filtering will be done.",
-                "WARN: No Panel-of-normal was specified for Mutect2."
-            ]
+            "No warnings"
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2025-12-15T23:30:58.725141411"
+        "timestamp": "2026-03-09T17:25:30.205556"
     }
 }


### PR DESCRIPTION
## Summary

Closes #1546

- Fix `FilterMutectCalls` being silently skipped for both tumor-only and somatic Mutect2 when no `germline_resource` is provided
- Use `remainder: true` on the segmentation/contamination `.join()` calls so items pass through with `null` when those channels are empty, defaulting to `[]` (these are optional GATK inputs)
- Update the `log.warn` message to reflect that filtering now runs without contamination estimation, rather than being skipped entirely

### Root cause

When no `germline_resource` is provided, `GetPileupSummaries` is skipped (input channel filtered empty), so `CalculateContamination` produces nothing, leaving `seg`/`cont` channels empty. The `.join()` with empty channels produces zero items, silently preventing `FilterMutectCalls` from ever running.

## Test plan

- [ ] Run `nf-test` for `variant_calling_mutect2` (tumor-only without germline resource)
- [ ] Run `nf-test` for `variant_calling_mutect2` (somatic without germline resource)
- [ ] Run `nf-test` for `joint_calling_mutect2`
- [ ] Verify FilterMutectCalls output VCFs are produced in all cases
- [ ] Snapshot updates expected for warning message change

🤖 Generated with [Claude Code](https://claude.com/claude-code)