### PR TITLE
Downgrade controlfreec/assesssignificance to control-freec 11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Sarvesjåhkå is the biggest stream from Sarvesvágge to flow in Rapaätno.
 - [#2189](https://github.com/nf-core/sarek/pull/2189) - Fixes the `interval_name` → `intervals_name` typo in the branch step (was a silent no-op)
 - [#2190](https://github.com/nf-core/sarek/pull/2190) - Fix controlfreec crash in edge cases when no breakpoints are found
 - [#2196](https://github.com/nf-core/sarek/pull/2196) - Update `vep_version` parameter from `115.0-0` to `115.2-1` and fix `loftee_path` from `/usr/local/share` to `/opt/conda/share` to match the container VEP installation path
+- [#2219](https://github.com/nf-core/sarek/pull/2219) - Downgrade `controlfreec/assesssignificance` from `control-freec` 11.6b (`hde5307d_3`) back to 11.6 (`h1b792b2_1`)
 
 ### Removed
 

--- a/modules.json
+++ b/modules.json
@@ -122,7 +122,7 @@
                     },
                     "controlfreec/assesssignificance": {
                         "branch": "master",
-                        "git_sha": "8f6fc518531291208e7a665f6e8bcbeb1f05f49e",
+                        "git_sha": "8a34a4cc59c480816e45d3b68ca11b8eab2edff1",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/controlfreec/assesssignificance/controlfreec-assesssignificance.diff"
                     },

--- a/modules/nf-core/controlfreec/assesssignificance/environment.yml
+++ b/modules/nf-core/controlfreec/assesssignificance/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::control-freec=11.6b
+  - bioconda::control-freec=11.6

--- a/modules/nf-core/controlfreec/assesssignificance/main.nf
+++ b/modules/nf-core/controlfreec/assesssignificance/main.nf
@@ -4,8 +4,8 @@ process CONTROLFREEC_ASSESSSIGNIFICANCE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hde5307d_3'
-        : 'quay.io/biocontainers/control-freec:11.6b--hde5307d_3'}"
+        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6--h1b792b2_1'
+        : 'quay.io/biocontainers/control-freec:11.6--h1b792b2_1'}"
 
     input:
     tuple val(meta), path(cnvs), path(ratio)


### PR DESCRIPTION
## Description

Reverts the `controlfreec/assesssignificance` submodule from `control-freec` 11.6b (`hde5307d_3`) back to 11.6 (`h1b792b2_1`).

## Changes

- `modules/nf-core/controlfreec/assesssignificance/environment.yml` — `control-freec=11.6b` → `control-freec=11.6`
- `modules/nf-core/controlfreec/assesssignificance/main.nf` — container `11.6b--hde5307d_3` → `11.6--h1b792b2_1`
- `modules.json` — pin updated `git_sha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)