### PR TITLE
Replace `.set {}` with plain assignment for strict-syntax readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2225](https://github.com/nf-core/sarek/pull/2225) - Back to dev (3.9.1dev)
 - [#2229](https://github.com/nf-core/sarek/pull/2229) - Update nft-utils to 1.0.0, migrate `getAllFilesFromDir` to `getAllFilesFromPath` in test utilities
 - [#2233](https://github.com/nf-core/sarek/pull/2233) - Replace the last remaining deprecated `channel.from` with `channel.of` in `prepare_genome`
-- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Replace deprecated `.set {}` channel terminator with plain assignment in local subworkflows for Nextflow strict-syntax / 26.x readiness
+- [#2234](https://github.com/nf-core/sarek/pull/2234) - Replace deprecated `.set {}` channel terminator with plain assignment in local subworkflows for Nextflow strict-syntax / 26.x readiness
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2225](https://github.com/nf-core/sarek/pull/2225) - Back to dev (3.9.1dev)
 - [#2229](https://github.com/nf-core/sarek/pull/2229) - Update nft-utils to 1.0.0, migrate `getAllFilesFromDir` to `getAllFilesFromPath` in test utilities
 - [#2233](https://github.com/nf-core/sarek/pull/2233) - Replace the last remaining deprecated `channel.from` with `channel.of` in `prepare_genome`
+- [#XXX](https://github.com/nf-core/sarek/pull/XXX) - Replace deprecated `.set {}` channel terminator with plain assignment in local subworkflows for Nextflow strict-syntax / 26.x readiness
 
 #### Fixed
 

--- a/subworkflows/local/fastq_preprocess_gatk/main.nf
+++ b/subworkflows/local/fastq_preprocess_gatk/main.nf
@@ -157,14 +157,13 @@ workflow FASTQ_PREPROCESS_GATK {
         // First, we must calculate number of lanes for each sample (meta.n_fastq)
         // This is needed to group reads from the same sample together using groupKey to avoid stalling the workflow
         // when reads from different samples are mixed together
-        reads_for_alignment.map { meta, reads ->
+        reads_grouping_key = reads_for_alignment.map { meta, reads ->
                 [ meta.subMap('patient', 'sample', 'sex', 'status'), reads ]
             }
             .groupTuple()
             .map { meta, reads ->
                 meta + [ n_fastq: reads.size() ] // We can drop the FASTQ files now that we know how many there are
             }
-            .set { reads_grouping_key }
 
         reads_for_alignment = reads_for_alignment.map{ meta, reads ->
             // Update meta.id to meta.sample no multiple lanes or splitted fastqs

--- a/subworkflows/local/fastq_preprocess_parabricks/main.nf
+++ b/subworkflows/local/fastq_preprocess_parabricks/main.nf
@@ -21,13 +21,13 @@ workflow FASTQ_PREPROCESS_PARABRICKS {
     ch_versions = channel.empty()
     ch_reports  = channel.empty()
 
-    ch_reads.map { meta, reads ->
+    reads_grouping_key = ch_reads.map { meta, reads ->
             [ meta.subMap('patient', 'sample', 'sex', 'status'), reads ]
         }
         .groupTuple()
         .map { meta, reads ->
             meta + [ n_fastq: reads.size() ] // We can drop the FASTQ files now that we know how many there are
-        }.set { reads_grouping_key }
+        }
 
     ch_reads = ch_reads.map{ meta, reads ->
         // Update meta.id to meta.sample no multiple lanes or splitted fastqs

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -129,13 +129,12 @@ workflow PREPARE_GENOME {
         }
         else if (bbsplit_fasta_list_in) {
             // Build it from scratch if we have FASTA
-            channel.of(file(bbsplit_fasta_list_in, checkIfExists: true))
+            ch_bbsplit_fasta_list = channel.of(file(bbsplit_fasta_list_in, checkIfExists: true))
                 .splitCsv(header: false, sep: ',')
                 .flatMap { id, fafile -> [['id', id], ['fasta', file(fafile, checkIfExists: true)]] }
                 .groupTuple()
                 .map { it -> it[1] }
                 .collect { [it] }
-                .set { ch_bbsplit_fasta_list }
 
             bbsplit_index = BBMAP_INDEX(
                 [[id: "build_index"], []],

--- a/subworkflows/local/prepare_snpsift_databases/main.nf
+++ b/subworkflows/local/prepare_snpsift_databases/main.nf
@@ -12,10 +12,10 @@ workflow PREPARE_SNPSIFT_DATABASES {
     ch_configs = channel.fromList(val_db_configs)
 
     // Branch: create vardb if not provided
-    ch_configs.branch {
+    ch_branched = ch_configs.branch {
         has_vardb: it.vardb != null
         needs_vardb: true
-    }.set { ch_branched }
+    }
 
     // Create vardbs for databases that need them
     // Convert semicolon-separated fields to comma-separated (SnpSift expects commas)


### PR DESCRIPTION
## Description

Replaces the deprecated `.set {}` channel terminator with plain leading
assignment in four local subworkflows. This pattern still runs in Nextflow
26.x but is flagged by the static-types type checker, so this is part of the
granular strict-syntax cleanup series.

Pure mechanical, semantics-preserving change (`.set { name }` → `name = <chain>`):

- `subworkflows/local/prepare_snpsift_databases/main.nf` — `ch_branched`
- `subworkflows/local/fastq_preprocess_gatk/main.nf` — `reads_grouping_key`
- `subworkflows/local/fastq_preprocess_parabricks/main.nf` — `reads_grouping_key`
- `subworkflows/local/prepare_genome/main.nf` — `ch_bbsplit_fasta_list`

## PR checklist

- [x] Targets the `dev` branch
- [x] `CHANGELOG.md` updated (Developer section)
- [ ] No functional/output changes — no tests or docs affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
