### PR TITLE
chore(modules): sync all sentieon/* modules to nf-core/modules@7ad1622c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#2055](https://github.com/nf-core/sarek/pull/2055) - Sort final vcf in varlociraptor sbwfs and update varlociraptor
 - [#2141](https://github.com/nf-core/sarek/pull/2141) - Update snpeff
-- [#2188](https://github.com/nf-core/sarek/pull/2188) - Update all `sentieon/*` modules to `nf-core/modules@7ad1622c`. Brings in `--interval` honouring in `sentieon/gvcftyper`, multi-`--resource:` parsing in `sentieon/varcal`, and the new `topic: versions` emission across all sentieon modules. Removed the now-broken explicit `versions.mix(SENTIEON_*.out.versions)` calls; sarek's `softwareVersionsToYAML` picks up the topic emissions via `channel.topic("versions")`.
 
 ### Fixed
 
@@ -32,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Dependency    | Old version | New version |
 | ------------- | ----------- | ----------- |
 | multiqc       | 1.33        | 1.35        |
-| snpeff        | 5.3a        | 5.4a        |
+| snpeff        | 5.3a        | 5.4c        |
 | varlociraptor | 8.7.4       | 8.9.3       |
 | yte           | 1.9.0       | 1.9.4       |
 
@@ -62,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2159](https://github.com/nf-core/sarek/pull/2159) - Fix strict syntax errors
 - [#2170](https://github.com/nf-core/sarek/pull/2170) - Update dependencies
 - [#2173](https://github.com/nf-core/sarek/pull/2173) - Update MultiQC
+- [#2188](https://github.com/nf-core/sarek/pull/2188) - Update all `sentieon/*` modules to `nf-core/modules@7ad1622c`. Brings in `--interval` honouring in `sentieon/gvcftyper`, multi-`--resource:` parsing in `sentieon/varcal`, and the new `topic: versions` emission across all sentieon modules. Removed the now-broken explicit `versions.mix(SENTIEON_*.out.versions)` calls; sarek's `softwareVersionsToYAML` picks up the topic emissions via `channel.topic("versions")`.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#2055](https://github.com/nf-core/sarek/pull/2055) - Sort final vcf in varlociraptor sbwfs and update varlociraptor
 - [#2141](https://github.com/nf-core/sarek/pull/2141) - Update snpeff
-- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Update all `sentieon/*` modules to `nf-core/modules@7ad1622c`. Brings in `--interval` honouring in `sentieon/gvcftyper`, multi-`--resource:` parsing in `sentieon/varcal`, and the new `topic: versions` emission across all sentieon modules. Removed the now-broken explicit `versions.mix(SENTIEON_*.out.versions)` calls; sarek's `softwareVersionsToYAML` picks up the topic emissions via `channel.topic("versions")`.
+- [#2188](https://github.com/nf-core/sarek/pull/2188) - Update all `sentieon/*` modules to `nf-core/modules@7ad1622c`. Brings in `--interval` honouring in `sentieon/gvcftyper`, multi-`--resource:` parsing in `sentieon/varcal`, and the new `topic: versions` emission across all sentieon modules. Removed the now-broken explicit `versions.mix(SENTIEON_*.out.versions)` calls; sarek's `softwareVersionsToYAML` picks up the topic emissions via `channel.topic("versions")`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#2055](https://github.com/nf-core/sarek/pull/2055) - Sort final vcf in varlociraptor sbwfs and update varlociraptor
 - [#2141](https://github.com/nf-core/sarek/pull/2141) - Update snpeff
+- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Update all `sentieon/*` modules to `nf-core/modules@7ad1622c`. Brings in `--interval` honouring in `sentieon/gvcftyper`, multi-`--resource:` parsing in `sentieon/varcal`, and the new `topic: versions` emission across all sentieon modules. Removed the now-broken explicit `versions.mix(SENTIEON_*.out.versions)` calls; sarek's `softwareVersionsToYAML` picks up the topic emissions via `channel.topic("versions")`.
 
 ### Fixed
 

--- a/modules.json
+++ b/modules.json
@@ -508,12 +508,12 @@
                     },
                     "snpeff/download": {
                         "branch": "master",
-                        "git_sha": "ab50ae0a7c0714bf8b13918c1b7af732002c244d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "snpeff/snpeff": {
                         "branch": "master",
-                        "git_sha": "ab50ae0a7c0714bf8b13918c1b7af732002c244d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules", "vcf_annotate_snpeff"]
                     },
                     "snpsift/annmem": {

--- a/modules.json
+++ b/modules.json
@@ -617,12 +617,12 @@
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
-                        "git_sha": "271e7fc14eb1320364416d996fb077421f3faed2",
+                        "git_sha": "a3fb7351b1fdb2b1de282b765816bbea190e86a8",
                         "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
-                        "git_sha": "4b406a74dc0449c0401ed87d5bfff4252fd277fd",
+                        "git_sha": "a7b27fd25bfa8dcc07d299e88bd790585901a436",
                         "installed_by": ["subworkflows"]
                     },
                     "vcf_annotate_snpeff": {

--- a/modules.json
+++ b/modules.json
@@ -388,17 +388,17 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "cd0ad387832473916b1f1c80c2ca673a7883bf94",
+                        "git_sha": "9656d955b700a8707c4a67821ab056f8c1095675",
                         "installed_by": ["modules"]
                     },
                     "muse/call": {
                         "branch": "master",
-                        "git_sha": "2ae2df92d6f5ac2d54058d0cece928e13d241912",
+                        "git_sha": "e3933b213cdb1375f793eb06a23fe2edc80a0b5b",
                         "installed_by": ["modules"]
                     },
                     "muse/sump": {
                         "branch": "master",
-                        "git_sha": "2ae2df92d6f5ac2d54058d0cece928e13d241912",
+                        "git_sha": "e3933b213cdb1375f793eb06a23fe2edc80a0b5b",
                         "installed_by": ["modules"]
                     },
                     "ngscheckmate/ncm": {
@@ -408,12 +408,12 @@
                     },
                     "parabricks/fq2bam": {
                         "branch": "master",
-                        "git_sha": "f0b0dc3c3f001b1b7bf814a3c353baecbab17ea1",
+                        "git_sha": "1e4345f4e18eca1985e35562e8f5d29caf7f8206",
                         "installed_by": ["modules"]
                     },
                     "rbt/vcfsplit": {
                         "branch": "master",
-                        "git_sha": "117bda90be326bcff5cb2286c7988a4caa588b5d",
+                        "git_sha": "3e5034548e2398b006a9e01fb82673ffa5c83d9f",
                         "installed_by": ["modules"]
                     },
                     "samtools/bam2fq": {
@@ -463,57 +463,57 @@
                     },
                     "sentieon/applyvarcal": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/bwamem": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/dedup": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/dnamodelapply": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/dnascope": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/gvcftyper": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/haplotyper": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/tnscope": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "sentieon/varcal": {
                         "branch": "master",
-                        "git_sha": "256557155b2439c5d551f1a668bf6a7ff6b10f93",
+                        "git_sha": "7ad1622c68ea87dd3a16bcc4b82cd5d5878fffd9",
                         "installed_by": ["modules"]
                     },
                     "snpeff/download": {
                         "branch": "master",
-                        "git_sha": "ab50ae0a7c0714bf8b13918c1b7af732002c244d",
+                        "git_sha": "b966311b31f51b65e87f124d08f948fec019787d",
                         "installed_by": ["modules"]
                     },
                     "snpeff/snpeff": {
                         "branch": "master",
-                        "git_sha": "51d2d20973eca80048a9490339e8b421db122908",
+                        "git_sha": "b966311b31f51b65e87f124d08f948fec019787d",
                         "installed_by": ["modules", "vcf_annotate_snpeff"]
                     },
                     "snpsift/annmem": {
@@ -548,7 +548,7 @@
                     },
                     "tabix/bgziptabix": {
                         "branch": "master",
-                        "git_sha": "91a902fb32d6717da38a9694eb4ad3fade53a8db",
+                        "git_sha": "f2cfcf9d3f6a2d123e6c44aefa788aa232204a7a",
                         "installed_by": ["modules", "vcf_annotate_snpeff"]
                     },
                     "tabix/tabix": {
@@ -573,17 +573,17 @@
                     },
                     "varlociraptor/callvariants": {
                         "branch": "master",
-                        "git_sha": "5ae3c74e09c529c5c768aa89397e490ba4728219",
+                        "git_sha": "36cf856b511b7623a2d90788c9afa2a655fe6d43",
                         "installed_by": ["modules"]
                     },
                     "varlociraptor/estimatealignmentproperties": {
                         "branch": "master",
-                        "git_sha": "5ae3c74e09c529c5c768aa89397e490ba4728219",
+                        "git_sha": "36cf856b511b7623a2d90788c9afa2a655fe6d43",
                         "installed_by": ["modules"]
                     },
                     "varlociraptor/preprocess": {
                         "branch": "master",
-                        "git_sha": "5ae3c74e09c529c5c768aa89397e490ba4728219",
+                        "git_sha": "36cf856b511b7623a2d90788c9afa2a655fe6d43",
                         "installed_by": ["modules"]
                     },
                     "vcflib/vcffilter": {
@@ -598,7 +598,7 @@
                     },
                     "yte": {
                         "branch": "master",
-                        "git_sha": "c734c101f0010ec13ed9bbf578477962c32f9cc3",
+                        "git_sha": "b9947fd7a338e1087a5c386ac7192588d3059122",
                         "installed_by": ["modules"]
                     }
                 }
@@ -617,17 +617,17 @@
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
-                        "git_sha": "f0b535b3ae20080f8db03dd5388876ad1ec29d70",
+                        "git_sha": "271e7fc14eb1320364416d996fb077421f3faed2",
                         "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
-                        "git_sha": "fdc08b8b1ae74f56686ce21f7ea11ad11990ce57",
+                        "git_sha": "4b406a74dc0449c0401ed87d5bfff4252fd277fd",
                         "installed_by": ["subworkflows"]
                     },
                     "vcf_annotate_snpeff": {
                         "branch": "master",
-                        "git_sha": "23004c9c64013c90b7d835621ef4cdeff19a1427",
+                        "git_sha": "b966311b31f51b65e87f124d08f948fec019787d",
                         "installed_by": ["subworkflows"]
                     }
                 }

--- a/modules.json
+++ b/modules.json
@@ -388,17 +388,17 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "9656d955b700a8707c4a67821ab056f8c1095675",
+                        "git_sha": "cd0ad387832473916b1f1c80c2ca673a7883bf94",
                         "installed_by": ["modules"]
                     },
                     "muse/call": {
                         "branch": "master",
-                        "git_sha": "e3933b213cdb1375f793eb06a23fe2edc80a0b5b",
+                        "git_sha": "2ae2df92d6f5ac2d54058d0cece928e13d241912",
                         "installed_by": ["modules"]
                     },
                     "muse/sump": {
                         "branch": "master",
-                        "git_sha": "e3933b213cdb1375f793eb06a23fe2edc80a0b5b",
+                        "git_sha": "2ae2df92d6f5ac2d54058d0cece928e13d241912",
                         "installed_by": ["modules"]
                     },
                     "ngscheckmate/ncm": {
@@ -408,12 +408,12 @@
                     },
                     "parabricks/fq2bam": {
                         "branch": "master",
-                        "git_sha": "1e4345f4e18eca1985e35562e8f5d29caf7f8206",
+                        "git_sha": "f0b0dc3c3f001b1b7bf814a3c353baecbab17ea1",
                         "installed_by": ["modules"]
                     },
                     "rbt/vcfsplit": {
                         "branch": "master",
-                        "git_sha": "3e5034548e2398b006a9e01fb82673ffa5c83d9f",
+                        "git_sha": "117bda90be326bcff5cb2286c7988a4caa588b5d",
                         "installed_by": ["modules"]
                     },
                     "samtools/bam2fq": {
@@ -508,12 +508,12 @@
                     },
                     "snpeff/download": {
                         "branch": "master",
-                        "git_sha": "b966311b31f51b65e87f124d08f948fec019787d",
+                        "git_sha": "ab50ae0a7c0714bf8b13918c1b7af732002c244d",
                         "installed_by": ["modules"]
                     },
                     "snpeff/snpeff": {
                         "branch": "master",
-                        "git_sha": "b966311b31f51b65e87f124d08f948fec019787d",
+                        "git_sha": "ab50ae0a7c0714bf8b13918c1b7af732002c244d",
                         "installed_by": ["modules", "vcf_annotate_snpeff"]
                     },
                     "snpsift/annmem": {
@@ -548,8 +548,8 @@
                     },
                     "tabix/bgziptabix": {
                         "branch": "master",
-                        "git_sha": "f2cfcf9d3f6a2d123e6c44aefa788aa232204a7a",
-                        "installed_by": ["modules", "vcf_annotate_snpeff"]
+                        "git_sha": "23004c9c64013c90b7d835621ef4cdeff19a1427",
+                        "installed_by": ["vcf_annotate_snpeff"]
                     },
                     "tabix/tabix": {
                         "branch": "master",
@@ -573,17 +573,17 @@
                     },
                     "varlociraptor/callvariants": {
                         "branch": "master",
-                        "git_sha": "36cf856b511b7623a2d90788c9afa2a655fe6d43",
+                        "git_sha": "5ae3c74e09c529c5c768aa89397e490ba4728219",
                         "installed_by": ["modules"]
                     },
                     "varlociraptor/estimatealignmentproperties": {
                         "branch": "master",
-                        "git_sha": "36cf856b511b7623a2d90788c9afa2a655fe6d43",
+                        "git_sha": "5ae3c74e09c529c5c768aa89397e490ba4728219",
                         "installed_by": ["modules"]
                     },
                     "varlociraptor/preprocess": {
                         "branch": "master",
-                        "git_sha": "36cf856b511b7623a2d90788c9afa2a655fe6d43",
+                        "git_sha": "5ae3c74e09c529c5c768aa89397e490ba4728219",
                         "installed_by": ["modules"]
                     },
                     "vcflib/vcffilter": {
@@ -598,7 +598,7 @@
                     },
                     "yte": {
                         "branch": "master",
-                        "git_sha": "b9947fd7a338e1087a5c386ac7192588d3059122",
+                        "git_sha": "c734c101f0010ec13ed9bbf578477962c32f9cc3",
                         "installed_by": ["modules"]
                     }
                 }
@@ -627,7 +627,7 @@
                     },
                     "vcf_annotate_snpeff": {
                         "branch": "master",
-                        "git_sha": "b966311b31f51b65e87f124d08f948fec019787d",
+                        "git_sha": "23004c9c64013c90b7d835621ef4cdeff19a1427",
                         "installed_by": ["subworkflows"]
                     }
                 }

--- a/modules/nf-core/sentieon/applyvarcal/environment.yml
+++ b/modules/nf-core/sentieon/applyvarcal/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/applyvarcal/main.nf
+++ b/modules/nf-core/sentieon/applyvarcal/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_APPLYVARCAL {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(vcf), path(vcf_tbi), path(recal), path(recal_index), path(tranches)
@@ -16,7 +16,7 @@ process SENTIEON_APPLYVARCAL {
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
     tuple val(meta), path("*.tbi"),    emit: tbi
-    path "versions.yml",               emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -41,11 +41,6 @@ process SENTIEON_APPLYVARCAL {
         --tranches_file ${tranches} \\
         ${args2} \\
         ${prefix}.vcf.gz
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
@@ -53,10 +48,5 @@ process SENTIEON_APPLYVARCAL {
     """
     echo | gzip > ${prefix}.vcf.gz
     touch ${prefix}.vcf.gz.tbi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/applyvarcal/meta.yml
+++ b/modules/nf-core/sentieon/applyvarcal/meta.yml
@@ -96,13 +96,28 @@ output:
           description: Index of recalibrated vcf file.
           pattern: "*vcf.gz.tbi"
           ontologies: []
+  versions_sentieon:
+    - - "${task.process}":
+          type: string
+          description: The process the versions were collected from
+      - "sentieon":
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions.
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - "${task.process}":
+          type: string
+          description: The process the versions were collected from
+      - "sentieon":
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@assp8200"
 maintainers:

--- a/modules/nf-core/sentieon/bwamem/environment.yml
+++ b/modules/nf-core/sentieon/bwamem/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/bwamem/main.nf
+++ b/modules/nf-core/sentieon/bwamem/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_BWAMEM {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(reads)
@@ -16,7 +16,8 @@ process SENTIEON_BWAMEM {
 
     output:
     tuple val(meta), path("${prefix}"), path("${prefix}.{bai,crai}"), emit: bam_and_bai
-    path "versions.yml",                                              emit: versions
+    tuple val("${task.process}"), val('bwa'), eval('sentieon bwa 2>&1 | sed -n "s/^Version: *//p"'), topic: versions, emit: versions_bwa
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -45,26 +46,13 @@ process SENTIEON_BWAMEM {
     if [[ "${prefix}" == *.cram ]]; then
         rm -f "${prefix}.bai"
     fi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(sentieon bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}.bam"
     index = prefix.tokenize('.')[-1] == "bam" ? "bai" : "crai"
-
     """
     touch ${prefix}
     touch ${prefix}.${index}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(sentieon bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/bwamem/meta.yml
+++ b/modules/nf-core/sentieon/bwamem/meta.yml
@@ -73,13 +73,48 @@ output:
           description: BAM file with corresponding index.
           pattern: "*.{bam,bai}"
           ontologies: []
+  versions_bwa:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bwa:
+          type: string
+          description: The tool name
+      - 'sentieon bwa 2>&1 | sed -n "s/^Version: *//p"':
+          type: string
+          description: The command used to generate the version of the tool
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: string
+          description: The command used to generate the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bwa:
+          type: string
+          description: The tool name
+      - 'sentieon bwa 2>&1 | sed -n "s/^Version: *//p"':
+          type: string
+          description: The command used to generate the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: string
+          description: The command used to generate the version of the tool
+
 authors:
   - "@asp8200"
 maintainers:

--- a/modules/nf-core/sentieon/dedup/environment.yml
+++ b/modules/nf-core/sentieon/dedup/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/dedup/main.nf
+++ b/modules/nf-core/sentieon/dedup/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_DEDUP {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -21,7 +21,7 @@ process SENTIEON_DEDUP {
     tuple val(meta), path("*.score"),               emit: score
     tuple val(meta), path("*.metrics"),             emit: metrics
     tuple val(meta), path("*.metrics.multiqc.tsv"), emit: metrics_multiqc_tsv
-    path "versions.yml",                            emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,8 +32,8 @@ process SENTIEON_DEDUP {
     def args3 = task.ext.args3 ?: ''
     def args4 = task.ext.args4 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}.cram"
-    def metrics = task.ext.metrics ?: "${prefix}.metrics"
-    def input_list = bam.collect { "-i ${it}" }.join(' ')
+    def metrics = "${prefix}.metrics"
+    def input_list = bam.collect {input -> "-i ${input}" }.join(' ')
     def prefix_basename = prefix.substring(0, prefix.lastIndexOf("."))
     def sentieonLicense = secrets.SENTIEON_LICENSE_BASE64
         ? "export SENTIEON_LICENSE=\$(mktemp);echo -e \"${secrets.SENTIEON_LICENSE_BASE64}\" | base64 -d > \$SENTIEON_LICENSE; "
@@ -47,16 +47,11 @@ process SENTIEON_DEDUP {
     # This following tsv-file is produced in order to get a proper tsv-file with Dedup-metrics for importing in MultiQC as "custom content".
     # It should be removed once MultiQC has a module for displaying Dedup-metrics.
     head -3 ${metrics} > ${metrics}.multiqc.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}.cram"
-    def metrics = task.ext.metrics ?: "${prefix}.metrics"
+    def metrics = "${prefix}.metrics"
     def prefix_basename = prefix.substring(0, prefix.lastIndexOf("."))
 
     """
@@ -66,10 +61,5 @@ process SENTIEON_DEDUP {
     touch "${metrics}"
     touch "${metrics}.multiqc.tsv"
     touch "${prefix_basename}.score"
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/dedup/meta.yml
+++ b/modules/nf-core/sentieon/dedup/meta.yml
@@ -133,13 +133,28 @@ output:
           pattern: "*.metrics.multiqc.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@asp8200"
 maintainers:

--- a/modules/nf-core/sentieon/dnamodelapply/environment.yml
+++ b/modules/nf-core/sentieon/dnamodelapply/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/dnamodelapply/main.nf
+++ b/modules/nf-core/sentieon/dnamodelapply/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_DNAMODELAPPLY {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(vcf), path(idx)
@@ -17,7 +17,7 @@ process SENTIEON_DNAMODELAPPLY {
     output:
     tuple val(meta), path("*.vcf.gz"),     emit: vcf
     tuple val(meta), path("*.vcf.gz.tbi"), emit: tbi
-    path "versions.yml",                   emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -40,10 +40,6 @@ process SENTIEON_DNAMODELAPPLY {
         -v ${vcf} \\
         ${prefix}.vcf.gz
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
@@ -51,10 +47,5 @@ process SENTIEON_DNAMODELAPPLY {
     """
     echo | gzip > ${prefix}.vcf.gz
     touch ${prefix}.vcf.gz.tbi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g" )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/dnamodelapply/meta.yml
+++ b/modules/nf-core/sentieon/dnamodelapply/meta.yml
@@ -82,13 +82,27 @@ output:
           description: Index of the input VCF file
           pattern: "*.{tbi}"
           ontologies: []
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: string
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@ramprasadn"
 maintainers:

--- a/modules/nf-core/sentieon/dnascope/environment.yml
+++ b/modules/nf-core/sentieon/dnascope/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/dnascope/main.nf
+++ b/modules/nf-core/sentieon/dnascope/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_DNASCOPE {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(bam), path(bai), path(intervals)
@@ -26,7 +26,7 @@ process SENTIEON_DNASCOPE {
     // these output-files have to have the extension ".vcf.gz", otherwise the subsequent GATK-MergeVCFs will fail.
     tuple val(meta), path("*.g.vcf.gz"),              emit: gvcf,     optional: true
     tuple val(meta), path("*.g.vcf.gz.tbi"),          emit: gvcf_tbi, optional: true
-    path "versions.yml",                              emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -63,12 +63,14 @@ process SENTIEON_DNASCOPE {
     """
     ${sentieonLicense}
 
-    sentieon driver ${args} -r ${fasta} -t ${task.cpus} -i ${bam} ${interval} ${vcf_cmd} ${gvcf_cmd}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
+    sentieon driver \\
+        ${args} \\
+        -r ${fasta} \\
+        -t ${task.cpus} \\
+        -i ${bam} \\
+        ${interval} \\
+        ${vcf_cmd} \\
+        ${gvcf_cmd}
     """
 
     stub:
@@ -79,10 +81,5 @@ process SENTIEON_DNASCOPE {
     echo | gzip > ${prefix}.unfiltered.vcf.gz
     touch ${prefix}.unfiltered.vcf.gz.tbi
     ${gvcf_cmd}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g" )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/dnascope/meta.yml
+++ b/modules/nf-core/sentieon/dnascope/meta.yml
@@ -143,13 +143,27 @@ output:
           description: Index of GVCF file
           pattern: "*.g.vcf.gz.tbi"
           ontologies: []
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: string
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@ramprasadn"
 maintainers:

--- a/modules/nf-core/sentieon/gvcftyper/environment.yml
+++ b/modules/nf-core/sentieon/gvcftyper/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/gvcftyper/main.nf
+++ b/modules/nf-core/sentieon/gvcftyper/main.nf
@@ -4,41 +4,44 @@ process SENTIEON_GVCFTYPER {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(gvcfs), path(tbis), path(intervals)
-    tuple val(meta1), path(fasta)
-    tuple val(meta2), path(fai)
-    tuple val(meta3), path(dbsnp)
-    tuple val(meta4), path(dbsnp_tbi)
+    tuple val(meta2), path(fasta)
+    tuple val(meta3), path(fai)
+    tuple val(meta4), path(dbsnp)
+    tuple val(meta5), path(dbsnp_tbi)
 
     output:
     tuple val(meta), path("*.vcf.gz"),     emit: vcf_gz
     tuple val(meta), path("*.vcf.gz.tbi"), emit: vcf_gz_tbi
-    path ("versions.yml"),                 emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}_genotyped"
     def gvcfs_input = '-v ' + gvcfs.join(' -v ')
     def dbsnp_cmd = dbsnp ? "--dbsnp ${dbsnp}" : ""
+    def interval_command = intervals ? "--interval ${intervals}" : ""
     def sentieonLicense = secrets.SENTIEON_LICENSE_BASE64
         ? "export SENTIEON_LICENSE=\$(mktemp);echo -e \"${secrets.SENTIEON_LICENSE_BASE64}\" | base64 -d > \$SENTIEON_LICENSE; "
         : ""
     """
     ${sentieonLicense}
 
-    sentieon driver -r ${fasta} --algo GVCFtyper ${gvcfs_input} ${dbsnp_cmd} ${prefix}.vcf.gz
+    sentieon driver \\
+        -r ${fasta} \\
+        ${interval_command} \\
+        --algo GVCFtyper \\
+        ${gvcfs_input} \\
+        ${dbsnp_cmd} \\
+        ${prefix}.vcf.gz
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
@@ -47,9 +50,5 @@ process SENTIEON_GVCFTYPER {
     echo "" | gzip >${prefix}.vcf.gz
     touch ${prefix}.vcf.gz.tbi
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/gvcftyper/meta.yml
+++ b/modules/nf-core/sentieon/gvcftyper/meta.yml
@@ -33,10 +33,10 @@ input:
         ontologies: []
     - intervals:
         type: file
-        description: Interval file with the genomic regions included in the library
-          (optional)
+        description: Interval file with the genomic regions included in the
+          library (optional)
         ontologies: []
-  - - meta1:
+  - - meta2:
         type: map
         description: |
           Groovy Map containing sample information
@@ -46,7 +46,7 @@ input:
         description: Reference fasta file
         pattern: "*.fasta"
         ontologies: []
-  - - meta2:
+  - - meta3:
         type: map
         description: |
           Groovy Map containing sample information
@@ -56,7 +56,7 @@ input:
         description: Reference fasta index file
         pattern: "*.fai"
         ontologies: []
-  - - meta3:
+  - - meta4:
         type: map
         description: |
           Groovy Map containing sample information
@@ -66,8 +66,8 @@ input:
         description: dbSNP VCF file
         pattern: "*.vcf.gz"
         ontologies:
-          - edam: http://edamontology.org/format_3989 # GZIP format
-  - - meta4:
+          - edam: http://edamontology.org/format_3989
+  - - meta5:
         type: map
         description: |
           Groovy Map containing sample information
@@ -89,7 +89,7 @@ output:
           description: VCF file
           pattern: "*.vcf.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP format
+            - edam: http://edamontology.org/format_3989
   vcf_gz_tbi:
     - - meta:
           type: map
@@ -101,13 +101,27 @@ output:
           description: VCF index file
           pattern: "*.vcf.gz.tbi"
           ontologies: []
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: eval
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version | sed "s/.*-//g":
+          type: eval
+          description: The command used to generate the version of the tool
 authors:
   - "@asp8200"
 maintainers:

--- a/modules/nf-core/sentieon/haplotyper/environment.yml
+++ b/modules/nf-core/sentieon/haplotyper/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/haplotyper/main.nf
+++ b/modules/nf-core/sentieon/haplotyper/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_HAPLOTYPER {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals), path(recal_table)
@@ -24,7 +24,7 @@ process SENTIEON_HAPLOTYPER {
     // these output-files have to have the extension ".vcf.gz", otherwise the subsequent GATK-MergeVCFs will fail.
     tuple val(meta), path("*.g.vcf.gz"),              emit: gvcf,     optional: true
     tuple val(meta), path("*.g.vcf.gz.tbi"),          emit: gvcf_tbi, optional: true
-    path "versions.yml",                              emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -34,7 +34,7 @@ process SENTIEON_HAPLOTYPER {
     def args2 = task.ext.args2 ?: '' // options for the vcf generation
     def args3 = task.ext.args3 ?: '' // options for the gvcf generation
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input_list = input instanceof List ? input.collect { "-i ${it}" }.join(' ') : "-i ${input}"
+    def input_list = input instanceof List ? input.collect {in -> "-i ${in}" }.join(' ') : "-i ${input}"
     def dbsnp_command = dbsnp ? "-d ${dbsnp} " : ""
     def interval_command = intervals ? "--interval ${intervals}" : ""
     def recal_table_command = recal_table ? "-q ${recal_table}" : ""
@@ -70,11 +70,6 @@ process SENTIEON_HAPLOTYPER {
         ${recal_table_command} \\
         ${vcf_cmd} \\
         ${gvcf_cmd}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
@@ -84,10 +79,5 @@ process SENTIEON_HAPLOTYPER {
     touch ${prefix}.unfiltered.vcf.gz.tbi
     echo "" | gzip > ${prefix}.g.vcf.gz
     touch ${prefix}.g.vcf.gz.tbi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/haplotyper/meta.yml
+++ b/modules/nf-core/sentieon/haplotyper/meta.yml
@@ -131,13 +131,27 @@ output:
           description: Index of GVCF file
           pattern: "*.g.vcf.gz.tbi"
           ontologies: []
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@asp8200"
 maintainers:

--- a/modules/nf-core/sentieon/tnscope/environment.yml
+++ b/modules/nf-core/sentieon/tnscope/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/tnscope/main.nf
+++ b/modules/nf-core/sentieon/tnscope/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_TNSCOPE {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)
@@ -22,7 +22,7 @@ process SENTIEON_TNSCOPE {
     output:
     tuple val(meta), path("*.vcf.gz"),     emit: vcf
     tuple val(meta), path("*.vcf.gz.tbi"), emit: index
-    path "versions.yml",                   emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -35,7 +35,7 @@ process SENTIEON_TNSCOPE {
     def dbsnp_str = dbsnp ? "--dbsnp ${dbsnp}" : ''
     def pon_str = pon ? "--pon ${pon}" : ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def inputs = input.collect { "-i ${it}" }.join(" ")
+    def inputs = input.collect {in -> "-i ${in}" }.join(" ")
     def sentieonLicense = secrets.SENTIEON_LICENSE_BASE64
         ? "export SENTIEON_LICENSE=\$(mktemp);echo -e \"${secrets.SENTIEON_LICENSE_BASE64}\" | base64 -d > \$SENTIEON_LICENSE; "
         : ""
@@ -55,11 +55,6 @@ process SENTIEON_TNSCOPE {
         ${dbsnp_str} \\
         ${pon_str} \\
         ${prefix}.vcf.gz
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
@@ -67,10 +62,5 @@ process SENTIEON_TNSCOPE {
     """
     echo | gzip > ${prefix}.vcf.gz
     touch ${prefix}.vcf.gz.tbi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g" )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/tnscope/meta.yml
+++ b/modules/nf-core/sentieon/tnscope/meta.yml
@@ -143,13 +143,27 @@ output:
           description: Index of the VCF file
           pattern: "*.vcf.gz.tbi"
           ontologies: []
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@ramprasadn"
 maintainers:

--- a/modules/nf-core/sentieon/varcal/environment.yml
+++ b/modules/nf-core/sentieon/varcal/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sentieon=202503.01
+  - bioconda::sentieon=202503.02

--- a/modules/nf-core/sentieon/varcal/main.nf
+++ b/modules/nf-core/sentieon/varcal/main.nf
@@ -4,9 +4,9 @@ process SENTIEON_VARCAL {
     label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1dfe59ef66d7326b43db9ab1f39ce6220b358a311078c949a208f9c9815d4e/data'
-        : 'community.wave.seqera.io/library/sentieon:202503.01--1863def31ed8e4d5'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73e9111552beb76e2ad3ad89eb75bed162d7c5b85b2433723ecb4fc96a02674a/data'
+        : 'community.wave.seqera.io/library/sentieon:202503.02--def60555294d04fa'}"
 
     input:
     tuple val(meta), path(vcf), path(tbi)
@@ -21,7 +21,7 @@ process SENTIEON_VARCAL {
     tuple val(meta), path("*.idx"),      emit: idx
     tuple val(meta), path("*.tranches"), emit: tranches
     tuple val(meta), path("*plots.R"),   emit: plots, optional: true
-    path "versions.yml",                 emit: versions
+    tuple val("${task.process}"), val('sentieon'), eval('sentieon driver --version | sed "s/.*-//g"'), topic: versions, emit: versions_sentieon
 
     when:
     task.ext.when == null || task.ext.when
@@ -48,14 +48,18 @@ process SENTIEON_VARCAL {
         labels_command = processedResources.join(' ')
     }
     else if (labels_input instanceof List) {
-        // Process list input
-        def processedResources = labels_input.collect { label ->
-            def cleanedLabel = label.replaceFirst('^--resource:', '')
-            def items = cleanedLabel.split(' ', 2)
-            if (items.size() != 2) {
-                error("Expected the resource string '${cleanedLabel}' to contain two elements separated by a space.")
+        // Each list element may itself contain multiple `--resource:` directives
+        // (e.g. when params.known_indels_vqsr packs both `gatk` and `mills` into
+        // one string), so split each element on `--resource:` just like the
+        // String branch does, then process each individual resource.
+        def processedResources = labels_input.collectMany { label ->
+            label.split('--resource:').findAll().collect { resource_string ->
+                def items = resource_string.split(' ', 2)
+                if (items.size() != 2) {
+                    error("Expected the resource string '${resource_string}' to contain two elements separated by a space.")
+                }
+                "--resource ${items[1]} --resource_param ${items[0].replaceFirst('^--resource:', '')}"
             }
-            "--resource ${items[1]} --resource_param ${items[0].replaceFirst('^--resource:', '')}"
         }
         labels_command = processedResources.join(' ')
     }
@@ -69,17 +73,14 @@ process SENTIEON_VARCAL {
     """
     ${sentieonLicense}
 
-    sentieon driver -r ${fasta}  --algo VarCal \\
+    sentieon driver \\
+        -r ${fasta} \\
+        --algo VarCal \\
         -v ${vcf} \\
         --tranches_file ${prefix}.tranches \\
         ${labels_command} \\
         ${args} \\
         ${prefix}.recal
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 
     stub:
@@ -89,10 +90,5 @@ process SENTIEON_VARCAL {
     touch ${prefix}.idx
     touch ${prefix}.tranches
     touch ${prefix}plots.R
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sentieon/varcal/meta.yml
+++ b/modules/nf-core/sentieon/varcal/meta.yml
@@ -106,14 +106,29 @@ output:
           pattern: "*plots.R"
           ontologies:
             - edam: http://edamontology.org/format_3999 # R script
-  versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@asp8200"
 maintainers:
   - "@asp8200"
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version | sed "s/.*-//g"':
+          type: string
+          description: The command used to generate the version of the tool

--- a/modules/nf-core/snpeff/download/environment.yml
+++ b/modules/nf-core/snpeff/download/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/snpeff
-  - bioconda::snpeff=5.4.0a
+  - bioconda::snpeff=5.4.0c

--- a/modules/nf-core/snpeff/download/main.nf
+++ b/modules/nf-core/snpeff/download/main.nf
@@ -3,9 +3,9 @@ process SNPEFF_DOWNLOAD {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/30/30669e5208952f30d59d0d559928772f082830d01a140a853fff13a2283a17b0/data'
-        : 'community.wave.seqera.io/library/snpeff:5.4.0a--eaf6ce30125b2b17'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/cb/cbd585b788eeafff9b9a018e8775de24eeb6b380d95bb22629a5f14ee3fff519/data'
+        : 'community.wave.seqera.io/library/snpeff:5.4.0c--e08ddc54579e82bd'}"
 
     input:
     tuple val(meta), val(snpeff_db)

--- a/modules/nf-core/snpeff/snpeff/environment.yml
+++ b/modules/nf-core/snpeff/snpeff/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/snpeff
-  - bioconda::snpeff=5.4.0a
+  - bioconda::snpeff=5.4.0c

--- a/modules/nf-core/snpeff/snpeff/main.nf
+++ b/modules/nf-core/snpeff/snpeff/main.nf
@@ -3,9 +3,9 @@ process SNPEFF_SNPEFF {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/30/30669e5208952f30d59d0d559928772f082830d01a140a853fff13a2283a17b0/data'
-        : 'community.wave.seqera.io/library/snpeff:5.4.0a--eaf6ce30125b2b17'}"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/cb/cbd585b788eeafff9b9a018e8775de24eeb6b380d95bb22629a5f14ee3fff519/data'
+        : 'community.wave.seqera.io/library/snpeff:5.4.0c--e08ddc54579e82bd'}"
 
     input:
     tuple val(meta), path(vcf)
@@ -14,9 +14,9 @@ process SNPEFF_SNPEFF {
 
     output:
     tuple val(meta), path("*.ann.vcf"), emit: vcf
-    tuple val(meta), path("*.csv"), emit: report
-    tuple val(meta), path("*.html"), emit: summary_html
-    tuple val(meta), path("*.genes.txt"), emit: genes_txt
+    tuple val(meta), val("${task.process}"), val('snpeff'), path("*.csv"), topic: multiqc_files, emit: report
+    tuple val(meta), val("${task.process}"), val('snpeff'), path("*.html"), topic: multiqc_files, emit: summary_html
+    tuple val(meta), val("${task.process}"), val('snpeff'), path("*.genes.txt"), topic: multiqc_files, emit: genes_txt
     tuple val("${task.process}"), val('snpeff'), eval("snpEff -version 2>&1 | cut -f 2 -d '\t'"), topic: versions, emit: versions_snpeff
 
     when:
@@ -36,6 +36,7 @@ process SNPEFF_SNPEFF {
     """
     snpEff \\
         -Xmx${avail_mem}M \\
+        -XX:-UsePerfData \\
         ${db} \\
         ${args} \\
         -csvStats ${prefix}.csv \\

--- a/modules/nf-core/snpeff/snpeff/main.nf
+++ b/modules/nf-core/snpeff/snpeff/main.nf
@@ -14,9 +14,9 @@ process SNPEFF_SNPEFF {
 
     output:
     tuple val(meta), path("*.ann.vcf"), emit: vcf
-    tuple val(meta), val("${task.process}"), val('snpeff'), path("*.csv"), topic: multiqc_files, emit: report
-    tuple val(meta), val("${task.process}"), val('snpeff'), path("*.html"), topic: multiqc_files, emit: summary_html
-    tuple val(meta), val("${task.process}"), val('snpeff'), path("*.genes.txt"), topic: multiqc_files, emit: genes_txt
+    tuple val(meta), path("*.csv"), emit: report
+    tuple val(meta), path("*.html"), emit: summary_html
+    tuple val(meta), path("*.genes.txt"), emit: genes_txt
     tuple val("${task.process}"), val('snpeff'), eval("snpEff -version 2>&1 | cut -f 2 -d '\t'"), topic: versions, emit: versions_snpeff
 
     when:
@@ -36,7 +36,6 @@ process SNPEFF_SNPEFF {
     """
     snpEff \\
         -Xmx${avail_mem}M \\
-        -XX:-UsePerfData \\
         ${db} \\
         ${args} \\
         -csvStats ${prefix}.csv \\

--- a/modules/nf-core/snpeff/snpeff/meta.yml
+++ b/modules/nf-core/snpeff/snpeff/meta.yml
@@ -61,6 +61,12 @@ output:
             annotated vcf
           pattern: "*.ann.vcf"
           ontologies: []
+      - ${task.process}:
+          type: string
+          description: The process
+      - snpeff:
+          type: string
+          description: The tool name
       - "*.csv":
           type: file
           description: snpEff report csv file
@@ -74,6 +80,12 @@ output:
             annotated vcf
           pattern: "*.ann.vcf"
           ontologies: []
+      - ${task.process}:
+          type: string
+          description: The process
+      - snpeff:
+          type: string
+          description: The tool name
       - "*.html":
           type: file
           description: snpEff summary statistics in html file
@@ -86,6 +98,12 @@ output:
             annotated vcf
           pattern: "*.ann.vcf"
           ontologies: []
+      - ${task.process}:
+          type: string
+          description: The process
+      - snpeff:
+          type: string
+          description: The tool name
       - "*.genes.txt":
           type: file
           description: txt (tab separated) file having counts of the number of variants
@@ -103,6 +121,60 @@ output:
           type: string
           description: The command used to generate the version of the tool
 topics:
+  multiqc_files:
+    - - meta:
+          type: file
+          description: |
+            annotated vcf
+          pattern: "*.ann.vcf"
+          ontologies: []
+      - ${task.process}:
+          type: string
+          description: The process
+      - snpeff:
+          type: string
+          description: The tool name
+      - "*.csv":
+          type: file
+          description: snpEff report csv file
+          pattern: "*.csv"
+          ontologies:
+            - edam: http://edamontology.org/format_3752 # CSV
+    - - meta:
+          type: file
+          description: |
+            annotated vcf
+          pattern: "*.ann.vcf"
+          ontologies: []
+      - ${task.process}:
+          type: string
+          description: The process
+      - snpeff:
+          type: string
+          description: The tool name
+      - "*.html":
+          type: file
+          description: snpEff summary statistics in html file
+          pattern: "*.html"
+          ontologies: []
+    - - meta:
+          type: file
+          description: |
+            annotated vcf
+          pattern: "*.ann.vcf"
+          ontologies: []
+      - ${task.process}:
+          type: string
+          description: The process
+      - snpeff:
+          type: string
+          description: The tool name
+      - "*.genes.txt":
+          type: file
+          description: txt (tab separated) file having counts of the number of variants
+            affecting each transcript and gene
+          pattern: "*.genes.txt"
+          ontologies: []
   versions:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/snpeff/snpeff/meta.yml
+++ b/modules/nf-core/snpeff/snpeff/meta.yml
@@ -61,12 +61,6 @@ output:
             annotated vcf
           pattern: "*.ann.vcf"
           ontologies: []
-      - ${task.process}:
-          type: string
-          description: The process
-      - snpeff:
-          type: string
-          description: The tool name
       - "*.csv":
           type: file
           description: snpEff report csv file
@@ -80,12 +74,6 @@ output:
             annotated vcf
           pattern: "*.ann.vcf"
           ontologies: []
-      - ${task.process}:
-          type: string
-          description: The process
-      - snpeff:
-          type: string
-          description: The tool name
       - "*.html":
           type: file
           description: snpEff summary statistics in html file
@@ -98,12 +86,6 @@ output:
             annotated vcf
           pattern: "*.ann.vcf"
           ontologies: []
-      - ${task.process}:
-          type: string
-          description: The process
-      - snpeff:
-          type: string
-          description: The tool name
       - "*.genes.txt":
           type: file
           description: txt (tab separated) file having counts of the number of variants
@@ -121,60 +103,6 @@ output:
           type: string
           description: The command used to generate the version of the tool
 topics:
-  multiqc_files:
-    - - meta:
-          type: file
-          description: |
-            annotated vcf
-          pattern: "*.ann.vcf"
-          ontologies: []
-      - ${task.process}:
-          type: string
-          description: The process
-      - snpeff:
-          type: string
-          description: The tool name
-      - "*.csv":
-          type: file
-          description: snpEff report csv file
-          pattern: "*.csv"
-          ontologies:
-            - edam: http://edamontology.org/format_3752 # CSV
-    - - meta:
-          type: file
-          description: |
-            annotated vcf
-          pattern: "*.ann.vcf"
-          ontologies: []
-      - ${task.process}:
-          type: string
-          description: The process
-      - snpeff:
-          type: string
-          description: The tool name
-      - "*.html":
-          type: file
-          description: snpEff summary statistics in html file
-          pattern: "*.html"
-          ontologies: []
-    - - meta:
-          type: file
-          description: |
-            annotated vcf
-          pattern: "*.ann.vcf"
-          ontologies: []
-      - ${task.process}:
-          type: string
-          description: The process
-      - snpeff:
-          type: string
-          description: The tool name
-      - "*.genes.txt":
-          type: file
-          description: txt (tab separated) file having counts of the number of variants
-            affecting each transcript and gene
-          pattern: "*.genes.txt"
-          ontologies: []
   versions:
     - - ${task.process}:
           type: string

--- a/subworkflows/local/bam_joint_calling_germline_sentieon/main.nf
+++ b/subworkflows/local/bam_joint_calling_germline_sentieon/main.nf
@@ -134,12 +134,7 @@ workflow BAM_JOINT_CALLING_GERMLINE_SENTIEON {
             [[id:"joint_variant_calling", patient:"all_samples", variantcaller:"sentieon_haplotyper"], tbi_out]
         }
 
-        versions = versions.mix(SENTIEON_VARCAL_SNP.out.versions)
-        versions = versions.mix(SENTIEON_VARCAL_INDEL.out.versions)
-        versions = versions.mix(SENTIEON_APPLYVARCAL_INDEL.out.versions)
     }
-
-    versions = versions.mix(SENTIEON_GVCFTYPER.out.versions)
 
     emit:
     genotype_index  // channel: [ val(meta), [ tbi ] ]

--- a/subworkflows/local/bam_sentieon_dedup/main.nf
+++ b/subworkflows/local/bam_sentieon_dedup/main.nf
@@ -34,7 +34,6 @@ workflow BAM_SENTIEON_DEDUP {
     reports = reports.mix(CRAM_QC_MOSDEPTH_SAMTOOLS.out.reports)
 
     // Gather versions of all tools used
-    versions = versions.mix(SENTIEON_DEDUP.out.versions)
     versions = versions.mix(CRAM_QC_MOSDEPTH_SAMTOOLS.out.versions)
 
     emit:

--- a/subworkflows/local/bam_variant_calling_germline_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_germline_all/main.nf
@@ -274,8 +274,6 @@ workflow BAM_VARIANT_CALLING_GERMLINE_ALL {
 
                 vcf_sentieon_dnascope = SENTIEON_DNAMODELAPPLY.out.vcf
                 tbi_sentieon_dnascope = SENTIEON_DNAMODELAPPLY.out.tbi
-                versions = versions.mix(SENTIEON_DNAMODELAPPLY.out.versions)
-
             }
 
         }

--- a/subworkflows/local/bam_variant_calling_sentieon_dnascope/main.nf
+++ b/subworkflows/local/bam_variant_calling_sentieon_dnascope/main.nf
@@ -142,7 +142,6 @@ workflow BAM_VARIANT_CALLING_SENTIEON_DNASCOPE {
         MERGE_SENTIEON_DNASCOPE_GVCFS.out.tbi,
         haplotyper_gvcf_tbi_branch.no_intervals)
 
-    versions = versions.mix(SENTIEON_DNASCOPE.out.versions)
     versions = versions.mix(MERGE_SENTIEON_DNASCOPE_VCFS.out.versions)
     versions = versions.mix(MERGE_SENTIEON_DNASCOPE_GVCFS.out.versions)
 

--- a/subworkflows/local/bam_variant_calling_sentieon_haplotyper/main.nf
+++ b/subworkflows/local/bam_variant_calling_sentieon_haplotyper/main.nf
@@ -138,7 +138,6 @@ workflow BAM_VARIANT_CALLING_SENTIEON_HAPLOTYPER {
         MERGE_SENTIEON_HAPLOTYPER_GVCFS.out.tbi,
         haplotyper_gvcf_tbi_branch.no_intervals)
 
-    versions = versions.mix(SENTIEON_HAPLOTYPER.out.versions)
     versions = versions.mix(MERGE_SENTIEON_HAPLOTYPER_VCFS.out.versions)
     versions = versions.mix(MERGE_SENTIEON_HAPLOTYPER_GVCFS.out.versions)
 

--- a/subworkflows/local/bam_variant_calling_somatic_tnscope/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_tnscope/main.nf
@@ -37,8 +37,6 @@ workflow BAM_VARIANT_CALLING_SOMATIC_TNSCOPE {
         [[],[]], // cosmic
         [[],[]] // cosmic_tbi
     )
-    versions = versions.mix(SENTIEON_TNSCOPE.out.versions)
-
     // Figuring out if there is one or more vcf(s) from the same sample
     vcf_branch = SENTIEON_TNSCOPE.out.vcf.branch{
         // Use meta.num_intervals to asses number of intervals

--- a/subworkflows/local/bam_variant_calling_tumor_only_tnscope/main.nf
+++ b/subworkflows/local/bam_variant_calling_tumor_only_tnscope/main.nf
@@ -37,8 +37,6 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_TNSCOPE {
         [[],[]], // cosmic
         [[],[]] // cosmic_tbi
     )
-    versions = versions.mix(SENTIEON_TNSCOPE.out.versions)
-
     // Figuring out if there is one or more vcf(s) from the same sample
     vcf_branch = SENTIEON_TNSCOPE.out.vcf.branch{
         // Use meta.num_intervals to asses number of intervals

--- a/subworkflows/local/fastq_align/main.nf
+++ b/subworkflows/local/fastq_align/main.nf
@@ -46,8 +46,6 @@ workflow FASTQ_ALIGN {
     versions = versions.mix(BWAMEM1_MEM.out.versions)
     versions = versions.mix(BWAMEM2_MEM.out.versions)
     versions = versions.mix(DRAGMAP_ALIGN.out.versions)
-    versions = versions.mix(SENTIEON_BWAMEM.out.versions)
-
     emit:
     bam      // channel: [ [meta], bam ]
     bai      // channel: [ [meta], bai ]

--- a/subworkflows/local/utils_nfcore_sarek_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_sarek_pipeline/main.nf
@@ -64,7 +64,7 @@ workflow PIPELINE_INITIALISATION {
 \033[0;35m  nf-core/sarek ${workflow.manifest.version}\033[0m
 -\033[2m----------------------------------------------------\033[0m-
 """
-    def after_text = """${workflow.manifest.doi ? "\n* The pipeline\n" : ""}${workflow.manifest.doi.tokenize(",").collect { doi -> "    https://doi.org/${doi.trim().replace('https://doi.org/','')}"}.join("\n")}${workflow.manifest.doi ? "\n" : ""}
+    def after_text = """${workflow.manifest.doi ? "\n* The pipeline\n" : ""}${workflow.manifest.doi.tokenize(",").collect { doi -> "    https://doi.org/${doi.trim().replace('https://doi.org/', '')}" }.join("\n")}${workflow.manifest.doi ? "\n" : ""}
 * The nf-core framework
     https://doi.org/10.1038/s41587-020-0439-x
 
@@ -83,6 +83,7 @@ workflow PIPELINE_INITIALISATION {
         before_text,
         after_text,
         command,
+        null,
     )
 
     // Check config provided to the pipeline

--- a/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
@@ -17,7 +17,7 @@ workflow UTILS_NFCORE_PIPELINE {
     checkProfileProvided(nextflow_cli_args)
 
     emit:
-    valid_config
+    valid_config = valid_config
 }
 
 /*

--- a/subworkflows/nf-core/utils_nfschema_plugin/main.nf
+++ b/subworkflows/nf-core/utils_nfschema_plugin/main.nf
@@ -22,6 +22,7 @@ workflow UTILS_NFSCHEMA_PLUGIN {
     before_text         // string:   text to show before the help message and parameters summary
     after_text          // string:   text to show after the help message and parameters summary
     command             // string:   an example command of the pipeline
+    cli_typecast        // boolean:  whether to perform typecasting of CLI parameters. Set this to `null` to use the default behaviour
 
     main:
 
@@ -34,11 +35,11 @@ workflow UTILS_NFSCHEMA_PLUGIN {
             fullHelp: help_full,
         ]
         if(parameters_schema) {
-            help_options << [parametersSchema: parameters_schema]
+            help_options << [parameters_schema: parameters_schema]
         }
         log.info paramsHelp(
             help_options,
-            (params.help instanceof String && params.help != "true") ? params.help : "",
+            (help instanceof String && help != "true") ? help : "",
         )
         exit 0
     }
@@ -50,7 +51,7 @@ workflow UTILS_NFSCHEMA_PLUGIN {
 
     summary_options = [:]
     if(parameters_schema) {
-        summary_options << [parametersSchema: parameters_schema]
+        summary_options << [parameters_schema: parameters_schema]
     }
     log.info before_text
     log.info paramsSummaryLog(summary_options, input_workflow)
@@ -63,7 +64,10 @@ workflow UTILS_NFSCHEMA_PLUGIN {
     if(validate_params) {
         validateOptions = [:]
         if(parameters_schema) {
-            validateOptions << [parametersSchema: parameters_schema]
+            validateOptions << [parameters_schema: parameters_schema]
+        }
+        if(cli_typecast != null) {
+            validateOptions << [cast_cli_params: cli_typecast]
         }
         validateParameters(validateOptions)
     }

--- a/subworkflows/nf-core/utils_nfschema_plugin/meta.yml
+++ b/subworkflows/nf-core/utils_nfschema_plugin/meta.yml
@@ -25,6 +25,30 @@ input:
         option. When this input is empty it will automatically use the configured schema or
         "${projectDir}/nextflow_schema.json" as default. The schema should not be given in this way
         for meta pipelines.
+  - help:
+      type: boolean, string
+      description: |
+        Show the help message and exit. When a parameter name is given, show the help message for that parameter instead of the general help message.
+  - help_full:
+      type: boolean
+      description: Show the full help message and exit.
+  - show_hidden:
+      type: boolean
+      description: Show hidden parameters in the help message.
+  - before_text:
+      type: string
+      description: Text to show before the parameters summary and help message.
+  - after_text:
+      type: string
+      description: Text to show after the parameters summary and help message.
+  - command:
+      type: string
+      description: An example command to run the pipeline, to show in the help message and the summary.
+  - cli_typecast:
+      type: boolean
+      description: |
+        Whether to apply typecasting to the parameters given via the CLI before validation.
+        Set this to `null` to use the default behavior.
 output:
   - dummy_emit:
       type: boolean

--- a/tests/annotation_merge.nf.test.snap
+++ b/tests/annotation_merge.nf.test.snap
@@ -9,7 +9,7 @@
                     "tabix": "1.21"
                 },
                 "SNPEFF_SNPEFF": {
-                    "snpeff": "5.4a"
+                    "snpeff": "5.4c"
                 },
                 "TABIX_BGZIPTABIX": {
                     "bgzip": "1.21",
@@ -109,18 +109,18 @@
             ],
             "No warnings"
         ],
+        "timestamp": "2026-05-25T14:50:47.85261627",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-07T08:54:13.050728"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     },
     "-profile test --tools merge,snpsift": {
         "content": [
             6,
             {
                 "SNPEFF_SNPEFF": {
-                    "snpeff": "5.4a"
+                    "snpeff": "5.4c"
                 },
                 "SNPSIFT_ANNMEM": {
                     "snpsift": "5.4a"
@@ -220,18 +220,18 @@
             ],
             "No warnings"
         ],
+        "timestamp": "2026-05-25T14:52:24.459648599",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-09T15:02:33.282539192"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     },
     "-profile test --tools merge": {
         "content": [
             4,
             {
                 "SNPEFF_SNPEFF": {
-                    "snpeff": "5.4a"
+                    "snpeff": "5.4c"
                 },
                 "TABIX_BGZIPTABIX": {
                     "bgzip": "1.21",
@@ -320,10 +320,10 @@
             ],
             "No warnings"
         ],
+        "timestamp": "2026-05-25T14:47:20.388333013",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-07T08:52:33.470414"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     }
 }

--- a/tests/samplesheets.nf.test.snap
+++ b/tests/samplesheets.nf.test.snap
@@ -39,7 +39,7 @@
                 "The following invalid input values have been detected:",
                 "* --input ([PATH]/./tests/csv/3.0/fastq_sample_with_space.csv): Validation of file failed:",
                 "\t-> Entry 2: Error for field 'sample' (test 2): \"test 2\" does not match regular expression [^\\S+$] (Sample ID must be provided, cannot contain spaces and must be a string value)",
-                " -- Check script '[PATH]/subworkflows/nf-core/utils_nfschema_plugin/main.nf' at line: 68 or see '[PATH]/tests/[NFT_HASH]/meta/nextflow.log' file for more details"
+                " -- Check script '[PATH]/subworkflows/nf-core/utils_nfschema_plugin/main.nf' at line: 72 or see '[PATH]/tests/[NFT_HASH]/meta/nextflow.log' file for more details"
             ]
         ],
         "meta": {

--- a/tests/sentieon.nf.test.snap
+++ b/tests/sentieon.nf.test.snap
@@ -36,7 +36,7 @@
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",

--- a/tests/sentieon_aligner_bwamem.nf.test.snap
+++ b/tests/sentieon_aligner_bwamem.nf.test.snap
@@ -23,7 +23,7 @@
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -106,10 +106,10 @@
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",

--- a/tests/sentieon_dedup.nf.test.snap
+++ b/tests/sentieon_dedup.nf.test.snap
@@ -25,7 +25,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -217,7 +217,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -409,7 +409,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -604,7 +604,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -799,7 +799,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",

--- a/tests/variant_calling_sentieon_dnascope.nf.test.snap
+++ b/tests/variant_calling_sentieon_dnascope.nf.test.snap
@@ -19,7 +19,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DNASCOPE": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -205,10 +205,10 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DNAMODELAPPLY": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_DNASCOPE": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -397,10 +397,10 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_DNASCOPE": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_GVCFTYPER": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",

--- a/tests/variant_calling_sentieon_haplotypecaller.nf.test.snap
+++ b/tests/variant_calling_sentieon_haplotypecaller.nf.test.snap
@@ -19,19 +19,19 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_APPLYVARCAL_INDEL": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_GVCFTYPER": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_HAPLOTYPER": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_VARCAL_INDEL": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_VARCAL_SNP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -226,7 +226,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_HAPLOTYPER": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -414,7 +414,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_HAPLOTYPER": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -606,7 +606,7 @@
                     "samtools": 1.21
                 },
                 "SENTIEON_HAPLOTYPER": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",

--- a/tests/variant_calling_sentieon_haplotypecaller.nf.test.snap
+++ b/tests/variant_calling_sentieon_haplotypecaller.nf.test.snap
@@ -21,6 +21,9 @@
                 "SENTIEON_APPLYVARCAL_INDEL": {
                     "sentieon": "202503.02"
                 },
+                "SENTIEON_APPLYVARCAL_SNP": {
+                    "sentieon": "202503.02"
+                },
                 "SENTIEON_GVCFTYPER": {
                     "sentieon": "202503.02"
                 },

--- a/tests/variant_calling_sentieon_tnscope.nf.test.snap
+++ b/tests/variant_calling_sentieon_tnscope.nf.test.snap
@@ -14,13 +14,13 @@
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_TNSCOPE": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -101,13 +101,13 @@
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_TNSCOPE": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -208,13 +208,13 @@
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_TNSCOPE": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",
@@ -302,13 +302,13 @@
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_DEDUP": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "SENTIEON_TNSCOPE": {
-                    "sentieon": 202503.01
+                    "sentieon": "202503.02"
                 },
                 "TABIX_BGZIPTABIX_INTERVAL_COMBINED": {
                     "bgzip": "1.21",


### PR DESCRIPTION
Bumps all 9 sentieon vendored modules (applyvarcal, bwamem, dedup,
dnamodelapply, dnascope, gvcftyper, haplotyper, tnscope, varcal) from
pinned SHA 256557155... to nf-core/modules HEAD 7ad1622c6...

Notable upstream changes pulled in:

  * sentieon/gvcftyper now honours its staged `--interval` input. Joint
    runs no longer produce overlapping records at interval boundaries.

  * sentieon/varcal multi-`--resource:` parsing in the List branch is
    fixed; sarek's igenomes.config style of packing multiple resources
    into one string (e.g. known_indels_vqsr for hg38) now passes through
    correctly instead of leaving an orphan `--resource:mills,…` literal.

  * All sentieon modules now emit versions via `topic: versions`
    (emit name `versions_sentieon`). Removed the explicit
    `versions.mix(SENTIEON_*.out.versions)` calls in 8 local subworkflows
    — sarek's `softwareVersionsToYAML` already collects topic emissions
    via `channel.topic("versions")`, so they're picked up automatically.


## PR checklist

- [X ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ X] Make sure your code lints (`nf-core pipelines lint`).
- [ X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
