### PR TITLE
Fix save_output_as_bam test: mark sentieon_dedup scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Dependencies - modules
+
+### Dependencies - plugins
+
+### Parameters
+
+### Developer section
+
+#### Added
+
+#### Changed
+
+- Mark sentieon_dedup scenario in `save_output_as_bam` test with `sentieon: true` flag
+
+#### Fixed
+
+#### Removed
+
 ## [3.9.0](https://github.com/nf-core/sarek/releases/tag/3.9.0) - Sarvesjåhkå
 
 Sarvesjåhkå is the biggest stream from Sarvesvágge to flow in Rapaätno.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,6 @@ Sarvesjåhkå is the biggest stream from Sarvesvágge to flow in Rapaätno.
 
 #### Fixed
 
-- [#2217](https://github.com/nf-core/sarek/pull/2217) - Mark sentieon_dedup scenario in `save_output_as_bam` test with `sentieon: true` flag
-
 - [#2117](https://github.com/nf-core/sarek/pull/2117) - Update alignment related files to strict syntax
 - [#2129](https://github.com/nf-core/sarek/pull/2129) - Fix MuSE timestamp, swap to topics and change to strict syntax
 - [#2165](https://github.com/nf-core/sarek/pull/2165) - Recover help message
@@ -92,6 +90,7 @@ Sarvesjåhkå is the biggest stream from Sarvesvágge to flow in Rapaätno.
 - [#2170](https://github.com/nf-core/sarek/pull/2170) - Add index to workflow output for MultiQC
 - [#2189](https://github.com/nf-core/sarek/pull/2189) - Preserve `groupKey` size hint into `groupTuple` in the sentieon haplotyper and dnascope subworkflows so per-sample MERGE*SENTIEON*\*\_VCFS / GVCFS emits progressively as each sample's intervals finish instead of bursting at end-of-haplotyper.
 - [#2197](https://github.com/nf-core/sarek/pull/2197) - Fix controlfreec `versions` emission: swap to topics and remove explicit `versions.mix` wiring
+- [#2217](https://github.com/nf-core/sarek/pull/2217) - Mark sentieon_dedup scenario in `save_output_as_bam` test with `sentieon: true` flag
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,34 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
-
-### Removed
-
-### Dependencies - modules
-
-### Dependencies - plugins
-
-### Parameters
-
-### Developer section
-
-#### Added
-
-#### Changed
-
-- Mark sentieon_dedup scenario in `save_output_as_bam` test with `sentieon: true` flag
-
-#### Fixed
-
-#### Removed
-
 ## [3.9.0](https://github.com/nf-core/sarek/releases/tag/3.9.0) - Sarvesjåhkå
 
 Sarvesjåhkå is the biggest stream from Sarvesvágge to flow in Rapaätno.
@@ -108,6 +80,7 @@ Sarvesjåhkå is the biggest stream from Sarvesvágge to flow in Rapaätno.
 - [#2194](https://github.com/nf-core/sarek/pull/2194) - Update `ensemblvep/vep` module: add `htslib` dependency, support apptainer container engine, fix cache input signature, fix output path patterns
 - [#2194](https://github.com/nf-core/sarek/pull/2194) - Update `main.nf` to use lowercase `channel.*` factory methods (strict syntax)
 - [#2203](https://github.com/nf-core/sarek/pull/2203) - Dedicated GHA for `Sentieon`
+- [#2217](https://github.com/nf-core/sarek/pull/2217) - Mark sentieon_dedup scenario in `save_output_as_bam` test with `sentieon: true` flag
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,10 @@ Sarvesjåhkå is the biggest stream from Sarvesvágge to flow in Rapaätno.
 - [#2194](https://github.com/nf-core/sarek/pull/2194) - Update `ensemblvep/vep` module: add `htslib` dependency, support apptainer container engine, fix cache input signature, fix output path patterns
 - [#2194](https://github.com/nf-core/sarek/pull/2194) - Update `main.nf` to use lowercase `channel.*` factory methods (strict syntax)
 - [#2203](https://github.com/nf-core/sarek/pull/2203) - Dedicated GHA for `Sentieon`
-- [#2217](https://github.com/nf-core/sarek/pull/2217) - Mark sentieon_dedup scenario in `save_output_as_bam` test with `sentieon: true` flag
 
 #### Fixed
+
+- [#2217](https://github.com/nf-core/sarek/pull/2217) - Mark sentieon_dedup scenario in `save_output_as_bam` test with `sentieon: true` flag
 
 - [#2117](https://github.com/nf-core/sarek/pull/2117) - Update alignment related files to strict syntax
 - [#2129](https://github.com/nf-core/sarek/pull/2129) - Fix MuSE timestamp, swap to topics and change to strict syntax

--- a/subworkflows/local/samplesheet_to_channel/tests/main.nf.test
+++ b/subworkflows/local/samplesheet_to_channel/tests/main.nf.test
@@ -56,7 +56,5 @@ nextflow_workflow {
             assert workflow.success
             assert snapshot(workflow.out).match()
         }
-
     }
-
 }

--- a/tests/save_output_as_bam.nf.test
+++ b/tests/save_output_as_bam.nf.test
@@ -30,6 +30,7 @@ nextflow_pipeline {
                 skip_tools: 'baserecalibrator,fastqc,mosdepth,multiqc,samtools',
                 input: "${projectDir}/tests/csv/3.0/mapped_single_cram.csv"
             ]
+            sentieon:true,
         ]
     ]
 

--- a/tests/save_output_as_bam.nf.test
+++ b/tests/save_output_as_bam.nf.test
@@ -29,7 +29,7 @@ nextflow_pipeline {
                 step: 'markduplicates',
                 skip_tools: 'baserecalibrator,fastqc,mosdepth,multiqc,samtools',
                 input: "${projectDir}/tests/csv/3.0/mapped_single_cram.csv"
-            ]
+            ],
             sentieon: true,
         ]
     ]

--- a/tests/save_output_as_bam.nf.test
+++ b/tests/save_output_as_bam.nf.test
@@ -30,7 +30,7 @@ nextflow_pipeline {
                 skip_tools: 'baserecalibrator,fastqc,mosdepth,multiqc,samtools',
                 input: "${projectDir}/tests/csv/3.0/mapped_single_cram.csv"
             ]
-            sentieon:true,
+            sentieon: true,
         ]
     ]
 


### PR DESCRIPTION
Mark the sentieon_dedup test scenario in save_output_as_bam.nf.test with the sentieon: true flag so it gets properly tagged in the test framework.