### PR TITLE
Replace deprecated `channel.from` with `channel.of` in prepare_genome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2178](https://github.com/nf-core/sarek/pull/2178) - Template update for nf-core/tools v4.0.2
 - [#2225](https://github.com/nf-core/sarek/pull/2225) - Back to dev (3.9.1dev)
 - [#2229](https://github.com/nf-core/sarek/pull/2229) - Update nft-utils to 1.0.0, migrate `getAllFilesFromDir` to `getAllFilesFromPath` in test utilities
+- [#2233](https://github.com/nf-core/sarek/pull/2233) - Replace the last remaining deprecated `channel.from` with `channel.of` in `prepare_genome`
 
 #### Fixed
 

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -129,7 +129,7 @@ workflow PREPARE_GENOME {
         }
         else if (bbsplit_fasta_list_in) {
             // Build it from scratch if we have FASTA
-            channel.from(file(bbsplit_fasta_list_in, checkIfExists: true))
+            channel.of(file(bbsplit_fasta_list_in, checkIfExists: true))
                 .splitCsv(header: false, sep: ',')
                 .flatMap { id, fafile -> [['id', id], ['fasta', file(fafile, checkIfExists: true)]] }
                 .groupTuple()


### PR DESCRIPTION
## Description

Replace the last remaining `channel.from` call with `channel.of` in `subworkflows/local/prepare_genome/main.nf`.

`channel.from` is deprecated in favour of `channel.of`/`channel.fromList` and prints a runtime deprecation warning. It is not flagged by `nextflow lint` (only the capital-`Channel` namespace is), and it does not break on 25.10 or 26.x — this is deprecation cleanup, not a compatibility fix: [https://docs.seqera.io/nextflow/tutorials/static-types#avoid-deprecated-patterns](https://docs.seqera.io/nextflow/tutorials/static-types#avoid-deprecated-patterns)

## Changes

- `subworkflows/local/prepare_genome/main.nf` line 132: `channel.from(...)` → `channel.of(...)`
- `CHANGELOG.md`: added entry under `### Changed`

## Semantics

The argument is a single file object (`file(bbsplit_fasta_list_in, checkIfExists: true)` returns a single Path), so `channel.of` is a direct drop-in with identical behaviour. The downstream `.splitCsv()` chain is unaffected.