### PR TITLE
Refactor BQSR: route SV/CNV callers to markdup output (pre-BQSR)

### DIFF
--- a/subworkflows/local/bam_variant_calling_germline_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_germline_all/main.nf
@@ -23,8 +23,9 @@ workflow BAM_VARIANT_CALLING_GERMLINE_ALL {
     take:
     tools                             // Mandatory, list of tools to apply
     skip_tools                        // Mandatory, list of tools to skip
-    bam                               // channel: [mandatory] meta, bam
-    cram                              // channel: [mandatory] meta, cram
+    bam                               // channel: [mandatory] meta, bam, bai — BQSR'd (or markdup if BQSR off)
+    cram                              // channel: [mandatory] meta, cram, crai — BQSR'd (or markdup if BQSR off), for SNV callers
+    cram_markdup                      // channel: [mandatory] meta, cram, crai — markdup output (before BQSR), for SV/CNV callers
     bwa                               // channel: [mandatory] meta, bwa
     cnvkit_reference                  // channel: [optional] cnvkit reference
     dbsnp                             // channel: [mandatory] meta, dbsnp
@@ -91,11 +92,11 @@ workflow BAM_VARIANT_CALLING_GERMLINE_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_MPILEUP.out.versions)
     }
 
-    // CNVKIT
+    // CNVKIT — uses markdup output (before BQSR) to preserve coverage signal
     if (tools && tools.split(',').contains('cnvkit')) {
         BAM_VARIANT_CALLING_CNVKIT(
             // Remap channel to match module/subworkflow
-            cram.map{ meta, cram, crai -> [ meta, [], cram ] },
+            cram_markdup.map{ meta, cram, crai -> [ meta, [], cram ] },
             fasta,
             fasta_fai,
             intervals_bed_combined.map{it -> it ? [[id:it[0].baseName], it]: [[id:'no_intervals'], []]},
@@ -193,10 +194,10 @@ workflow BAM_VARIANT_CALLING_GERMLINE_ALL {
         }
     }
 
-    // MANTA
+    // MANTA — SV caller, uses markdup output (before BQSR)
     if (tools && tools.split(',').contains('manta')) {
         BAM_VARIANT_CALLING_GERMLINE_MANTA (
-            cram,
+            cram_markdup,
             fasta,
             fasta_fai,
             intervals_bed_gz_tbi_combined
@@ -207,10 +208,10 @@ workflow BAM_VARIANT_CALLING_GERMLINE_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_GERMLINE_MANTA.out.versions)
     }
 
-    // INDEXCOV, for WGS only
+    // INDEXCOV — CNV caller, uses markdup output (before BQSR) to preserve coverage signal
     if (params.wes==false &&  tools.split(',').contains('indexcov')) {
         BAM_VARIANT_CALLING_INDEXCOV (
-            cram,
+            cram_markdup,
             fasta,
             fasta_fai
         )
@@ -361,10 +362,10 @@ workflow BAM_VARIANT_CALLING_GERMLINE_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_SINGLE_STRELKA.out.versions)
     }
 
