### PR TITLE
Update EnsemblVEP to 116.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Update EnsemblVEP to 116.0
+- [#2229](https://github.com/nf-core/sarek/pull/2229) - Update EnsemblVEP to 116.0
 
 ### Fixed
 
@@ -53,12 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - [#2225](https://github.com/nf-core/sarek/pull/2225) - Back to dev (3.9.1dev)
-- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Update nft-utils to 1.0.0, migrate `getAllFilesFromDir` to `getAllFilesFromPath` in test utilities
+- [#2229](https://github.com/nf-core/sarek/pull/2229) - Update nft-utils to 1.0.0, migrate `getAllFilesFromDir` to `getAllFilesFromPath` in test utilities
 
 #### Fixed
 
 - [#2208](https://github.com/nf-core/sarek/pull/2208) - Update freebayes params (remove `--pooled-discrete` and change `--min-alternate-fraction` from 0.03 to 0.01), move chunk_size param
-- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Fix LoFTEE test to validate CSQ fields instead of asserting nothing
+- [#2229](https://github.com/nf-core/sarek/pull/2229) - Fix LoFTEE test to validate CSQ fields instead of asserting nothing
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Update EnsemblVEP to 116.0
+
 ### Fixed
 
 ### Removed
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Dependency    | Old version | New version |
 | ------------- | ----------- | ----------- |
 | varlociraptor | 8.9.3       | 8.9.5       |
+| ensembl-vep   | 115.2       | 116.0       |
 
 ### Dependencies - plugins
 
@@ -37,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | `--varlociraptor_events_tumor_only` | New    |
 | `--varlociraptor_fdr`               | New    |
 
+| Parameter   | Old default | New default |
+| ----------- | ----------- | ----------- |
+| vep_version | 115.2-1     | 116.0-0     |
+
 ### Developer section
 
 #### Added
@@ -46,10 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - [#2225](https://github.com/nf-core/sarek/pull/2225) - Back to dev (3.9.1dev)
+- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Update nft-utils to 1.0.0, migrate `getAllFilesFromDir` to `getAllFilesFromPath` in test utilities
 
 #### Fixed
 
 - [#2208](https://github.com/nf-core/sarek/pull/2208) - Update freebayes params (remove `--pooled-discrete` and change `--min-alternate-fraction` from 0.03 to 0.01), move chunk_size param
+- [#XXXX](https://github.com/nf-core/sarek/pull/XXXX) - Fix LoFTEE test to validate CSQ fields instead of asserting nothing
 
 #### Removed
 

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -77,7 +77,7 @@ params {
             pon_tbi                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000g_pon.hg38.vcf.gz.tbi"
             sentieon_dnascope_model = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/Sentieon/SentieonDNAscopeModel1.1.model"
             snpeff_db               = 'GRCh38.99'
-            vep_cache_version       = '115'
+            vep_cache_version       = '116'
             vep_genome              = 'GRCh38'
             vep_species             = 'homo_sapiens'
         }
@@ -96,7 +96,7 @@ params {
             fasta                 = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
             ngscheckmate_bed      ="${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/NGSCheckMate/SNP_GRCh38_hg38_wChr.bed"
             snpeff_db             = 'GRCh38.99'
-            vep_cache_version     = '115'
+            vep_cache_version     = '116'
             vep_genome            = 'GRCh38'
             vep_species           = 'homo_sapiens'
         }
@@ -239,7 +239,7 @@ params {
             bwa                   = "${params.igenomes_base}/Homo_sapiens/UCSC/hg38/Sequence/BWAIndex/version0.6.0/"
             fasta                 = "${params.igenomes_base}/Homo_sapiens/UCSC/hg38/Sequence/WholeGenomeFasta/genome.fa"
             snpeff_db             = 'GRCh38.99'
-            vep_cache_version     = '115'
+            vep_cache_version     = '116'
             vep_genome            = 'GRCh38'
             vep_species           = 'homo_sapiens'
         }

--- a/docs/DEVELOPER_GUIDELINES.md
+++ b/docs/DEVELOPER_GUIDELINES.md
@@ -489,6 +489,12 @@ nf-core modules update <tool>/<subcommand>
 nf-core modules list local
 ```
 
+### Updating VEP modules
+
+When updating `ensemblvep/vep` module, always update the `vep_version` parameter to match the new VEP version. This parameter is used by the LoFTEE plugin to locate the VEP installation path (e.g. `/opt/conda/share/ensembl-vep-${vep_version}`).
+
+Also update `vep_cache_version` in `conf/igenomes.config` for available genomes, based on what's available on [annotation-cache](https://annotation-cache.github.io/ensemblvep/). Not all genomes may have a cache for the new version — only update those that do.
+
 ---
 
 ## Subworkflows

--- a/modules.json
+++ b/modules.json
@@ -163,12 +163,12 @@
                     },
                     "ensemblvep/download": {
                         "branch": "master",
-                        "git_sha": "251885fdb29eca03523d326aca5c827d1f6bdfeb",
+                        "git_sha": "db055f5f8c726a924bf51dadce3978da3bbdad7e",
                         "installed_by": ["cache_download_ensemblvep_snpeff", "modules"]
                     },
                     "ensemblvep/vep": {
                         "branch": "master",
-                        "git_sha": "251885fdb29eca03523d326aca5c827d1f6bdfeb",
+                        "git_sha": "db055f5f8c726a924bf51dadce3978da3bbdad7e",
                         "installed_by": ["modules"]
                     },
                     "fastp": {

--- a/modules/nf-core/ensemblvep/download/environment.yml
+++ b/modules/nf-core/ensemblvep/download/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/ensembl-vep
-  - bioconda::ensembl-vep=115.2
+  - bioconda::ensembl-vep=116.0
   # renovate: datasource=conda depName=bioconda/perl-math-cdf
   - bioconda::perl-math-cdf=0.1
   # renovate: datasource=conda depName=bioconda/htslib

--- a/modules/nf-core/ensemblvep/download/main.nf
+++ b/modules/nf-core/ensemblvep/download/main.nf
@@ -4,8 +4,8 @@ process ENSEMBLVEP_DOWNLOAD {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ed/edd02dfaf968d06c808e3c208d5b3e86afb4259590bfa6e5499965ef3bc81881/data'
-        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:efd9a6d1c5f218a9'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/11/112b7b57f93b053ccd3f8b2f2207a5faa629fd4ea181af8e1a41a1fbd007e657/data'
+        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:c4edd3fb4a233ae6'}"
 
     input:
     tuple val(meta), val(assembly), val(species), val(cache_version)

--- a/modules/nf-core/ensemblvep/vep/environment.yml
+++ b/modules/nf-core/ensemblvep/vep/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/ensembl-vep
-  - bioconda::ensembl-vep=115.2
+  - bioconda::ensembl-vep=116.0
   # renovate: datasource=conda depName=bioconda/perl-math-cdf
   - bioconda::perl-math-cdf=0.1
   # renovate: datasource=conda depName=bioconda/htslib

--- a/modules/nf-core/ensemblvep/vep/main.nf
+++ b/modules/nf-core/ensemblvep/vep/main.nf
@@ -4,8 +4,8 @@ process ENSEMBLVEP_VEP {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ed/edd02dfaf968d06c808e3c208d5b3e86afb4259590bfa6e5499965ef3bc81881/data'
-        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:efd9a6d1c5f218a9'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/11/112b7b57f93b053ccd3f8b2f2207a5faa629fd4ea181af8e1a41a1fbd007e657/data'
+        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:c4edd3fb4a233ae6'}"
 
     input:
     tuple val(meta), path(vcf), path(custom_extra_files)

--- a/nextflow.config
+++ b/nextflow.config
@@ -142,7 +142,7 @@ params {
     vep_cache_preflight_check = false // No preflight check by default
     vep_spliceai              = null // spliceai plugin disabled within VEP
     vep_spliceregion          = null // spliceregion plugin disabled within VEP
-    vep_version               = "115.2-1"      // Should be updated when we update VEP, needs this to get full path to some plugins
+    vep_version               = "116.0-0"      // Should be updated when we update VEP, needs this to get full path to some plugins
 
     // MultiQC options
     multiqc_config              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -777,7 +777,7 @@
                 },
                 "vep_version": {
                     "type": "string",
-                    "default": "115.2-1",
+                    "default": "116.0-0",
                     "fa_icon": "fas fa-toolbox",
                     "description": "Should reflect the VEP version used in the container.",
                     "help_text": "Used by the loftee plugin which needs the full path to the VEP installation (e.g. `/opt/conda/share/ensembl-vep-${vep_version}`). Update this when the VEP container version changes."

--- a/nf-test.config
+++ b/nf-test.config
@@ -20,7 +20,7 @@ config {
     // load the necessary plugins
     plugins {
         load "nft-bam@0.6.1"
-        load "nft-utils@0.0.9"
+        load "nft-utils@1.0.0"
         load "nft-vcf@1.0.7"
     }
 }

--- a/tests/annotation_merge.nf.test.snap
+++ b/tests/annotation_merge.nf.test.snap
@@ -4,7 +4,7 @@
             5,
             {
                 "ENSEMBLVEP_VEP": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 },
@@ -16,7 +16,7 @@
                     "tabix": "1.21"
                 },
                 "VCF_ANNOTATE_MERGE": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 }
@@ -109,10 +109,10 @@
             ],
             "No warnings"
         ],
-        "timestamp": "2026-05-27T10:13:01.036308477",
+        "timestamp": "2026-07-08T10:14:04.788318141",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "26.04.4"
         }
     },
     "-profile test --tools merge,snpsift": {
@@ -133,7 +133,7 @@
                     "tabix": "1.21"
                 },
                 "VCF_ANNOTATE_MERGE": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 }
@@ -220,10 +220,10 @@
             ],
             "No warnings"
         ],
-        "timestamp": "2026-05-27T10:14:01.977520509",
+        "timestamp": "2026-07-08T10:15:44.567611717",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "26.04.4"
         }
     },
     "-profile test --tools merge": {
@@ -238,7 +238,7 @@
                     "tabix": "1.21"
                 },
                 "VCF_ANNOTATE_MERGE": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 }
@@ -320,10 +320,10 @@
             ],
             "No warnings"
         ],
-        "timestamp": "2026-05-27T10:12:05.371914045",
+        "timestamp": "2026-07-08T10:12:53.660022078",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/tests/annotation_vep.nf.test
+++ b/tests/annotation_vep.nf.test
@@ -41,6 +41,7 @@ nextflow_pipeline {
                 tools: 'vep',
                 vep_loftee: true,
             ],
+            vcf_header_check: '|LoF|',
         ],
     ]
 

--- a/tests/annotation_vep.nf.test.snap
+++ b/tests/annotation_vep.nf.test.snap
@@ -4,7 +4,7 @@
             2,
             {
                 "ENSEMBLVEP_VEP": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 }
@@ -52,12 +52,15 @@
             [
                 "test_VEP.ann.vcf.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
+            [
+                "test_VEP.ann.vcf.gz:header.contains(|LoF|),true"
+            ],
             "No warnings"
         ],
-        "timestamp": "2026-05-27T13:40:41.25343459",
+        "timestamp": "2026-07-08T10:26:06.53157943",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "26.04.4"
         }
     },
     "Fails with profile test --dbnsfp and no dbnsfp_tbi": {

--- a/tests/lib/UTILS.groovy
+++ b/tests/lib/UTILS.groovy
@@ -14,6 +14,7 @@ class UTILS {
 
         // These strings are not stable and should be ignored
         def snapshot_ignore_list = [
+            "Check script",
             "Creating env using",
             "Downloading plugin",
             "Got an interrupted  exception while taking agent result",
@@ -61,7 +62,7 @@ class UTILS {
             assertion.add(cram_files.isEmpty() ? 'No CRAM files' : cram_files.collect { file -> file.tokenize('/').last() + ":md5," + cram(absolutePath(file), fasta).readsMD5 })
             if (scenario.include_muse_txt) {
                 // It will skip the first line of the txt file
-                assertion.add(txt_files.isEmpty() ? 'No TXT files' : txt_files.collect{ file -> file.getName() + ":md5," + file.readLines()[2..-1].join('\n').md5() })
+                assertion.add(txt_files.isEmpty() ? 'No TXT files' : txt_files.collect { file -> file.tokenize('/').last() + ":md5," + path(absolutePath(file)).readLines().drop(2).join('\n').md5() })
             }
             if (scenario.include_freebayes_unfiltered) {
                 // It will only print the vcf summary to avoid differing md5sums because of small differences in QUAL score

--- a/tests/lib/UTILS.groovy
+++ b/tests/lib/UTILS.groovy
@@ -24,26 +24,28 @@ class UTILS {
         ]
 
         // stable_name: All files + folders in ${outdir}/ with a stable name
-        def stable_name = getAllFilesFromDir(outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+        def stable_name = getAllFilesFromPath(outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
         // stable_content: All files in ${outdir}/ with stable content
-        def stable_content = getAllFilesFromDir(outdir, ignoreFile: 'tests/.nftignore', ignore: [scenario.ignoreFiles ])
+        def stable_content = getAllFilesFromPath(outdir, ignoreFile: 'tests/.nftignore', ignore: [scenario.ignoreFiles])
         // bam_files: All bam files
-        def bam_files = getAllFilesFromDir(outdir, include: ['**/*.bam'], ignore: [scenario.ignoreFiles ])
+        def bam_files = getAllFilesFromPath(outdir, include: ['**/*.bam'], ignore: [scenario.ignoreFiles])
         // cram_files: All cram files
-        def cram_files = getAllFilesFromDir(outdir, include: ['**/*.cram'], ignore: [scenario.ignoreFiles ])
+        def cram_files = getAllFilesFromPath(outdir, include: ['**/*.cram'], ignore: [scenario.ignoreFiles])
         // Fasta file for cram verification with nft-bam
         def fasta_base = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
         def fasta = fasta_base + 'genomics/homo_sapiens/genome/genome.fasta'
         // txt_files: MuSE txt files
-        def txt_files = getAllFilesFromDir(outdir, include: ['**/*.MuSE.txt'])
+        def txt_files = getAllFilesFromPath(outdir, include: ['**/*.MuSE.txt'])
         // vcf_files: All vcf files
-        def vcf_files = getAllFilesFromDir(outdir, include: ['**/*.vcf{,.gz}'], ignore: [scenario.ignoreFiles ])
+        def vcf_files = getAllFilesFromPath(outdir, include: ['**/*.vcf{,.gz}'], ignore: [scenario.ignoreFiles])
         // freebayes_unfiltered: vcf files from freebayes without quality filtering
-        def freebayes_unfiltered = getAllFilesFromDir(outdir, include: ['**/*.freebayes.vcf.gz'])
+        def freebayes_unfiltered = getAllFilesFromPath(outdir, include: ['**/*.freebayes.vcf.gz'])
         // varlociraptor vcf
-        def varlociraptor_vcf = getAllFilesFromDir(outdir, include: ['**/*.varlociraptor.{vcf}{,.gz}'])
+        def varlociraptor_vcf = getAllFilesFromPath(outdir, include: ['**/*.varlociraptor.{vcf}{,.gz}'])
 
         def assertion = []
+        // getAllFilesFromPath returns relative paths (strings), so this resolves to an absolute path
+        def absolutePath = { file -> file.toString().startsWith('/') ? file.toString() : "${outdir}/${file}" }
 
         if (!scenario.failure) {
             assertion.add(workflow.trace.succeeded().size())
@@ -54,26 +56,31 @@ class UTILS {
         assertion.add(stable_name)
 
         if (!scenario.stub) {
-            assertion.add(stable_content.isEmpty() ? 'No stable content' : stable_content)
-            assertion.add(bam_files.isEmpty() ? 'No BAM files' : bam_files.collect { file -> file.getName() + ":md5," + bam(file.toString()).readsMD5 })
-            assertion.add(cram_files.isEmpty() ? 'No CRAM files' : cram_files.collect { file -> file.getName() + ":md5," + cram(file.toString(), fasta).readsMD5 })
+            assertion.add(stable_content.isEmpty() ? 'No stable content' : stable_content.collect { file -> path(absolutePath(file)) })
+            assertion.add(bam_files.isEmpty() ? 'No BAM files' : bam_files.collect { file -> file.tokenize('/').last() + ":md5," + bam(absolutePath(file)).readsMD5 })
+            assertion.add(cram_files.isEmpty() ? 'No CRAM files' : cram_files.collect { file -> file.tokenize('/').last() + ":md5," + cram(absolutePath(file), fasta).readsMD5 })
             if (scenario.include_muse_txt) {
                 // It will skip the first line of the txt file
                 assertion.add(txt_files.isEmpty() ? 'No TXT files' : txt_files.collect{ file -> file.getName() + ":md5," + file.readLines()[2..-1].join('\n').md5() })
             }
             if (scenario.include_freebayes_unfiltered) {
                 // It will only print the vcf summary to avoid differing md5sums because of small differences in QUAL score
-                assertion.add(freebayes_unfiltered.isEmpty() ? 'No Freebayes unfiltered VCF files' : freebayes_unfiltered.collect { file -> [ file.getName(), path(file.toString()).vcf.summary ] })
+                assertion.add(freebayes_unfiltered.isEmpty() ? 'No Freebayes unfiltered VCF files' : freebayes_unfiltered.collect { file -> [ file.getName(), path(absolutePath(file)).vcf.summary ] })
             }
             if (scenario.no_vcf_md5sum) {
                 // Will print the summary instead of the md5sum for vcf files
-                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> [ file.getName(), path(file.toString()).vcf.summary ] })
+                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> [ file.getName(), path(absolutePath(file)).vcf.summary ] })
             } else {
-                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> file.getName() + ":md5," + path(file.toString()).vcf.variantsMD5 })
+                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> file.tokenize('/').last() + ":md5," + path(absolutePath(file)).vcf.variantsMD5 })
                 if (scenario.include_varlociraptor_vcf) {
                     // It will use the summary method to extract the vcf file content
-                    assertion.add(varlociraptor_vcf.isEmpty() ? 'No Varlociraptor VCF files' : varlociraptor_vcf.collect { file -> file.getName() + ":summary," + path(file.toString()).vcf.summary })
+                    assertion.add(varlociraptor_vcf.isEmpty() ? 'No Varlociraptor VCF files' : varlociraptor_vcf.collect { file -> file.tokenize('/').last() + ":summary," + path(absolutePath(file)).vcf.summary })
                 }
+            }
+
+            // Check for specific VCF header fields if requested
+            if (scenario.vcf_header_check) {
+                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> file.tokenize('/').last() + ":header.contains(${scenario.vcf_header_check})," + path(absolutePath(file)).vcf.header.toString().contains(scenario.vcf_header_check) })
             }
         }
 

--- a/tests/lib/UTILS.groovy
+++ b/tests/lib/UTILS.groovy
@@ -66,11 +66,11 @@ class UTILS {
             }
             if (scenario.include_freebayes_unfiltered) {
                 // It will only print the vcf summary to avoid differing md5sums because of small differences in QUAL score
-                assertion.add(freebayes_unfiltered.isEmpty() ? 'No Freebayes unfiltered VCF files' : freebayes_unfiltered.collect { file -> [ file.getName(), path(absolutePath(file)).vcf.summary ] })
+                assertion.add(freebayes_unfiltered.isEmpty() ? 'No Freebayes unfiltered VCF files' : freebayes_unfiltered.collect { file -> [ file.tokenize('/').last(), path(absolutePath(file)).vcf.summary ] })
             }
             if (scenario.no_vcf_md5sum) {
                 // Will print the summary instead of the md5sum for vcf files
-                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> [ file.getName(), path(absolutePath(file)).vcf.summary ] })
+                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> [ file.tokenize('/').last(), path(absolutePath(file)).vcf.summary ] })
             } else {
                 assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> file.tokenize('/').last() + ":md5," + path(absolutePath(file)).vcf.variantsMD5 })
                 if (scenario.include_varlociraptor_vcf) {

--- a/tests/samplesheets.nf.test.snap
+++ b/tests/samplesheets.nf.test.snap
@@ -29,8 +29,7 @@
             [
                 "The following invalid input values have been detected:",
                 "* --input ([PATH]/./tests/csv/3.0/fastq_sample_with_space.csv): Validation of file failed:",
-                "\t-> Entry 2: Error for field 'sample' (test 2): \"test 2\" does not match regular expression [^\\S+$] (Sample ID must be provided, cannot contain spaces and must be a string value)",
-                " -- Check script '[PATH]/subworkflows/nf-core/utils_nfschema_plugin/main.nf' at line: 72 or see '[PATH]/tests/[NFT_HASH]/meta/nextflow.log' file for more details"
+                "\t-> Entry 2: Error for field 'sample' (test 2): \"test 2\" does not match regular expression [^\\S+$] (Sample ID must be provided, cannot contain spaces and must be a string value)"
             ]
         ],
         "meta": {


### PR DESCRIPTION
Update EnsemblVEP from 115.2 to 116.0, following the changes made in nf-core/rnavar#318.

Changes:
- Update ensemblvep modules (download and vep) to 116.0
- Update `vep_version` from 115.2-1 to 116.0-0
- Update `vep_cache_version` to 116 for GRCh38 genomes (GRCh37 remains at 115 as it's not on annotation-cache)
- Add VEP module update guidelines to developer docs
- Update nft-utils to 1.0.0, migrate `getAllFilesFromDir` to `getAllFilesFromPath`
- Add `vcf_header_check` support for LoFTEE test validation
- Regenerate test snapshots

---

Generated by opencode
Verified by @maxulysse 