### PR TITLE
Fix controlfreec versions emission: swap to topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,13 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Fix controlfreec `versions` emission: swap to topics and remove explicit `versions.mix` wiring
 - [#2117](https://github.com/nf-core/sarek/pull/2117) - Update alignment related files to strict syntax
 - [#2129](https://github.com/nf-core/sarek/pull/2129) - Fix MuSE timestamp, swap to topics and change to strict syntax
 - [#2165](https://github.com/nf-core/sarek/pull/2165) - Recover help message
 - [#2167](https://github.com/nf-core/sarek/pull/2167) - Fix and extend pipeline level stub tests
 - [#2170](https://github.com/nf-core/sarek/pull/2170) - Add index to workflow output for MultiQC
 - [#2189](https://github.com/nf-core/sarek/pull/2189) - Preserve `groupKey` size hint into `groupTuple` in the sentieon haplotyper and dnascope subworkflows so per-sample MERGE*SENTIEON*\*\_VCFS / GVCFS emits progressively as each sample's intervals finish instead of bursting at end-of-haplotyper.
+- [#2197](https://github.com/nf-core/sarek/pull/2197) - Fix controlfreec `versions` emission: swap to topics and remove explicit `versions.mix` wiring
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Fix controlfreec `versions` emission: swap to topics and remove explicit `versions.mix` wiring
 - [#2117](https://github.com/nf-core/sarek/pull/2117) - Update alignment related files to strict syntax
 - [#2129](https://github.com/nf-core/sarek/pull/2129) - Fix MuSE timestamp, swap to topics and change to strict syntax
 - [#2165](https://github.com/nf-core/sarek/pull/2165) - Recover help message

--- a/subworkflows/local/bam_variant_calling_somatic_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_all/main.nf
@@ -122,7 +122,6 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
 
         versions = versions.mix(MPILEUP_NORMAL.out.versions)
         versions = versions.mix(MPILEUP_TUMOR.out.versions)
-        versions = versions.mix(BAM_VARIANT_CALLING_SOMATIC_CONTROLFREEC.out.versions)
     }
 
     // CNVKIT

--- a/subworkflows/local/bam_variant_calling_somatic_controlfreec/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_controlfreec/main.nf
@@ -23,8 +23,6 @@ workflow BAM_VARIANT_CALLING_SOMATIC_CONTROLFREEC {
 
     main:
 
-    ch_versions = Channel.empty()
-
     FREEC_SOMATIC(controlfreec_input, fasta, fasta_fai, [], dbsnp, dbsnp_tbi, chr_files, mappability, intervals_bed, [])
 
     //Filter the files that come out of freec somatic as ASSESS_SIGNIFICANCE only takes one cnv and one ratio file
@@ -54,13 +52,4 @@ workflow BAM_VARIANT_CALLING_SOMATIC_CONTROLFREEC {
     FREEC2BED(FREEC_SOMATIC.out.ratio)
     FREEC2CIRCOS(FREEC_SOMATIC.out.ratio)
     MAKEGRAPH2(FREEC_SOMATIC.out.ratio.join(FREEC_SOMATIC.out.BAF, failOnDuplicate: true, failOnMismatch: true))
-
-    ch_versions = ch_versions.mix(FREEC_SOMATIC.out.versions)
-    ch_versions = ch_versions.mix(ASSESS_SIGNIFICANCE.out.versions)
-    ch_versions = ch_versions.mix(FREEC2BED.out.versions)
-    ch_versions = ch_versions.mix(FREEC2CIRCOS.out.versions)
-    ch_versions = ch_versions.mix(MAKEGRAPH2.out.versions)
-
-    emit:
-    versions = ch_versions
 }

--- a/subworkflows/local/bam_variant_calling_tumor_only_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_tumor_only_all/main.nf
@@ -92,7 +92,6 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_ALL {
             wes ? intervals_bed_combined : [],
         )
 
-        versions = versions.mix(BAM_VARIANT_CALLING_TUMOR_ONLY_CONTROLFREEC.out.versions)
     }
 
     // CNVKIT

--- a/subworkflows/local/bam_variant_calling_tumor_only_controlfreec/main.nf
+++ b/subworkflows/local/bam_variant_calling_tumor_only_controlfreec/main.nf
@@ -23,21 +23,10 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_CONTROLFREEC {
 
     main:
 
-    ch_versions = Channel.empty()
-
     FREEC_TUMORONLY(controlfreec_input, fasta, fasta_fai, [], dbsnp, dbsnp_tbi, chr_files, mappability, intervals_bed, [])
 
     ASSESS_SIGNIFICANCE(FREEC_TUMORONLY.out.CNV.join(FREEC_TUMORONLY.out.ratio, failOnDuplicate: true, failOnMismatch: true))
     FREEC2BED(FREEC_TUMORONLY.out.ratio)
     FREEC2CIRCOS(FREEC_TUMORONLY.out.ratio)
     MAKEGRAPH2(FREEC_TUMORONLY.out.ratio.join(FREEC_TUMORONLY.out.BAF, failOnDuplicate: true, failOnMismatch: true))
-
-    ch_versions = ch_versions.mix(FREEC_TUMORONLY.out.versions)
-    ch_versions = ch_versions.mix(ASSESS_SIGNIFICANCE.out.versions)
-    ch_versions = ch_versions.mix(FREEC2BED.out.versions)
-    ch_versions = ch_versions.mix(FREEC2CIRCOS.out.versions)
-    ch_versions = ch_versions.mix(MAKEGRAPH2.out.versions)
-
-    emit:
-    versions = ch_versions
 }

--- a/tests/variant_calling_controlfreec.nf.test.snap
+++ b/tests/variant_calling_controlfreec.nf.test.snap
@@ -4,7 +4,7 @@
             11,
             {
                 "ASSESS_SIGNIFICANCE": {
-                    "controlfreec": 11.6
+                    "controlfreec": "11.6b"
                 },
                 "FREEC2BED": {
                     "controlfreec": "11.6b"
@@ -143,18 +143,18 @@
             "No VCF files",
             "No warnings"
         ],
+        "timestamp": "2026-05-28T15:29:16.864765246",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-30T22:28:08.497498851"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     },
     "-profile test --tools controlfreec somatic": {
         "content": [
             16,
             {
                 "ASSESS_SIGNIFICANCE": {
-                    "controlfreec": 11.6
+                    "controlfreec": "11.6b"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -322,18 +322,18 @@
             "No VCF files",
             "No warnings"
         ],
+        "timestamp": "2026-05-28T15:27:36.537227044",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-30T22:26:38.500794704"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     },
     "-profile test --tools controlfreec --no_intervals somatic -stub": {
         "content": [
             14,
             {
                 "ASSESS_SIGNIFICANCE": {
-                    "controlfreec": 11.6
+                    "controlfreec": "11.6b"
                 },
                 "FREEC2BED": {
                     "controlfreec": "11.6b"
@@ -371,6 +371,7 @@
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/.stub",
                 "multiqc/multiqc_plots",
+                "multiqc/multiqc_plots/.stub",
                 "multiqc/multiqc_report.html",
                 "no_intervals.bed",
                 "no_intervals.bed.gz",
@@ -433,18 +434,18 @@
                 "WARN: nf-core pipelines do not accept positional arguments. The positional argument `true` has been detected."
             ]
         ],
+        "timestamp": "2026-05-28T15:30:21.092617766",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-18T13:14:28.699871503"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     },
     "-profile test --tools controlfreec tumoronly -stub": {
         "content": [
             13,
             {
                 "ASSESS_SIGNIFICANCE": {
-                    "controlfreec": 11.6
+                    "controlfreec": "11.6b"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -489,6 +490,7 @@
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/.stub",
                 "multiqc/multiqc_plots",
+                "multiqc/multiqc_plots/.stub",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",
                 "pipeline_info/nf_core_sarek_software_mqc_versions.yml",
@@ -533,10 +535,10 @@
                 "WARN: nf-core pipelines do not accept positional arguments. The positional argument `true` has been detected."
             ]
         ],
+        "timestamp": "2026-05-28T15:31:24.029091171",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-18T13:15:24.776142198"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
+        }
     }
 }


### PR DESCRIPTION
### Description

All controlfreec modules already publish versions via `topic: versions`, but the subworkflows still had explicit `versions.mix()` wiring referencing `.out.versions` — which doesn't exist (the emit name is `versions_controlfreec`). This caused a `No such variable: versions` runtime error.

### Fix

- Remove unused `ch_versions` initialization and `emit: versions` from both `bam_variant_calling_somatic_controlfreec` and `bam_variant_calling_tumor_only_controlfreec` subworkflows
- Remove `versions.mix(BAM_VARIANT_CALLING_*_CONTROLFREEC.out.versions)` from the somatic and tumor-only dispatchers
- The main workflow already collects from `channel.topic("versions")` at `workflows/sarek/main.nf:591`, so controlfreec versions are still captured correctly

Closes #XXX