-    // TIDDIT
+    // TIDDIT — SV caller, uses markdup output (before BQSR)
     if (tools && tools.split(',').contains('tiddit')) {
         BAM_VARIANT_CALLING_SINGLE_TIDDIT(
-            cram,
+            cram_markdup,
             // Remap channel to match module/subworkflow
             fasta,
             bwa

--- a/subworkflows/local/bam_variant_calling_somatic_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_all/main.nf
@@ -21,8 +21,10 @@ include { MSISENSORPRO_MSISOMATIC                       } from '../../../modules
 workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
     take:
     tools                         // Mandatory, list of tools to apply
-    bam                           // channel: [mandatory] bam
-    cram                          // channel: [mandatory] cram
+    bam                           // channel: [mandatory] bam — BQSR'd (or markdup if BQSR off), for SNV callers
+    cram                          // channel: [mandatory] cram — BQSR'd (or markdup if BQSR off), for SNV callers
+    cram_markdup                  // channel: [mandatory] cram — markdup output (before BQSR), for SV/CNV callers
+    bam_markdup                   // channel: [mandatory] bam — markdup output (before BQSR), for CNV callers needing BAM (cnvkit)
     bwa                           // channel: [optional] bwa
     cf_chrom_len                  // channel: [optional] controlfreec length file
     chr_files
@@ -72,9 +74,10 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
     tbi_tiddit       = channel.empty()
     tbi_tnscope      = channel.empty()
 
+    // ASCAT — CNV caller, uses markdup output (before BQSR) to preserve coverage signal
     if (tools && tools.split(',').contains('ascat')) {
         BAM_VARIANT_CALLING_SOMATIC_ASCAT(
-            cram,
+            cram_markdup,
             allele_files,
             loci_files,
             (wes ? intervals_bed_combined : []),
@@ -86,10 +89,10 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_SOMATIC_ASCAT.out.versions)
     }
 
-    // CONTROLFREEC
+    // CONTROLFREEC — CNV caller, uses markdup output (before BQSR) to preserve coverage signal
     if (tools && tools.split(',').contains('controlfreec')) {
-        cram_normal = cram.map { meta, normal_cram, normal_crai, _tumor_cram, _tumor_crai -> [meta, normal_cram, normal_crai] }
-        cram_tumor = cram.map { meta, _normal_cram, _normal_crai, tumor_cram, tumor_crai -> [meta, tumor_cram, tumor_crai] }
+        cram_normal = cram_markdup.map { meta, normal_cram, normal_crai, _tumor_cram, _tumor_crai -> [meta, normal_cram, normal_crai] }
+        cram_tumor = cram_markdup.map { meta, _normal_cram, _normal_crai, tumor_cram, tumor_crai -> [meta, tumor_cram, tumor_crai] }
 
         MPILEUP_NORMAL(
             cram_normal,
@@ -125,10 +128,10 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_SOMATIC_CONTROLFREEC.out.versions)
     }
 
-    // CNVKIT
+    // CNVKIT — CNV caller, uses markdup BAM (before BQSR) to preserve coverage signal
     if (tools && tools.split(',').contains('cnvkit')) {
         BAM_VARIANT_CALLING_CNVKIT(
-            bam.map { meta, normal_bam, _normal_bai, tumor_bam, _tumor_bai -> [meta, tumor_bam, normal_bam] },
+            bam_markdup.map { meta, normal_bam, _normal_bai, tumor_bam, _tumor_bai -> [meta, tumor_bam, normal_bam] },
             fasta,
             fasta_fai,
             intervals_bed_combined.map { _intervals -> _intervals ? [[id: _intervals[0].baseName], _intervals] : [[id: 'no_intervals'], []] },
@@ -153,10 +156,10 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_FREEBAYES.out.versions)
     }
 
-    // MANTA
+    // MANTA — SV caller, uses markdup output (before BQSR)
     if (tools && tools.split(',').contains('manta')) {
         BAM_VARIANT_CALLING_SOMATIC_MANTA(
-            cram,
+            cram_markdup,
             fasta,
             fasta_fai,
             intervals_bed_gz_tbi_combined,
@@ -168,11 +171,11 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
     }
 
 
-    // INDEXCOV
+    // INDEXCOV — CNV caller, uses markdup output (before BQSR) to preserve coverage signal
     //   WGS only
     if (params.wes == false && tools.split(',').contains('indexcov')) {
         BAM_VARIANT_CALLING_INDEXCOV(
-            cram,
+            cram_markdup,
             fasta,
             fasta_fai,
         )
@@ -272,11 +275,11 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_SOMATIC_TNSCOPE.out.versions)
     }
 
-    // TIDDIT
+    // TIDDIT — SV caller, uses markdup output (before BQSR)
     if (tools && tools.split(',').contains('tiddit')) {
         BAM_VARIANT_CALLING_SOMATIC_TIDDIT(
-            cram.map { meta, normal_cram, normal_crai, _tumor_cram, _tumor_crai -> [meta, normal_cram, normal_crai] },
-            cram.map { meta, _normal_cram, _normal_crai, tumor_cram, tumor_crai -> [meta, tumor_cram, tumor_crai] },
+            cram_markdup.map { meta, normal_cram, normal_crai, _tumor_cram, _tumor_crai -> [meta, normal_cram, normal_crai] },
+            cram_markdup.map { meta, _normal_cram, _normal_crai, tumor_cram, tumor_crai -> [meta, tumor_cram, tumor_crai] },
             fasta,
             bwa,
         )

--- a/subworkflows/local/bam_variant_calling_tumor_only_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_tumor_only_all/main.nf
@@ -17,8 +17,10 @@ include { MSISENSOR2_MSI                              } from '../../../modules/n
 workflow BAM_VARIANT_CALLING_TUMOR_ONLY_ALL {
     take:
     tools                         // Mandatory, list of tools to apply
-    bam                           // channel: [mandatory] bam
-    cram                          // channel: [mandatory] cram
+    bam                           // channel: [mandatory] bam — BQSR'd (or markdup if BQSR off), for SNV callers
+    cram                          // channel: [mandatory] cram — BQSR'd (or markdup if BQSR off), for SNV callers
+    cram_markdup                  // channel: [mandatory] cram — markdup output (before BQSR), for SV/CNV callers
+    bam_markdup                   // channel: [mandatory] bam — markdup output (before BQSR), for CNV callers needing BAM (cnvkit)
     bwa                           // channel: [optional] bwa
     cf_chrom_len                  // channel: [optional] controlfreec length file
     chr_files
@@ -95,10 +97,10 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_TUMOR_ONLY_CONTROLFREEC.out.versions)
     }
 
-    // CNVKIT
+    // CNVKIT — CNV caller, uses markdup BAM (before BQSR) to preserve coverage signal
     if (tools && tools.split(',').contains('cnvkit')) {
         BAM_VARIANT_CALLING_CNVKIT(
-            bam.map { meta_, bam_, _bai -> [meta_, bam_, []] },
+            bam_markdup.map { meta_, bam_, _bai -> [meta_, bam_, []] },
             fasta,
             fasta_fai,
             [[id: "null"], []],
@@ -172,10 +174,10 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_TUMOR_ONLY_LOFREQ.out.versions)
     }
 
-    // MANTA
+    // MANTA — SV caller, uses markdup output (before BQSR)
     if (tools && tools.split(',').contains('manta')) {
         BAM_VARIANT_CALLING_TUMOR_ONLY_MANTA(
-            cram,
+            cram_markdup,
             fasta,
             fasta_fai,
             intervals_bed_gz_tbi_combined,
@@ -186,10 +188,10 @@ workflow BAM_VARIANT_CALLING_TUMOR_ONLY_ALL {
         versions = versions.mix(BAM_VARIANT_CALLING_TUMOR_ONLY_MANTA.out.versions)
     }
 
-    // TIDDIT
+    // TIDDIT — SV caller, uses markdup output (before BQSR)
     if (tools && tools.split(',').contains('tiddit')) {
         BAM_VARIANT_CALLING_SINGLE_TIDDIT(
-            cram,
+            cram_markdup,
             fasta,
             bwa,
         )

--- a/subworkflows/local/fastq_preprocess_gatk/main.nf
+++ b/subworkflows/local/fastq_preprocess_gatk/main.nf
@@ -517,10 +517,18 @@ workflow FASTQ_PREPROCESS_GATK {
             // - crams from markduplicates = ch_cram_for_bam_baserecalibrator if skip BQSR but not started from step recalibration
             cram_variant_calling = Channel.empty().mix(ch_cram_for_bam_baserecalibrator)
         }
+
+        // cram_markdup: markdup output before BQSR, for SV/CNV callers that should not use recalibrated reads
+        // When starting from step 'recalibrate', markdup CRAMs are not available — use cram_variant_calling as fallback
+        // TODO: warn users that SV/CNV callers will use recalibrated reads when starting from --step recalibrate
+        cram_markdup = (params.step == 'recalibrate')
+            ? cram_variant_calling
+            : ch_cram_for_bam_baserecalibrator
     }
 
     emit:
     cram_variant_calling
+    cram_markdup
     reports
     versions
 

--- a/workflows/sarek/main.nf
+++ b/workflows/sarek/main.nf
@@ -32,6 +32,7 @@ include { FASTQ_PREPROCESS_PARABRICKS                       } from '../../subwor
 
 // CRAM_TO_BAM conversion
 include { SAMTOOLS_CONVERT as CRAM_TO_BAM                   } from '../../modules/nf-core/samtools/convert'
+include { SAMTOOLS_CONVERT as CRAM_TO_BAM_MARKDUP           } from '../../modules/nf-core/samtools/convert'
 
 // Variant calling on a single normal sample
 include { BAM_VARIANT_CALLING_GERMLINE_ALL                  } from '../../subworkflows/local/bam_variant_calling_germline_all'
@@ -252,6 +253,10 @@ workflow SAREK {
             cram_variant_calling = channel.empty()
             cram_variant_calling = cram_variant_calling.mix(FASTQ_PREPROCESS_GATK.out.cram_variant_calling)
 
+            // Gather markdup output (before BQSR) for SV/CNV callers
+            cram_markdup = channel.empty()
+            cram_markdup = cram_markdup.mix(FASTQ_PREPROCESS_GATK.out.cram_markdup)
+
             // Gather used softwares versions
             reports = reports.mix(FASTQ_PREPROCESS_GATK.out.reports)
             versions = versions.mix(FASTQ_PREPROCESS_GATK.out.versions)
@@ -261,11 +266,14 @@ workflow SAREK {
     if (step == 'variant_calling') {
 
         cram_variant_calling = channel.empty().mix(input_sample)
+        // When starting from variant_calling, no markdup CRAMs are available — use the same input
+        cram_markdup = channel.empty().mix(input_sample)
     }
 
     if (step == 'annotate') {
 
         cram_variant_calling = channel.empty()
+        cram_markdup = channel.empty()
     }
 
     // RUN CRAM QC on the recalibrated CRAM files or when starting from step variant calling. NGSCheckmate should be run also on non-recalibrated CRAM files
@@ -283,6 +291,7 @@ workflow SAREK {
     if (tools) {
 
         bam_variant_calling = channel.empty()
+        bam_markdup = channel.empty()
 
         //  For cnvkit, msisensor2 and muse we need to use bam input and not cram
         if (tools.split(',').contains('cnvkit') || tools.split(',').contains('msisensor2') || tools.split(',').contains('muse')) {
@@ -307,6 +316,26 @@ workflow SAREK {
             versions = versions.mix(CRAM_TO_BAM.out.versions)
         }
 
+        // For cnvkit we also need markdup BAMs (before BQSR) to preserve coverage signal
+        if (tools.split(',').contains('cnvkit')) {
+
+            cram_markdup_status_tmp = cram_markdup.branch { meta, file, index ->
+                bam: file.toString().endsWith('.bam')
+                cram: file.toString().endsWith('.cram')
+            }
+
+            CRAM_TO_BAM_MARKDUP(cram_markdup_status_tmp.cram, fasta, fasta_fai)
+
+            bam_markdup = CRAM_TO_BAM_MARKDUP.out.bam
+                .join(CRAM_TO_BAM_MARKDUP.out.bai, by: [0])
+                .mix(cram_markdup_status_tmp.bam)
+                .map { meta, bam, bai ->
+                    [meta + [data_type: 'bam'], bam, bai]
+                }
+
+            versions = versions.mix(CRAM_TO_BAM_MARKDUP.out.versions)
+        }
+
         // Logic to separate germline samples, tumor samples with no matched normal, and combine tumor-normal pairs
         cram_variant_calling_status = cram_variant_calling.branch { meta, file, index ->
             normal: meta.status == 0
@@ -319,13 +348,29 @@ workflow SAREK {
             tumor: meta.status == 1
         }
 
+        // Same branching for markdup CRAMs (SV/CNV callers)
+        cram_markdup_status = cram_markdup.branch { meta, file, index ->
+            normal: meta.status == 0
+            tumor: meta.status == 1
+        }
+
+        // Same branching for markdup BAMs (CNV callers needing BAM, e.g. cnvkit)
+        bam_markdup_status = bam_markdup.branch { meta, file, index ->
+            normal: meta.status == 0
+            tumor: meta.status == 1
+        }
+
         // All Germline samples
         cram_variant_calling_normal_to_cross = cram_variant_calling_status.normal.map { meta, cram, crai -> [meta.patient, meta, cram, crai] }
         bam_variant_calling_normal_to_cross = bam_variant_calling_status.normal.map { meta, bam, bai -> [meta.patient, meta, bam, bai] }
+        cram_markdup_normal_to_cross = cram_markdup_status.normal.map { meta, cram, crai -> [meta.patient, meta, cram, crai] }
+        bam_markdup_normal_to_cross = bam_markdup_status.normal.map { meta, bam, bai -> [meta.patient, meta, bam, bai] }
 
         // All tumor samples
         cram_variant_calling_pair_to_cross = cram_variant_calling_status.tumor.map { meta, cram, crai -> [meta.patient, meta, cram, crai] }
         bam_variant_calling_pair_to_cross = bam_variant_calling_status.tumor.map { meta, bam, bai -> [meta.patient, meta, bam, bai] }
+        cram_markdup_pair_to_cross = cram_markdup_status.tumor.map { meta, cram, crai -> [meta.patient, meta, cram, crai] }
+        bam_markdup_pair_to_cross = bam_markdup_status.tumor.map { meta, bam, bai -> [meta.patient, meta, bam, bai] }
 
         // Tumor only samples
         // 1. Group together all tumor samples by patient ID [ patient1, [ meta1, meta2 ], [ cram1, crai1, cram2, crai2 ] ]
@@ -333,19 +378,27 @@ workflow SAREK {
         // Downside: this only works by waiting for all tumor samples to finish preprocessing, since no group size is provided
         cram_variant_calling_tumor_grouped = cram_variant_calling_pair_to_cross.groupTuple()
         bam_variant_calling_tumor_grouped = bam_variant_calling_pair_to_cross.groupTuple()
+        cram_markdup_tumor_grouped = cram_markdup_pair_to_cross.groupTuple()
+        bam_markdup_tumor_grouped = bam_markdup_pair_to_cross.groupTuple()
 
         // 2. Join with normal samples, in each channel there is one key per patient now. Patients without matched normal end up with: [ patient1, [ meta1, meta2 ], [ cram1, crai1, cram2, crai2 ], null ]
         cram_variant_calling_tumor_joined = cram_variant_calling_tumor_grouped.join(cram_variant_calling_normal_to_cross, failOnDuplicate: true, remainder: true)
         bam_variant_calling_tumor_joined = bam_variant_calling_tumor_grouped.join(bam_variant_calling_normal_to_cross, failOnDuplicate: true, remainder: true)
+        cram_markdup_tumor_joined = cram_markdup_tumor_grouped.join(cram_markdup_normal_to_cross, failOnDuplicate: true, remainder: true)
+        bam_markdup_tumor_joined = bam_markdup_tumor_grouped.join(bam_markdup_normal_to_cross, failOnDuplicate: true, remainder: true)
 
         // 3. Filter out entries with last entry null
         cram_variant_calling_tumor_filtered = cram_variant_calling_tumor_joined.filter { it -> !(it.last()) }
         bam_variant_calling_tumor_filtered = bam_variant_calling_tumor_joined.filter { it -> !(it.last()) }
+        cram_markdup_tumor_filtered = cram_markdup_tumor_joined.filter { it -> !(it.last()) }
+        bam_markdup_tumor_filtered = bam_markdup_tumor_joined.filter { it -> !(it.last()) }
 
         // 4. Transpose [ patient1, [ meta1, meta2 ], [ cram1, crai1, cram2, crai2 ] ] back to [ patient1, meta1, [ cram1, crai1 ], null ] [ patient1, meta2, [ cram2, crai2 ], null ]
         // and remove patient ID field & null value for further processing [ meta1, [ cram1, crai1 ] ] [ meta2, [ cram2, crai2 ] ]
         cram_variant_calling_tumor_only = cram_variant_calling_tumor_filtered.transpose().map { it -> [it[1], it[2], it[3]] }
         bam_variant_calling_tumor_only = bam_variant_calling_tumor_filtered.transpose().map { it -> [it[1], it[2], it[3]] }
+        cram_markdup_tumor_only = cram_markdup_tumor_filtered.transpose().map { it -> [it[1], it[2], it[3]] }
+        bam_markdup_tumor_only = bam_markdup_tumor_filtered.transpose().map { it -> [it[1], it[2], it[3]] }
 
         if (params.only_paired_variant_calling) {
             // Normal only samples
@@ -353,18 +406,26 @@ workflow SAREK {
             // 1. Join with tumor samples, in each channel there is one key per patient now. Patients without matched tumor end up with: [ patient1, [ meta1 ], [ cram1, crai1 ], null ] as there is only one matched normal possible
             cram_variant_calling_normal_joined = cram_variant_calling_normal_to_cross.join(cram_variant_calling_tumor_grouped, failOnDuplicate: true, remainder: true)
             bam_variant_calling_normal_joined = bam_variant_calling_normal_to_cross.join(bam_variant_calling_tumor_grouped, failOnDuplicate: true, remainder: true)
+            cram_markdup_normal_joined = cram_markdup_normal_to_cross.join(cram_markdup_tumor_grouped, failOnDuplicate: true, remainder: true)
+            bam_markdup_normal_joined = bam_markdup_normal_to_cross.join(bam_markdup_tumor_grouped, failOnDuplicate: true, remainder: true)
 
             // 2. Filter out entries with last entry null
             cram_variant_calling_normal_filtered = cram_variant_calling_normal_joined.filter { it -> !(it.last()) }
             bam_variant_calling_normal_filtered = bam_variant_calling_normal_joined.filter { it -> !(it.last()) }
+            cram_markdup_normal_filtered = cram_markdup_normal_joined.filter { it -> !(it.last()) }
+            bam_markdup_normal_filtered = bam_markdup_normal_joined.filter { it -> !(it.last()) }
 
             // 3. Remove patient ID field & null value for further processing [ meta1, [ cram1, crai1 ] ] [ meta2, [ cram2, crai2 ] ] (no transposing needed since only one normal per patient ID)
             cram_variant_calling_status_normal = cram_variant_calling_normal_filtered.map { it -> [it[1], it[2], it[3]] }
             bam_variant_calling_status_normal = bam_variant_calling_normal_filtered.map { it -> [it[1], it[2], it[3]] }
+            cram_markdup_status_normal = cram_markdup_normal_filtered.map { it -> [it[1], it[2], it[3]] }
+            bam_markdup_status_normal = bam_markdup_normal_filtered.map { it -> [it[1], it[2], it[3]] }
         }
         else {
             cram_variant_calling_status_normal = cram_variant_calling_status.normal
             bam_variant_calling_status_normal = bam_variant_calling_status.normal
+            cram_markdup_status_normal = cram_markdup_status.normal
+            bam_markdup_status_normal = bam_markdup_status.normal
         }
 
         // Tumor - normal pairs
@@ -396,6 +457,33 @@ workflow SAREK {
 
                 [meta, normal[2], normal[3], tumor[2], tumor[3]]
             }
+        cram_markdup_pair = cram_markdup_normal_to_cross
+            .cross(cram_markdup_pair_to_cross)
+            .map { normal, tumor ->
+                def meta = [:]
+
+                meta.id = "${tumor[1].sample}_vs_${normal[1].sample}".toString()
+                meta.normal_id = normal[1].sample
+                meta.patient = normal[0]
+                meta.sex = normal[1].sex
+                meta.tumor_id = tumor[1].sample
+                meta.contamination = tumor[1].contamination
+
+                [meta, normal[2], normal[3], tumor[2], tumor[3]]
+            }
+        bam_markdup_pair = bam_markdup_normal_to_cross
+            .cross(bam_markdup_pair_to_cross)
+            .map { normal, tumor ->
+                def meta = [:]
+
+                meta.id = "${tumor[1].sample}_vs_${normal[1].sample}".toString()
+                meta.normal_id = normal[1].sample
+                meta.patient = normal[0]
+                meta.sex = normal[1].sex
+                meta.tumor_id = tumor[1].sample
+
+                [meta, normal[2], normal[3], tumor[2], tumor[3]]
+            }
 
         // GERMLINE VARIANT CALLING
         //   No bwa index for TIDDIT
@@ -409,6 +497,7 @@ workflow SAREK {
             skip_tools,
             bam_variant_calling_status_normal,
             cram_variant_calling_status_normal,
+            cram_markdup_status_normal,
             [[id: 'bwa'], []],
             cnvkit_reference,
             dbsnp,
@@ -445,6 +534,8 @@ workflow SAREK {
             tools,
             bam_variant_calling_tumor_only,
             cram_variant_calling_tumor_only,
+            cram_markdup_tumor_only,
+            bam_markdup_tumor_only,
             [[id: 'bwa'], []],
             cf_chrom_len,
             chr_files,
@@ -477,6 +568,8 @@ workflow SAREK {
             tools,
             bam_variant_calling_pair,
             cram_variant_calling_pair,
+            cram_markdup_pair,
+            bam_markdup_pair,
             [[id: 'bwa'], []],
             cf_chrom_len,
             chr_files,


### PR DESCRIPTION
## Summary

Refactor BQSR routing so that **SV and CNV callers use markdup output (before BQSR)** rather than recalibrated reads. BQSR distorts coverage signals that CNV callers rely on, and SV callers don't benefit from base quality recalibration. SNV callers continue to use the BQSR'd reads (when BQSR is enabled).

A new pre-BQSR `cram_markdup` channel (plus `bam_markdup` for cnvkit) is threaded through the workflow to the relevant callers:

- **SV callers** (manta, tiddit) → `cram_markdup`
- **CNV callers** (cnvkit, controlfreec, ascat, indexcov) → `cram_markdup` / `bam_markdup`
- **SNV callers** (all others) → `cram` / `bam` (BQSR'd when enabled)

## Changes

- `fastq_preprocess_gatk`: emit `cram_markdup` (markdup output before BQSR); falls back to `cram_variant_calling` when `--step recalibrate`
- `workflows/sarek`: mirror the full channel-shaping pipeline (status split, tumor-only grouping/joining, normal-only path, tumor-normal pairing) for the markdup channels; add `CRAM_TO_BAM_MARKDUP` conversion for cnvkit
- `bam_variant_calling_{germline,somatic,tumor_only}_all`: add `cram_markdup` (+ `bam_markdup`) inputs and route SV/CNV callers to them

## Known follow-ups / open questions

- [ ] **`--step recalibrate` fallback** silently uses recalibrated reads for SV/CNV callers (markdup CRAMs aren't available at that entry point). A user-facing warning is still a TODO.
- [ ] **`bam_markdup_pair`** meta block omits `meta.contamination` that `cram_markdup_pair` sets — confirm whether intentional.
- [ ] **No tests/snapshots** updated yet.

> [!NOTE]
> Opening as a **draft** to track the work — not ready for review yet.
