### PR TITLE
chore(modules): migrate alignment/UMI/utility modules to versions topic channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2235](https://github.com/nf-core/sarek/pull/2235) - Nextflow strict-syntax / 26.x readiness for local code: explicit, named closure parameters (replacing implicit/generic `it`), `_`-prefixed unused parameters, and removal of unused `take:` inputs. Previously-dropped Manta candidate VCFs and Sentieon gVCF indices are now emitted.
 - [#2235](https://github.com/nf-core/sarek/pull/2235) - germline CNVKIT reuses the shared `CRAM_TO_BAM` conversion instead of re-converting CRAM internally, avoiding a duplicate conversion. Side effect: with `--step variant_calling` (user-supplied CRAM/BAM), CNVKit output files are named after the input file rather than the sample; runs from FASTQ are unaffected.
 - [#2238](https://github.com/nf-core/sarek/pull/2238) - Migrate `gatk4`/`gatk4spark` modules to the versions topic channel (bumps gatk4spark 4.6.1.0 → 4.6.2.0)
+- [#2239](https://github.com/nf-core/sarek/pull/2239) - Migrate alignment/UMI/utility modules (`bwa`, `bwamem2`, `dragmap`, `fgbio`, `fastp`, `cat`, `gawk`, `gunzip`, `untar`, `unzip`, `spring`) to the versions topic channel (fastp 0.24.0 → 1.1.0)
 
 ### Fixed
 
@@ -37,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | ensembl-vep   | 115.2       | 116.0       |
 | gatk4         | 4.6.1.0     | 4.6.2.0     |
 | gatk4-spark   | 4.6.1.0     | 4.6.2.0     |
+| bwa           | 0.7.18      | 0.7.19      |
+| bwa-mem2      | 2.2.1       | 2.3         |
+| fastp         | 0.24.0      | 1.1.0       |
+| fgbio         | 2.4.0       | 3.1.2       |
+| gawk          | 5.3.0       | 5.3.1       |
+| pigz          | 2.3.4       | 2.8         |
 
 ### Dependencies - plugins
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -135,7 +135,7 @@ The resulting files are intermediate and by default not kept in the final files 
 
 **Output directory: `{outdir}/preprocessing/fastp/<sample>`**
 
-- `<sample>_<lane>_{1,2}.fastp.fastq.gz>`
+- `<sample>_<lane>_{R1,R2}.fastp.fastq.gz>`
   - Bgzipped FastQ file
 
 </details>
@@ -151,7 +151,7 @@ These files are intermediate and by default not placed in the output-folder kept
 
 **Output directory: `{outdir}/preprocessing/fastp/<sample>/`**
 
-- `<sample_lane_{1,2}.fastp.fastq.gz>`
+- `<sample>_<lane>_{R1,R2}.fastp.fastq.gz>`
   - Bgzipped FastQ file
 
 </details>

--- a/modules.json
+++ b/modules.json
@@ -62,32 +62,32 @@
                     },
                     "bwa/index": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "bwa/mem": {
                         "branch": "master",
-                        "git_sha": "a29f18660f5e3748d44d6f716241e70c942c065d",
+                        "git_sha": "2fb127c8fd13de0adaa676df7169131e45c0b114",
                         "installed_by": ["modules"]
                     },
                     "bwamem2/index": {
                         "branch": "master",
-                        "git_sha": "b2902040b9cb9b7b32b62400f1c024a709bd4812",
+                        "git_sha": "62ce917fd775aaef732eb82019de069c765adfd3",
                         "installed_by": ["modules"]
                     },
                     "bwamem2/mem": {
                         "branch": "master",
-                        "git_sha": "a29f18660f5e3748d44d6f716241e70c942c065d",
+                        "git_sha": "62ce917fd775aaef732eb82019de069c765adfd3",
                         "installed_by": ["modules"]
                     },
                     "cat/cat": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "eac429d4c67ac5114ce7d4287d460d8f05fd9fab",
                         "installed_by": ["modules"]
                     },
                     "cat/fastq": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "cnvkit/antitarget": {
@@ -153,12 +153,12 @@
                     },
                     "dragmap/align": {
                         "branch": "master",
-                        "git_sha": "8b06d86f6a82b6203f239ad409f606fdf71ec697",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "dragmap/hashtable": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "ensemblvep/download": {
@@ -173,7 +173,7 @@
                     },
                     "fastp": {
                         "branch": "master",
-                        "git_sha": "d082103d7976a2804f21225446cc110cbd822f4c",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fastqc": {
@@ -183,22 +183,22 @@
                     },
                     "fgbio/callmolecularconsensusreads": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fgbio/copyumifromreadname": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fgbio/fastqtobam": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fgbio/groupreadsbyumi": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "freebayes": {
@@ -333,7 +333,7 @@
                     },
                     "gawk": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "goleft/indexcov": {
@@ -343,7 +343,7 @@
                     },
                     "gunzip": {
                         "branch": "master",
-                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "git_sha": "0902eac3012baaf4f9ab6513c8c55acc9353c96c",
                         "installed_by": ["modules"]
                     },
                     "lofreq/callparallel": {
@@ -528,7 +528,7 @@
                     },
                     "spring/decompress": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "strelka/germline": {
@@ -563,12 +563,12 @@
                     },
                     "untar": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "unzip": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "1c43a7e22f04cf19c9f9d3de7e7e5a3addd9382a",
                         "installed_by": ["modules"]
                     },
                     "varlociraptor/callvariants": {

--- a/modules/nf-core/bwa/index/environment.yml
+++ b/modules/nf-core/bwa/index/environment.yml
@@ -6,8 +6,8 @@ channels:
 
 dependencies:
   # renovate: datasource=conda depName=bioconda/bwa
-  - bioconda::bwa=0.7.18
+  - bioconda::bwa=0.7.19
   # renovate: datasource=conda depName=bioconda/htslib
-  - bioconda::htslib=1.21
+  - bioconda::htslib=1.22.1
   # renovate: datasource=conda depName=bioconda/samtools
-  - bioconda::samtools=1.21
+  - bioconda::samtools=1.22.1

--- a/modules/nf-core/bwa/index/main.nf
+++ b/modules/nf-core/bwa/index/main.nf
@@ -2,19 +2,19 @@ process BWA_INDEX {
     tag "$fasta"
     // NOTE requires 5.37N memory where N is the size of the database
     // source: https://bio-bwa.sourceforge.net/bwa.shtml#8
-    memory { 6.B * fasta.size() }
+    memory { 7.B * fasta.size() }
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/bf/bf7890f8d4e38a7586581cb7fa13401b7af1582f21d94eef969df4cea852b6da/data' :
-        'community.wave.seqera.io/library/bwa_htslib_samtools:56c9f8d5201889a4' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d7/d7e24dc1e4d93ca4d3a76a78d4c834a7be3985b0e1e56fddd61662e047863a8a/data' :
+        'community.wave.seqera.io/library/bwa_htslib_samtools:83b50ff84ead50d0' }"
 
     input:
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path("bwa")  , emit: index
-    path "versions.yml"             , emit: versions
+    tuple val(meta), path("bwa"), emit: index
+    tuple val("${task.process}"), val('bwa'), eval('bwa 2>&1 | sed -n "s/^Version: //p"'), topic: versions, emit: versions_bwa
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,27 +29,16 @@ process BWA_INDEX {
         $args \\
         -p bwa/${prefix} \\
         $fasta
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${fasta.baseName}"
     """
     mkdir bwa
-
     touch bwa/${prefix}.amb
     touch bwa/${prefix}.ann
     touch bwa/${prefix}.bwt
     touch bwa/${prefix}.pac
     touch bwa/${prefix}.sa
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bwa/index/meta.yml
+++ b/modules/nf-core/bwa/index/meta.yml
@@ -42,17 +42,30 @@ output:
           pattern: "*.{amb,ann,bwt,pac,sa}"
           ontologies:
             - edam: "http://edamontology.org/data_3210" # Genome index
+  versions_bwa:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bwa:
+          type: string
+          description: The tool name
+      - 'bwa 2>&1 | sed -n "s/^Version: //p"':
+          type: string
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bwa:
+          type: string
+          description: The tool name
+      - 'bwa 2>&1 | sed -n "s/^Version: //p"':
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@drpatelh"
   - "@maxulysse"
 maintainers:
-  - "@drpatelh"
   - "@maxulysse"
   - "@gallvp"

--- a/modules/nf-core/bwa/mem/environment.yml
+++ b/modules/nf-core/bwa/mem/environment.yml
@@ -6,8 +6,8 @@ channels:
 
 dependencies:
   # renovate: datasource=conda depName=bioconda/bwa
-  - bioconda::bwa=0.7.18
+  - bioconda::bwa=0.7.19
   # renovate: datasource=conda depName=bioconda/htslib
-  - bioconda::htslib=1.21
+  - bioconda::htslib=1.22.1
   # renovate: datasource=conda depName=bioconda/samtools
-  - bioconda::samtools=1.21
+  - bioconda::samtools=1.22.1

--- a/modules/nf-core/bwa/mem/main.nf
+++ b/modules/nf-core/bwa/mem/main.nf
@@ -3,9 +3,9 @@ process BWA_MEM {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/bf/bf7890f8d4e38a7586581cb7fa13401b7af1582f21d94eef969df4cea852b6da/data' :
-        'community.wave.seqera.io/library/bwa_htslib_samtools:56c9f8d5201889a4' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d7/d7e24dc1e4d93ca4d3a76a78d4c834a7be3985b0e1e56fddd61662e047863a8a/data' :
+        'community.wave.seqera.io/library/bwa_htslib_samtools:83b50ff84ead50d0' }"
 
     input:
     tuple val(meta) , path(reads)
@@ -16,9 +16,11 @@ process BWA_MEM {
     output:
     tuple val(meta), path("*.bam")  , emit: bam,    optional: true
     tuple val(meta), path("*.cram") , emit: cram,   optional: true
+    tuple val(meta), path("*.sam")  , emit: sam,    optional: true
     tuple val(meta), path("*.csi")  , emit: csi,    optional: true
     tuple val(meta), path("*.crai") , emit: crai,   optional: true
-    path  "versions.yml"            , emit: versions
+    tuple val("${task.process}"), val('bwa'), eval('bwa 2>&1 | sed -n "s/^Version: //p"'), topic: versions, emit: versions_bwa
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), topic: versions, emit: versions_samtools
 
     when:
     task.ext.when == null || task.ext.when
@@ -35,6 +37,15 @@ process BWA_MEM {
                     "bam"
     def reference = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
     if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+    //
+    // For SAM output we can skip samtools view
+    //
+    def pipe_command = ""
+    if (extension == "sam") {
+        pipe_command = "> ${prefix}.${extension}"
+    } else {
+        pipe_command = "| samtools $samtools_command $args2 ${reference} --threads $task.cpus -o ${prefix}.${extension} -"
+    }
     """
     INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
 
@@ -43,13 +54,7 @@ process BWA_MEM {
         -t $task.cpus \\
         \$INDEX \\
         $reads \\
-        | samtools $samtools_command $args2 ${reference} --threads $task.cpus -o ${prefix}.${extension} -
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
+        $pipe_command
     """
 
     stub:
@@ -64,11 +69,5 @@ process BWA_MEM {
     touch ${prefix}.${extension}
     touch ${prefix}.csi
     touch ${prefix}.crai
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bwa/mem/meta.yml
+++ b/modules/nf-core/bwa/mem/meta.yml
@@ -16,7 +16,8 @@ tools:
       homepage: http://bio-bwa.sourceforge.net/
       documentation: https://bio-bwa.sourceforge.net/bwa.shtml
       arxiv: arXiv:1303.3997
-      licence: ["GPL-3.0-or-later"]
+      licence:
+        - "GPL-3.0-or-later"
       identifier: "biotools:bwa"
 input:
   - - meta:
@@ -30,8 +31,8 @@ input:
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively.
         ontologies:
-          - edam: "http://edamontology.org/data_2044" # Sequence
-          - edam: "http://edamontology.org/format_1930" # FASTQ
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1930"
   - - meta2:
         type: map
         description: |
@@ -42,7 +43,7 @@ input:
         description: BWA genome index files
         pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
         ontologies:
-          - edam: "http://edamontology.org/data_3210" # Genome index
+          - edam: "http://edamontology.org/data_3210"
   - - meta3:
         type: map
         description: |
@@ -53,54 +54,101 @@ input:
         description: Reference genome in FASTA format
         pattern: "*.{fasta,fa}"
         ontologies:
-          - edam: "http://edamontology.org/data_2044" # Sequence
-          - edam: "http://edamontology.org/format_1929" # FASTA
-  - - sort_bam:
-        type: boolean
-        description: use samtools sort (true) or samtools view (false)
-        pattern: "true or false"
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+      pattern: "true or false"
 output:
-  - bam:
-      - meta:
-          type: file
-          description: Output BAM file containing read alignments
+  bam:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
       - "*.bam":
           type: file
           description: Output BAM file containing read alignments
           pattern: "*.{bam}"
           ontologies:
-            - edam: "http://edamontology.org/format_2572" # BAM
-  - cram:
-      - meta:
-          type: file
-          description: Output CRAM file containing read alignments
+            - edam: "http://edamontology.org/format_2572"
+  cram:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
       - "*.cram":
           type: file
           description: Output CRAM file containing read alignments
           pattern: "*.{cram}"
           ontologies:
-            - edam: "http://edamontology.org/format_3462" # CRAM
-  - csi:
-      - meta:
+            - edam: "http://edamontology.org/format_3462"
+  sam:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.sam":
           type: file
-          description: Optional index file for BAM file
+          description: Output SAM file containing read alignments
+          pattern: "*.{sam}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2573"
+  csi:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
       - "*.csi":
           type: file
           description: Optional index file for BAM file
           pattern: "*.{csi}"
-  - crai:
-      - meta:
-          type: file
-          description: Optional index file for CRAM file
+          ontologies: []
+  crai:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
       - "*.crai":
           type: file
           description: Optional index file for CRAM file
           pattern: "*.{crai}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_bwa:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwa:
+          type: string
+          description: The name of the tool
+      - 'bwa 2>&1 | sed -n "s/^Version: //p"':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwa:
+          type: string
+          description: The name of the tool
+      - 'bwa 2>&1 | sed -n "s/^Version: //p"':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@drpatelh"
   - "@jeremy1805"

--- a/modules/nf-core/bwamem2/index/environment.yml
+++ b/modules/nf-core/bwamem2/index/environment.yml
@@ -6,8 +6,8 @@ channels:
 
 dependencies:
   # renovate: datasource=conda depName=bioconda/bwa-mem2
-  - bwa-mem2=2.2.1
+  - bwa-mem2=2.3
   # renovate: datasource=conda depName=bioconda/htslib
-  - htslib=1.21
+  - htslib=1.22.1
   # renovate: datasource=conda depName=bioconda/samtools
-  - samtools=1.21
+  - samtools=1.22.1

--- a/modules/nf-core/bwamem2/index/main.nf
+++ b/modules/nf-core/bwamem2/index/main.nf
@@ -2,19 +2,19 @@ process BWAMEM2_INDEX {
     tag "$fasta"
     // NOTE Requires 28N GB memory where N is the size of the reference sequence, floor of 280M
     // source: https://github.com/bwa-mem2/bwa-mem2/issues/9
-    memory { (280.MB * Math.ceil(fasta.size() / 10000000)) * task.attempt }
+    memory { 280.MB * Math.ceil(fasta.size() / 10000000) * task.attempt }
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9a/9ac054213e67b3c9308e409b459080bbe438f8fd6c646c351bc42887f35a42e7/data' :
-        'community.wave.seqera.io/library/bwa-mem2_htslib_samtools:e1f420694f8e42bd' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e0/e05ce34b46ad42810eb29f74e4e304c0cb592b2ca15572929ed8bbaee58faf01/data' :
+        'community.wave.seqera.io/library/bwa-mem2_htslib_samtools:db98f81f55b64113' }"
 
     input:
     tuple val(meta), path(fasta)
 
     output:
     tuple val(meta), path("bwamem2"), emit: index
-    path "versions.yml"             , emit: versions
+    tuple val("${task.process}"), val('bwamem2'), eval('bwa-mem2 version | grep -o -E "[0-9]+(\\.[0-9]+)+"'), emit: versions_bwamem2, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,11 +29,6 @@ process BWAMEM2_INDEX {
         $args \\
         -p bwamem2/${prefix} \\
         $fasta
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwamem2: \$(echo \$(bwa-mem2 version 2>&1) | sed 's/.* //')
-    END_VERSIONS
     """
 
     stub:
@@ -46,10 +41,5 @@ process BWAMEM2_INDEX {
     touch bwamem2/${prefix}.pac
     touch bwamem2/${prefix}.amb
     touch bwamem2/${prefix}.bwt.2bit.64
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwamem2: \$(echo \$(bwa-mem2 version 2>&1) | sed 's/.* //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bwamem2/index/meta.yml
+++ b/modules/nf-core/bwamem2/index/meta.yml
@@ -12,7 +12,14 @@ tools:
         a large reference genome, such as the human genome.
       homepage: https://github.com/bwa-mem2/bwa-mem2
       documentation: https://github.com/bwa-mem2/bwa-mem2#usage
-      licence: ["MIT"]
+      doi: "10.1109/IPDPS.2019.00041"
+      publication:
+        author: "Vasimuddin M., Misra S., Li H. & Aluru S."
+        year: 2018
+        source: "IEEE International Parallel and Distributed Processing Symposium (IPDPS)"
+        title: "Efficient Architecture-Aware Acceleration of BWA-MEM for Multicore Systems"
+      licence:
+        - "MIT"
       identifier: "biotools:bwa-mem2"
 input:
   - - meta:
@@ -24,8 +31,8 @@ input:
         type: file
         description: Input genome fasta file
         ontologies:
-          - edam: "http://edamontology.org/data_2044" # Sequence
-          - edam: "http://edamontology.org/format_1929" # FASTA
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
 output:
   index:
     - - meta:
@@ -34,18 +41,38 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - bwamem2:
-          type: file
+          type: string
           description: BWA genome index files
           pattern: "*.{0123,amb,ann,bwt.2bit.64,pac}"
           ontologies:
-            - edam: "http://edamontology.org/data_3210" # Genome index
+            - edam: "http://edamontology.org/data_3210"
+  versions_bwamem2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem2:
+          type: string
+          description: BWA genome index files
+          pattern: "*.{0123,amb,ann,bwt.2bit.64,pac}"
+          ontologies:
+            - edam: "http://edamontology.org/data_3210"
+      - bwa-mem2 version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem2:
+          type: string
+          description: BWA genome index files
+          pattern: "*.{0123,amb,ann,bwt.2bit.64,pac}"
+          ontologies:
+            - edam: "http://edamontology.org/data_3210"
+      - bwa-mem2 version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@maxulysse"
 maintainers:

--- a/modules/nf-core/bwamem2/mem/environment.yml
+++ b/modules/nf-core/bwamem2/mem/environment.yml
@@ -6,8 +6,8 @@ channels:
 
 dependencies:
   # renovate: datasource=conda depName=bioconda/bwa-mem2
-  - bwa-mem2=2.2.1
+  - bwa-mem2=2.3
   # renovate: datasource=conda depName=bioconda/htslib
-  - htslib=1.21
+  - htslib=1.22.1
   # renovate: datasource=conda depName=bioconda/samtools
-  - samtools=1.21
+  - samtools=1.22.1

--- a/modules/nf-core/bwamem2/mem/main.nf
+++ b/modules/nf-core/bwamem2/mem/main.nf
@@ -1,25 +1,26 @@
 process BWAMEM2_MEM {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9a/9ac054213e67b3c9308e409b459080bbe438f8fd6c646c351bc42887f35a42e7/data' :
-        'community.wave.seqera.io/library/bwa-mem2_htslib_samtools:e1f420694f8e42bd' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e0/e05ce34b46ad42810eb29f74e4e304c0cb592b2ca15572929ed8bbaee58faf01/data'
+        : 'community.wave.seqera.io/library/bwa-mem2_htslib_samtools:db98f81f55b64113'}"
 
     input:
     tuple val(meta), path(reads)
     tuple val(meta2), path(index)
     tuple val(meta3), path(fasta)
-    val   sort_bam
+    val sort_bam
 
     output:
-    tuple val(meta), path("*.sam")  , emit: sam , optional:true
-    tuple val(meta), path("*.bam")  , emit: bam , optional:true
-    tuple val(meta), path("*.cram") , emit: cram, optional:true
-    tuple val(meta), path("*.crai") , emit: crai, optional:true
-    tuple val(meta), path("*.csi")  , emit: csi , optional:true
-    path  "versions.yml"            , emit: versions
+    tuple val(meta), path("*.sam"), emit: sam, optional: true
+    tuple val(meta), path("*.bam"), emit: bam, optional: true
+    tuple val(meta), path("*.cram"), emit: cram, optional: true
+    tuple val(meta), path("*.crai"), emit: crai, optional: true
+    tuple val(meta), path("*.csi"), emit: csi, optional: true
+    tuple val("${task.process}"), val('bwamem2'), eval('bwa-mem2 version | grep -o -E "[0-9]+(\\.[0-9]+)+"'), emit: versions_bwamem2, topic: versions
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), emit: versions_samtools, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,53 +32,43 @@ process BWAMEM2_MEM {
     def samtools_command = sort_bam ? 'sort' : 'view'
 
     def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
-    def extension_matcher =  (args2 =~ extension_pattern)
+    def extension_matcher = (args2 =~ extension_pattern)
     def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
-    def reference = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
-    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
-
+    def reference = fasta && extension == "cram" ? "--reference ${fasta}" : ""
+    if (!fasta && extension == "cram") {
+        error("Fasta reference is required for CRAM output")
+    }
     """
     INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
 
     bwa-mem2 \\
         mem \\
-        $args \\
-        -t $task.cpus \\
+        ${args} \\
+        -t ${task.cpus} \\
         \$INDEX \\
-        $reads \\
-        | samtools $samtools_command $args2 -@ $task.cpus ${reference} -o ${prefix}.${extension} -
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwamem2: \$(echo \$(bwa-mem2 version 2>&1) | sed 's/.* //')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
+        ${reads} \\
+        | samtools ${samtools_command} ${args2} -@ ${task.cpus} ${reference} -o ${prefix}.${extension} -
     """
 
     stub:
-
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
-    def extension_matcher =  (args2 =~ extension_pattern)
+    def extension_matcher = (args2 =~ extension_pattern)
     def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
-    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+    if (!fasta && extension == "cram") {
+        error("Fasta reference is required for CRAM output")
+    }
 
     def create_index = ""
     if (extension == "cram") {
         create_index = "touch ${prefix}.crai"
-    } else if (extension == "bam") {
+    }
+    else if (extension == "bam") {
         create_index = "touch ${prefix}.csi"
     }
-
     """
     touch ${prefix}.${extension}
     ${create_index}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwamem2: \$(echo \$(bwa-mem2 version 2>&1) | sed 's/.* //')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bwamem2/mem/meta.yml
+++ b/modules/nf-core/bwamem2/mem/meta.yml
@@ -9,14 +9,20 @@ keywords:
   - bam
   - sam
 tools:
-  - bwa:
+  - bwamem2:
       description: |
         BWA-mem2 is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: https://github.com/bwa-mem2/bwa-mem2
-      documentation: http://www.htslib.org/doc/samtools.html
-      arxiv: arXiv:1303.3997
-      licence: ["MIT"]
+      documentation: https://github.com/bwa-mem2/bwa-mem2#usage
+      doi: "10.1109/IPDPS.2019.00041"
+      publication:
+        author: "Vasimuddin M., Misra S., Li H. & Aluru S."
+        year: 2018
+        source: "IEEE International Parallel and Distributed Processing Symposium (IPDPS)"
+        title: "Efficient Architecture-Aware Acceleration of BWA-MEM for Multicore Systems"
+      licence:
+        - "MIT"
       identifier: "biotools:bwa-mem2"
 input:
   - - meta:
@@ -30,8 +36,8 @@ input:
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively.
         ontologies:
-          - edam: "http://edamontology.org/data_2044" # Sequence
-          - edam: "http://edamontology.org/format_1930" # FASTQ
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1930"
   - - meta2:
         type: map
         description: |
@@ -42,7 +48,7 @@ input:
         description: BWA genome index files
         pattern: "Directory containing BWA index *.{0132,amb,ann,bwt.2bit.64,pac}"
         ontologies:
-          - edam: "http://edamontology.org/data_3210" # Genome index
+          - edam: "http://edamontology.org/data_3210"
   - - meta3:
         type: map
         description: |
@@ -53,15 +59,15 @@ input:
         description: Reference genome in FASTA format
         pattern: "*.{fa,fasta,fna}"
         ontologies:
-          - edam: "http://edamontology.org/data_2044" # Sequence
-          - edam: "http://edamontology.org/format_1929" # FASTA
-  - - sort_bam:
-        type: boolean
-        description: use samtools sort (true) or samtools view (false)
-        pattern: "true or false"
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+      pattern: "true or false"
 output:
-  - sam:
-      - meta:
+  sam:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -71,9 +77,9 @@ output:
           description: Output SAM file containing read alignments
           pattern: "*.{sam}"
           ontologies:
-            - edam: "http://edamontology.org/format_2573" # SAM
-  - bam:
-      - meta:
+            - edam: "http://edamontology.org/format_2573"
+  bam:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -83,9 +89,9 @@ output:
           description: Output BAM file containing read alignments
           pattern: "*.{bam}"
           ontologies:
-            - edam: "http://edamontology.org/format_2572" # BAM
-  - cram:
-      - meta:
+            - edam: "http://edamontology.org/format_2572"
+  cram:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -95,9 +101,9 @@ output:
           description: Output CRAM file containing read alignments
           pattern: "*.{cram}"
           ontologies:
-            - edam: "http://edamontology.org/format_3462" # CRAM
-  - crai:
-      - meta:
+            - edam: "http://edamontology.org/format_3462"
+  crai:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -106,8 +112,9 @@ output:
           type: file
           description: Index file for CRAM file
           pattern: "*.{crai}"
-  - csi:
-      - meta:
+          ontologies: []
+  csi:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -116,11 +123,47 @@ output:
           type: file
           description: Index file for BAM file
           pattern: "*.{csi}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_bwamem2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem2:
+          type: string
+          description: The name of the tool
+      - bwa-mem2 version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem2:
+          type: string
+          description: The name of the tool
+      - bwa-mem2 version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@maxulysse"
   - "@matthdsm"

--- a/modules/nf-core/cat/cat/environment.yml
+++ b/modules/nf-core/cat/cat/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::pigz=2.3.4
+  - conda-forge::pigz=2.8

--- a/modules/nf-core/cat/cat/main.nf
+++ b/modules/nf-core/cat/cat/main.nf
@@ -3,72 +3,48 @@ process CAT_CAT {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pigz:2.3.4' :
-        'biocontainers/pigz:2.3.4' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/pigz:2.8' :
+        'quay.io/biocontainers/pigz:2.8' }"
 
     input:
     tuple val(meta), path(files_in)
 
     output:
     tuple val(meta), path("${prefix}"), emit: file_out
-    path "versions.yml"               , emit: versions
+    tuple val("${task.process}"), val("pigz"), eval("pigz --version 2>&1 | sed 's/pigz //g'"),  topic: versions, emit: versions_cat
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
-    def file_list = files_in.collect { it.toString() }
+    def deprecation_message = """
+    WARNING: This module has been deprecated. Please use nf-core/modules/find/concatenate
 
-    // choose appropriate concatenation tool depending on input and output format
+    Reason:
+    This module passes all input files as shell arguments, which can exceed the UNIX ARG_MAX
+    limit when concatenating large numbers of files. The find/concatenate module resolves this
+    by staging files into a directory and enumerating them with `find`, and also enforces
+    consistent input compression (all gzipped or all uncompressed). Also enables faster, parallel
+    decompression with pigz.
+    """
+    assert false: deprecation_message
 
-    // | input     | output     | command1 | command2 |
-    // |-----------|------------|----------|----------|
-    // | gzipped   | gzipped    | cat      |          |
-    // | ungzipped | ungzipped  | cat      |          |
-    // | gzipped   | ungzipped  | zcat     |          |
-    // | ungzipped | gzipped    | cat      | pigz     |
-
-    // Use input file ending as default
+    def file_list = files_in.collect { file -> file.toString() }
     prefix   = task.ext.prefix ?: "${meta.id}${getFileSuffix(file_list[0])}"
-    out_zip  = prefix.endsWith('.gz')
-    in_zip   = file_list[0].endsWith('.gz')
-    command1 = (in_zip && !out_zip) ? 'zcat' : 'cat'
-    command2 = (!in_zip && out_zip) ? "| pigz -c -p $task.cpus $args2" : ''
-    if(file_list.contains(prefix.trim())) {
-        error "The name of the input file can't be the same as for the output prefix in the " +
-        "module CAT_CAT (currently `$prefix`). Please choose a different one."
-    }
-    """
-    $command1 \\
-        $args \\
-        ${file_list.join(' ')} \\
-        $command2 \\
-        > ${prefix}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
-    """
 
     stub:
-    def file_list   = files_in.collect { it.toString() }
-    prefix          = task.ext.prefix ?: "${meta.id}${file_list[0].substring(file_list[0].lastIndexOf('.'))}"
-    if(file_list.contains(prefix.trim())) {
-        error "The name of the input file can't be the same as for the output prefix in the " +
-        "module CAT_CAT (currently `$prefix`). Please choose a different one."
-    }
-    """
-    touch $prefix
+    def deprecation_message = """
+    WARNING: This module has been deprecated. Please use nf-core/modules/find/concatenate
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
+    Reason:
+    This module passes all input files as shell arguments, which can exceed the UNIX ARG_MAX
+    limit when concatenating large numbers of files. The find/concatenate module resolves this
+    by staging files into a directory and enumerating them with `find`, and also enforces
+    consistent input compression (all gzipped or all uncompressed). Also enables faster, parallel
+    decompression with pigz.
     """
+    assert false: deprecation_message
 }
 
 // for .gz files also include the second to last extension if it is present. E.g., .fasta.gz

--- a/modules/nf-core/cat/cat/meta.yml
+++ b/modules/nf-core/cat/cat/meta.yml
@@ -1,5 +1,6 @@
 name: cat_cat
 description: A module for concatenation of gzipped or uncompressed files
+deprecated: true
 keywords:
   - concatenate
   - gzip
@@ -20,21 +21,41 @@ input:
         type: file
         description: List of compressed / uncompressed files
         pattern: "*"
+        ontologies: []
 output:
-  - file_out:
-      - meta:
-          type: file
-          description: Concatenated file. Will be gzipped if file_out ends with ".gz"
-          pattern: "${file_out}"
+  file_out:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
       - ${prefix}:
           type: file
-          description: Concatenated file. Will be gzipped if file_out ends with ".gz"
+          description: Concatenated file. Will be gzipped if file_out ends with
+            ".gz"
           pattern: "${file_out}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_cat:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - "pigz --version 2>&1 | sed 's/pigz //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - "pigz --version 2>&1 | sed 's/pigz //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@erikrikarddaniel"
   - "@FriederikeHanssen"

--- a/modules/nf-core/cat/fastq/main.nf
+++ b/modules/nf-core/cat/fastq/main.nf
@@ -3,7 +3,7 @@ process CAT_FASTQ {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
         : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
 
@@ -12,23 +12,19 @@ process CAT_FASTQ {
 
     output:
     tuple val(meta), path("*.merged.fastq.gz"), emit: reads
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val("cat"), eval("cat --version 2>&1 | head -n 1 | sed 's/^.*coreutils) //; s/ .*\$//'"), emit: versions_cat, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def readList = reads instanceof List ? reads.collect { it.toString() } : [reads.toString()]
+    def readList = reads instanceof List ? reads.collect { item -> item.toString() } : [reads.toString()]
+    def compress = readList[0]?.endsWith('.gz') ? '' : '| gzip'
     if (meta.single_end) {
         if (readList.size >= 1) {
             """
-            cat ${readList.join(' ')} > ${prefix}.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
+            cat ${readList.join(' ')} ${compress} > ${prefix}.merged.fastq.gz
             """
         } else {
             error("Could not find any FASTQ files to concatenate in the process input")
@@ -40,13 +36,8 @@ process CAT_FASTQ {
             def read2 = []
             readList.eachWithIndex { v, ix -> (ix & 1 ? read2 : read1) << v }
             """
-            cat ${read1.join(' ')} > ${prefix}_1.merged.fastq.gz
-            cat ${read2.join(' ')} > ${prefix}_2.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
+            cat ${read1.join(' ')} ${compress} > ${prefix}_1.merged.fastq.gz
+            cat ${read2.join(' ')} ${compress} > ${prefix}_2.merged.fastq.gz
             """
         } else {
             error("Could not find any FASTQ file pairs to concatenate in the process input")
@@ -55,16 +46,11 @@ process CAT_FASTQ {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def readList = reads instanceof List ? reads.collect { it.toString() } : [reads.toString()]
+    def readList = reads instanceof List ? reads.collect { item -> item.toString() } : [reads.toString()]
     if (meta.single_end) {
         if (readList.size >= 1) {
             """
             echo '' | gzip > ${prefix}.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
             """
         } else {
             error("Could not find any FASTQ files to concatenate in the process input")
@@ -75,11 +61,6 @@ process CAT_FASTQ {
             """
             echo '' | gzip > ${prefix}_1.merged.fastq.gz
             echo '' | gzip > ${prefix}_2.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
             """
         } else {
             error("Could not find any FASTQ file pairs to concatenate in the process input")

--- a/modules/nf-core/cat/fastq/meta.yml
+++ b/modules/nf-core/cat/fastq/meta.yml
@@ -1,9 +1,10 @@
 name: cat_fastq
-description: Concatenates fastq files
+description: Concatenates fastq files. Supports both compressed (.gz) and uncompressed inputs; uncompressed files are automatically gzip-compressed during concatenation.
 keywords:
   - cat
   - fastq
   - concatenate
+  - compress
 tools:
   - cat:
       description: |
@@ -21,9 +22,11 @@ input:
         type: file
         description: |
           List of input FastQ files to be concatenated.
+          Accepts both gzip-compressed (.fastq.gz) and uncompressed (.fastq) files.
+        ontologies: []
 output:
-  - reads:
-      - meta:
+  reads:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -32,11 +35,30 @@ output:
           type: file
           description: Merged fastq file
           pattern: "*.{merged.fastq.gz}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_cat:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - cat:
+          type: string
+          description: The tool name
+      - cat --version 2>&1 | head -n 1 | sed 's/^.*coreutils) //; s/ .*\$//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - cat:
+          type: string
+          description: The tool name
+      - cat --version 2>&1 | head -n 1 | sed 's/^.*coreutils) //; s/ .*\$//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/dragmap/align/main.nf
+++ b/modules/nf-core/dragmap/align/main.nf
@@ -4,9 +4,9 @@ process DRAGMAP_ALIGN {
 
     conda "${moduleDir}/environment.yml"
     // WARN: Do not update this tool to 1.3.0 until https://github.com/Illumina/DRAGMAP/issues/47 is resolved
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0'
-        : 'biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0'}"
+        : 'quay.io/biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0'}"
 
     input:
     tuple val(meta), path(reads)
@@ -21,7 +21,9 @@ process DRAGMAP_ALIGN {
     tuple val(meta), path("*.crai"), emit: crai, optional: true
     tuple val(meta), path("*.csi"),  emit: csi,  optional: true
     tuple val(meta), path('*.log'),  emit: log
-    path "versions.yml",             emit: versions
+    tuple val("${task.process}"), val('dragmap'), eval("dragen-os --version 2>&1"), emit: versions_dragmap, topic: versions
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), emit: versions_samtools, topic: versions
+    tuple val("${task.process}"), val('pigz'), eval("pigz --version 2>&1 | sed 's/pigz //'"), emit: versions_pigz, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -46,15 +48,8 @@ process DRAGMAP_ALIGN {
         ${args} \\
         --num-threads ${task.cpus} \\
         ${reads_command} \\
-        2> >(tee ${prefix}.dragmap.log >&2) \\
+        2>| >(tee ${prefix}.dragmap.log >&2) \\
         | samtools ${samtools_command} ${args2} --threads ${task.cpus} ${reference} -o ${prefix}.${extension} -
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        dragmap: \$(echo \$(dragen-os --version 2>&1))
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 
     stub:
@@ -79,12 +74,5 @@ process DRAGMAP_ALIGN {
     touch ${prefix}.${extension}
     ${create_index}
     touch ${prefix}.log
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        dragmap: \$(echo \$(dragen-os --version 2>&1))
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/dragmap/align/meta.yml
+++ b/modules/nf-core/dragmap/align/meta.yml
@@ -12,7 +12,8 @@ tools:
       homepage: https://github.com/Illumina/dragmap
       documentation: https://github.com/Illumina/dragmap
       tool_dev_url: https://github.com/Illumina/dragmap#basic-command-line-usage
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: ""
 input:
   - - meta:
@@ -25,6 +26,8 @@ input:
         description: |
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively.
+        ontologies:
+          - edam: http://edamontology.org/format_1930
   - - meta2:
         type: map
         description: |
@@ -34,6 +37,7 @@ input:
         type: file
         description: DRAGMAP hash table
         pattern: "Directory containing DRAGMAP hash table *.{cmp,.bin,.txt}"
+        ontologies: []
   - - meta3:
         type: map
         description: |
@@ -43,12 +47,14 @@ input:
         type: file
         description: Genome fasta reference files
         pattern: "*.{fa,fasta,fna}"
-  - - sort_bam:
-        type: boolean
-        description: Sort the BAM file
+        ontologies:
+          - edam: http://edamontology.org/format_1929
+  - sort_bam:
+      type: boolean
+      description: Sort the BAM file
 output:
-  - sam:
-      - meta:
+  sam:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -57,17 +63,22 @@ output:
           type: file
           description: Output SAM file containing read alignments
           pattern: "*.{sam}"
-  - bam:
-      - meta:
-          type: file
-          description: Output BAM file containing read alignments
-          pattern: "*.{bam}"
+          ontologies:
+            - edam: http://edamontology.org/format_2571
+  bam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
       - "*.bam":
           type: file
           description: Output BAM file containing read alignments
           pattern: "*.{bam}"
-  - cram:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_2572
+  cram:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -76,8 +87,10 @@ output:
           type: file
           description: Output CRAM file containing read alignments
           pattern: "*.{cram}"
-  - crai:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_2573
+  crai:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -86,8 +99,9 @@ output:
           type: file
           description: Index file for CRAM file
           pattern: "*.{crai}"
-  - csi:
-      - meta:
+          ontologies: []
+  csi:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -96,8 +110,9 @@ output:
           type: file
           description: Index file for CRAM file
           pattern: "*.{csi}"
-  - log:
-      - meta:
+          ontologies: []
+  log:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -106,11 +121,67 @@ output:
           type: file
           description: Log file
           pattern: "*.{log}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies:
+            - edam: http://edamontology.org/format_3888
+  versions_dragmap:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - dragmap:
+          type: string
+          description: The name of the tool
+      - dragen-os --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_pigz:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed 's/pigz //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - dragmap:
+          type: string
+          description: The name of the tool
+      - dragen-os --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed 's/pigz //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@edmundmiller"
 maintainers:

--- a/modules/nf-core/dragmap/hashtable/main.nf
+++ b/modules/nf-core/dragmap/hashtable/main.nf
@@ -4,16 +4,16 @@ process DRAGMAP_HASHTABLE {
 
     conda "${moduleDir}/environment.yml"
     // WARN: Do not update this tool to 1.3.0 until https://github.com/Illumina/DRAGMAP/issues/47 is resolved
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/dragmap:1.2.1--h72d16da_1'
-        : 'biocontainers/dragmap:1.2.1--h72d16da_1'}"
+        : 'quay.io/biocontainers/dragmap:1.2.1--h72d16da_1'}"
 
     input:
     tuple val(meta), path(fasta)
 
     output:
     tuple val(meta), path("dragmap"), emit: hashmap
-    path "versions.yml",              emit: versions
+    tuple val("${task.process}"), val('dragmap'), eval("dragen-os --version 2>&1"), emit: versions_dragmap, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -28,20 +28,10 @@ process DRAGMAP_HASHTABLE {
         --output-directory dragmap \\
         ${args} \\
         --ht-num-threads ${task.cpus}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        dragmap: \$(echo \$(dragen-os --version 2>&1))
-    END_VERSIONS
     """
 
     stub:
     """
     mkdir dragmap
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        dragmap: \$(echo \$(dragen-os --version 2>&1))
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/dragmap/hashtable/meta.yml
+++ b/modules/nf-core/dragmap/hashtable/meta.yml
@@ -11,7 +11,8 @@ tools:
       homepage: https://github.com/Illumina/dragmap
       documentation: https://github.com/Illumina/dragmap
       tool_dev_url: https://github.com/Illumina/dragmap#basic-command-line-usage
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: ""
 input:
   - - meta:
@@ -22,7 +23,8 @@ input:
     - fasta:
         type: file
         description: Input genome fasta file
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_1929
 output:
   hashmap:
     - - meta:
@@ -31,17 +33,35 @@ output:
             Groovy Map containing reference information
             e.g. [ id:'test', single_end:false ]
       - dragmap:
-          type: file
+          type: string
           description: DRAGMAP hash table
           pattern: "*.{cmp,.bin,.txt}"
           ontologies: []
+  versions_dragmap:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - dragmap:
+          type: string
+          description: DRAGMAP hash table
+          pattern: "*.{cmp,.bin,.txt}"
+          ontologies: []
+      - dragen-os --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - dragmap:
+          type: string
+          description: DRAGMAP hash table
+          pattern: "*.{cmp,.bin,.txt}"
+          ontologies: []
+      - dragen-os --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@edmundmiller"
 maintainers:

--- a/modules/nf-core/fastp/environment.yml
+++ b/modules/nf-core/fastp/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fastp=0.24.0
+  # renovate: datasource=conda depName=bioconda/fastp
+  - bioconda::fastp=1.1.0

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -3,13 +3,12 @@ process FASTP {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/88/889a182b8066804f4799f3808a5813ad601381a8a0e3baa4ab8d73e739b97001/data' :
-        'community.wave.seqera.io/library/fastp:0.24.0--62c97b06e8447690' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/55/556474e164daf5a5e218cd5d497681dcba0645047cf24698f88e3e078eacbd09/data' :
+        'community.wave.seqera.io/library/fastp:1.1.0--08aa7c5662a30d57' }"
 
     input:
-    tuple val(meta), path(reads)
-    path  adapter_fasta
+    tuple val(meta), path(reads), path(adapter_fasta)
     val   discard_trimmed_pass
     val   save_trimmed_fail
     val   save_merged
@@ -21,7 +20,7 @@ process FASTP {
     tuple val(meta), path('*.log')            , emit: log
     tuple val(meta), path('*.fail.fastq.gz')  , optional:true, emit: reads_fail
     tuple val(meta), path('*.merged.fastq.gz'), optional:true, emit: reads_merged
-    path "versions.yml"                       , emit: versions
+    tuple val("${task.process}"), val('fastp'), eval('fastp --version 2>&1 | sed -e "s/fastp //g"'), emit: versions_fastp, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,9 +29,9 @@ process FASTP {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def adapter_list = adapter_fasta ? "--adapter_fasta ${adapter_fasta}" : ""
-    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--failed_out ${prefix}.paired.fail.fastq.gz --unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
-    def out_fq1 = discard_trimmed_pass ?: ( meta.single_end ? "--out1 ${prefix}.fastp.fastq.gz" : "--out1 ${prefix}_1.fastp.fastq.gz" )
-    def out_fq2 = discard_trimmed_pass ?: "--out2 ${prefix}_2.fastp.fastq.gz"
+    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--failed_out ${prefix}.paired.fail.fastq.gz --unpaired1 ${prefix}_R1.fail.fastq.gz --unpaired2 ${prefix}_R2.fail.fastq.gz" : ''
+    def out_fq1 = discard_trimmed_pass ?: ( meta.single_end ? "--out1 ${prefix}.fastp.fastq.gz" : "--out1 ${prefix}_R1.fastp.fastq.gz" )
+    def out_fq2 = discard_trimmed_pass ?: "--out2 ${prefix}_R2.fastp.fastq.gz"
     // Added soft-links to original fastqs for consistent naming in MultiQC
     // Use single ended for interleaved. Add --interleaved_in in config.
     if ( task.ext.args?.contains('--interleaved_in') ) {
@@ -48,13 +47,8 @@ process FASTP {
             $adapter_list \\
             $fail_fastq \\
             $args \\
-            2> >(tee ${prefix}.fastp.log >&2) \\
+            2>| >(tee ${prefix}.fastp.log >&2) \\
         | gzip -c > ${prefix}.fastp.fastq.gz
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
-        END_VERSIONS
         """
     } else if (meta.single_end) {
         """
@@ -69,21 +63,16 @@ process FASTP {
             $adapter_list \\
             $fail_fastq \\
             $args \\
-            2> >(tee ${prefix}.fastp.log >&2)
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
-        END_VERSIONS
+            2>| >(tee ${prefix}.fastp.log >&2)
         """
     } else {
         def merge_fastq = save_merged ? "-m --merged_out ${prefix}.merged.fastq.gz" : ''
         """
-        [ ! -f  ${prefix}_1.fastq.gz ] && ln -sf ${reads[0]} ${prefix}_1.fastq.gz
-        [ ! -f  ${prefix}_2.fastq.gz ] && ln -sf ${reads[1]} ${prefix}_2.fastq.gz
+        [ ! -f  ${prefix}_R1.fastq.gz ] && ln -sf ${reads[0]} ${prefix}_R1.fastq.gz
+        [ ! -f  ${prefix}_R2.fastq.gz ] && ln -sf ${reads[1]} ${prefix}_R2.fastq.gz
         fastp \\
-            --in1 ${prefix}_1.fastq.gz \\
-            --in2 ${prefix}_2.fastq.gz \\
+            --in1 ${prefix}_R1.fastq.gz \\
+            --in2 ${prefix}_R2.fastq.gz \\
             $out_fq1 \\
             $out_fq2 \\
             --json ${prefix}.fastp.json \\
@@ -94,21 +83,16 @@ process FASTP {
             --thread $task.cpus \\
             --detect_adapter_for_pe \\
             $args \\
-            2> >(tee ${prefix}.fastp.log >&2)
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
-        END_VERSIONS
+            2>| >(tee ${prefix}.fastp.log >&2)
         """
     }
 
     stub:
     def prefix              = task.ext.prefix ?: "${meta.id}"
     def is_single_output    = task.ext.args?.contains('--interleaved_in') || meta.single_end
-    def touch_reads         = (discard_trimmed_pass) ? "" : (is_single_output) ? "echo '' | gzip > ${prefix}.fastp.fastq.gz" : "echo '' | gzip > ${prefix}_1.fastp.fastq.gz ; echo '' | gzip > ${prefix}_2.fastp.fastq.gz"
+    def touch_reads         = (discard_trimmed_pass) ? "" : (is_single_output) ? "echo '' | gzip > ${prefix}.fastp.fastq.gz" : "echo '' | gzip > ${prefix}_R1.fastp.fastq.gz ; echo '' | gzip > ${prefix}_R2.fastp.fastq.gz"
     def touch_merged        = (!is_single_output && save_merged) ? "echo '' | gzip >  ${prefix}.merged.fastq.gz" : ""
-    def touch_fail_fastq    = (!save_trimmed_fail) ? "" : meta.single_end ? "echo '' | gzip > ${prefix}.fail.fastq.gz" : "echo '' | gzip > ${prefix}.paired.fail.fastq.gz ; echo '' | gzip > ${prefix}_1.fail.fastq.gz ; echo '' | gzip > ${prefix}_2.fail.fastq.gz"
+    def touch_fail_fastq    = (!save_trimmed_fail) ? "" : meta.single_end ? "echo '' | gzip > ${prefix}.fail.fastq.gz" : "echo '' | gzip > ${prefix}.paired.fail.fastq.gz ; echo '' | gzip > ${prefix}_R1.fail.fastq.gz ; echo '' | gzip > ${prefix}_R2.fail.fastq.gz"
     """
     $touch_reads
     $touch_fail_fastq
@@ -116,10 +100,5 @@ process FASTP {
     touch "${prefix}.fastp.json"
     touch "${prefix}.fastp.html"
     touch "${prefix}.fastp.log"
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/fastp/meta.yml
+++ b/modules/nf-core/fastp/meta.yml
@@ -24,25 +24,27 @@ input:
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively. If you wish to run interleaved paired-end data,  supply as single-end data
           but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
-  - - adapter_fasta:
+        ontologies: []
+    - adapter_fasta:
         type: file
         description: File in FASTA format containing possible adapters to remove.
         pattern: "*.{fasta,fna,fas,fa}"
-  - - discard_trimmed_pass:
-        type: boolean
-        description: |
-          Specify true to not write any reads that pass trimming thresholds.
-          This can be used to use fastp for the output report only.
-  - - save_trimmed_fail:
-        type: boolean
-        description: Specify true to save files that failed to pass trimming thresholds
-          ending in `*.fail.fastq.gz`
-  - - save_merged:
-        type: boolean
-        description: Specify true to save all merged reads to a file ending in `*.merged.fastq.gz`
+        ontologies: []
+  - discard_trimmed_pass:
+      type: boolean
+      description: |
+        Specify true to not write any reads that pass trimming thresholds.
+        This can be used to use fastp for the output report only.
+  - save_trimmed_fail:
+      type: boolean
+      description: Specify true to save files that failed to pass trimming thresholds
+        ending in `*.fail.fastq.gz`
+  - save_merged:
+      type: boolean
+      description: Specify true to save all merged reads to a file ending in `*.merged.fastq.gz`
 output:
-  - reads:
-      - meta:
+  reads:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -51,8 +53,11 @@ output:
           type: file
           description: The trimmed/modified/unmerged fastq reads
           pattern: "*fastp.fastq.gz"
-  - json:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  json:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -61,8 +66,10 @@ output:
           type: file
           description: Results in JSON format
           pattern: "*.json"
-  - html:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_3464 # JSON
+  html:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -71,8 +78,9 @@ output:
           type: file
           description: Results in HTML format
           pattern: "*.html"
-  - log:
-      - meta:
+          ontologies: []
+  log:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -81,8 +89,9 @@ output:
           type: file
           description: fastq log file
           pattern: "*.log"
-  - reads_fail:
-      - meta:
+          ontologies: []
+  reads_fail:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -91,8 +100,11 @@ output:
           type: file
           description: Reads the failed the preprocessing
           pattern: "*fail.fastq.gz"
-  - reads_merged:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  reads_merged:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -101,14 +113,32 @@ output:
           type: file
           description: Reads that were successfully merged
           pattern: "*.{merged.fastq.gz}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_fastp:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - fastp:
+          type: string
+          description: The name of the tool
+      - 'fastp --version 2>&1 | sed -e "s/fastp //g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - fastp:
+          type: string
+          description: The name of the tool
+      - 'fastp --version 2>&1 | sed -e "s/fastp //g"':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@drpatelh"
   - "@kevinmenden"
+  - "@eit-maxlcummins"
 maintainers:
   - "@drpatelh"
   - "@kevinmenden"

--- a/modules/nf-core/fgbio/callmolecularconsensusreads/environment.yml
+++ b/modules/nf-core/fgbio/callmolecularconsensusreads/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.4.0
+  - bioconda::fgbio=3.1.2

--- a/modules/nf-core/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/nf-core/fgbio/callmolecularconsensusreads/main.nf
@@ -1,11 +1,11 @@
 process FGBIO_CALLMOLECULARCONSENSUSREADS {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
-        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4d/4d1150a2e123f49f8c268f0ab429847afae642376fa52af713b846b084df4a9f/data'
+        : 'community.wave.seqera.io/library/fgbio:3.1.2--6e9400d507a9dc55'}"
 
     input:
     tuple val(meta), path(grouped_bam)
@@ -14,7 +14,7 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
 
     output:
     tuple val(meta), path("*.bam"), emit: bam
-    path  "versions.yml"          , emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval('fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\\[.*$//"'), topic: versions, emit: versions_fgbio
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,11 +24,14 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
     def prefix = task.ext.prefix ?: "${meta.id}_consensus_unmapped"
     def mem_gb = 8
     if (!task.memory) {
-        log.info '[fgbio CallMolecularConsensusReads] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.'
-    } else {
+        log.info('[fgbio CallMolecularConsensusReads] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.')
+    }
+    else {
         mem_gb = task.memory.giga
     }
-    if ("$grouped_bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if ("${grouped_bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
     """
     fgbio \\
         -Xmx${mem_gb}g \\
@@ -36,29 +39,20 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
         --async-io=true \\
         --compression=1 \\
         CallMolecularConsensusReads \\
-        --input $grouped_bam \\
+        --input ${grouped_bam} \\
         --output ${prefix}.bam \\
         --min-reads ${min_reads} \\
         --min-input-base-quality ${min_baseq} \\
         --threads ${task.cpus} \\
-        $args;
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
+        ${args}
     """
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}_consensus_unmapped"
-    if ("$grouped_bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if ("${grouped_bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
     """
     touch ${prefix}.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
-
 }

--- a/modules/nf-core/fgbio/callmolecularconsensusreads/meta.yml
+++ b/modules/nf-core/fgbio/callmolecularconsensusreads/meta.yml
@@ -1,12 +1,14 @@
 name: fgbio_callmolecularconsensusreads
-description: Calls consensus sequences from reads with the same unique molecular tag.
+description: Calls consensus sequences from reads with the same unique molecular
+  tag.
 keywords:
   - UMIs
   - consensus sequence
   - bam
 tools:
   - fgbio:
-      description: Tools for working with genomic and high throughput sequencing data.
+      description: Tools for working with genomic and high throughput sequencing
+        data.
       homepage: https://github.com/fulcrumgenomics/fgbio
       documentation: http://fulcrumgenomics.github.io/fgbio/
       licence: ["MIT"]
@@ -22,15 +24,16 @@ input:
         description: |
           The input SAM or BAM file, grouped by UMIs
         pattern: "*.{bam,sam}"
-  - - min_reads:
-        type: integer
-        description: Minimum number of original reads to build each consensus read.
-  - - min_baseq:
-        type: integer
-        description: Ignore bases in raw reads that have Q below this value.
+        ontologies: []
+  - min_reads:
+      type: integer
+      description: Minimum number of original reads to build each consensus read.
+  - min_baseq:
+      type: integer
+      description: Ignore bases in raw reads that have Q below this value.
 output:
-  - bam:
-      - meta:
+  bam:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -40,11 +43,29 @@ output:
           description: |
             Output SAM or BAM file to write consensus reads.
           pattern: "*.{bam,sam}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_fgbio:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@sruthipsuresh"
 maintainers:

--- a/modules/nf-core/fgbio/copyumifromreadname/environment.yml
+++ b/modules/nf-core/fgbio/copyumifromreadname/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.4.0
+  - bioconda::fgbio=3.1.2

--- a/modules/nf-core/fgbio/copyumifromreadname/main.nf
+++ b/modules/nf-core/fgbio/copyumifromreadname/main.nf
@@ -1,11 +1,11 @@
 process FGBIO_COPYUMIFROMREADNAME {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
-        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4d/4d1150a2e123f49f8c268f0ab429847afae642376fa52af713b846b084df4a9f/data'
+        : 'community.wave.seqera.io/library/fgbio:3.1.2--6e9400d507a9dc55'}"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -13,22 +13,23 @@ process FGBIO_COPYUMIFROMREADNAME {
     output:
     tuple val(meta), path("*.bam"), emit: bam
     tuple val(meta), path("*.bai"), emit: bai
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval('fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\\[.*$//"'), topic: versions, emit: versions_fgbio
 
     when:
     task.ext.when == null || task.ext.when
-
 
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}_umi_extracted"
     def mem_gb = 8
     if (!task.memory) {
-        log.info '[fgbio CopyUmiFromReadName] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.'
-    } else if (mem_gb > task.memory.giga) {
+        log.info('[fgbio CopyUmiFromReadName] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.')
+    }
+    else if (mem_gb > task.memory.giga) {
         if (task.memory.giga < 2) {
             mem_gb = 1
-        } else {
+        }
+        else {
             mem_gb = task.memory.giga - 1
         }
     }
@@ -41,24 +42,12 @@ process FGBIO_COPYUMIFROMREADNAME {
         ${args} \\
         --input ${bam} \\
         --output ${prefix}.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
-
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}_umi_extracted"
     """
-
     touch ${prefix}.bam
     touch ${prefix}.bai
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$(fgbio --version)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/fgbio/copyumifromreadname/meta.yml
+++ b/modules/nf-core/fgbio/copyumifromreadname/meta.yml
@@ -2,9 +2,10 @@
 name: "fgbio_copyumifromreadname"
 description: Copies the UMI at the end of a bam files read name to the RX tag.
 keywords:
-  - sort
-  - example
-  - genomics
+  - fgbio
+  - copy
+  - umi
+  - readname
 tools:
   - "fgbio":
       description: "A set of tools for working with genomic and high throughput sequencing
@@ -65,14 +66,28 @@ output:
           pattern: "*.{bai}"
           ontologies:
             - edam: "http://edamontology.org/format_3327" # BAI
-  versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+  versions_fgbio:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
 
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@sppearce"
 maintainers:

--- a/modules/nf-core/fgbio/fastqtobam/environment.yml
+++ b/modules/nf-core/fgbio/fastqtobam/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.4.0
+  - bioconda::fgbio=3.1.2

--- a/modules/nf-core/fgbio/fastqtobam/main.nf
+++ b/modules/nf-core/fgbio/fastqtobam/main.nf
@@ -1,19 +1,18 @@
 process FGBIO_FASTQTOBAM {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
-        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4d/4d1150a2e123f49f8c268f0ab429847afae642376fa52af713b846b084df4a9f/data'
+        : 'community.wave.seqera.io/library/fgbio:3.1.2--6e9400d507a9dc55'}"
 
     input:
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*.bam") , emit: bam , optional: true
-    tuple val(meta), path("*.cram"), emit: cram, optional: true
-    path "versions.yml"            , emit: versions
+    tuple val(meta), path("*.{bam,cram}"), emit: bam
+    tuple val("${task.process}"), val('fgbio'), eval('fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\\[.*$//"'), topic: versions, emit: versions_fgbio
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,11 +26,13 @@ process FGBIO_FASTQTOBAM {
 
     def mem_gb = 8
     if (!task.memory) {
-        log.info '[fgbio FastqToBam] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.'
-    } else if (mem_gb > task.memory.giga) {
+        log.info('[fgbio FastqToBam] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.')
+    }
+    else if (mem_gb > task.memory.giga) {
         if (task.memory.giga < 2) {
             mem_gb = 1
-        } else {
+        }
+        else {
             mem_gb = task.memory.giga - 1
         }
     }
@@ -47,24 +48,12 @@ process FGBIO_FASTQTOBAM {
         --output ${prefix}.${suffix} \\
         ${sample_name} \\
         ${library_name}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def suffix = task.ext.suffix ?: "bam"
-
     """
     touch ${prefix}.${suffix}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/fgbio/fastqtobam/meta.yml
+++ b/modules/nf-core/fgbio/fastqtobam/meta.yml
@@ -7,8 +7,8 @@ keywords:
   - cram
 tools:
   - fgbio:
-      description: A set of tools for working with genomic and high throughput sequencing
-        data, including UMIs
+      description: A set of tools for working with genomic and high throughput
+        sequencing data, including UMIs
       homepage: http://fulcrumgenomics.github.io/fgbio/
       documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
       tool_dev_url: https://github.com/fulcrumgenomics/fgbio
@@ -24,32 +24,42 @@ input:
         type: file
         description: pair of reads to be converted into BAM file
         pattern: "*.{fastq.gz}"
+        ontologies: []
 output:
-  - bam:
-      - meta:
+  bam:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*.bam":
+      - "*.{bam,cram}":
           type: file
-          description: Unaligned, unsorted BAM file
-          pattern: "*.{bam}"
-  - cram:
-      - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-      - "*.cram":
-          type: file
-          description: Unaligned, unsorted CRAM file
-          pattern: "*.{cram}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          description: Unaligned, unsorted BAM or CRAM file
+          pattern: "*.{bam,cram}"
+          ontologies: []
+  versions_fgbio:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@lescai"
   - "@matthdsm"

--- a/modules/nf-core/fgbio/groupreadsbyumi/environment.yml
+++ b/modules/nf-core/fgbio/groupreadsbyumi/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.4.0
+  - bioconda::fgbio=3.1.2

--- a/modules/nf-core/fgbio/groupreadsbyumi/main.nf
+++ b/modules/nf-core/fgbio/groupreadsbyumi/main.nf
@@ -1,20 +1,21 @@
 process FGBIO_GROUPREADSBYUMI {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
-        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4d/4d1150a2e123f49f8c268f0ab429847afae642376fa52af713b846b084df4a9f/data'
+        : 'community.wave.seqera.io/library/fgbio:3.1.2--6e9400d507a9dc55'}"
 
     input:
     tuple val(meta), path(bam)
-    val(strategy)
+    val strategy
 
     output:
-    tuple val(meta), path("*.bam")         , emit: bam
+    tuple val(meta), path("*.bam"), emit: bam
     tuple val(meta), path("*histogram.txt"), emit: histogram
-    path "versions.yml"                    , emit: versions
+    tuple val(meta), path("*read-metrics.txt"), emit: read_metrics
+    tuple val("${task.process}"), val('fgbio'), eval('fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\\[.*$//"'), topic: versions, emit: versions_fgbio
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,44 +25,42 @@ process FGBIO_GROUPREADSBYUMI {
     def prefix = task.ext.prefix ?: "${meta.id}_umi-grouped"
     def mem_gb = 8
     if (!task.memory) {
-        log.info '[fgbio FilterConsensusReads] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.'
-    } else if (mem_gb > task.memory.giga) {
+        log.info('[fgbio FilterConsensusReads] Available memory not known - defaulting to 8GB. Specify process memory requirements to change this.')
+    }
+    else if (mem_gb > task.memory.giga) {
         if (task.memory.giga < 2) {
             mem_gb = 1
-        } else {
+        }
+        else {
             mem_gb = task.memory.giga - 1
         }
     }
 
-    if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if ("${bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
 
     """
     fgbio \\
         -Xmx${mem_gb}g \\
         --tmp-dir=. \\
         GroupReadsByUmi \\
-        -s $strategy \\
-        $args \\
-        -i $bam \\
+        -s ${strategy} \\
+        ${args} \\
+        -i ${bam} \\
         -o ${prefix}.bam \\
-        -f ${prefix}_histogram.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
+        -f ${prefix}_histogram.txt \\
+        --grouping-metrics ${prefix}_read-metrics.txt
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}_umi-grouped"
-    if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if ("${bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
     """
     touch ${prefix}.bam
     touch ${prefix}_histogram.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
+    touch ${prefix}_read-metrics.txt
     """
 }

--- a/modules/nf-core/fgbio/groupreadsbyumi/meta.yml
+++ b/modules/nf-core/fgbio/groupreadsbyumi/meta.yml
@@ -30,15 +30,16 @@ input:
         description: |
           BAM file. Note: the MQ tag is required on reads with mapped mates (!)
         pattern: "*.bam"
-  - - strategy:
-        type: string
-        enum: ["Identity", "Edit", "Adjacency", "Paired"]
-        description: |
-          Required argument: defines the UMI assignment strategy.
-          Must be chosen among: Identity, Edit, Adjacency, Paired.
+        ontologies: []
+  - strategy:
+      type: string
+      enum: ["Identity", "Edit", "Adjacency", "Paired"]
+      description: |
+        Required argument: defines the UMI assignment strategy.
+        Must be chosen among: Identity, Edit, Adjacency, Paired.
 output:
-  - bam:
-      - meta:
+  bam:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -47,8 +48,9 @@ output:
           type: file
           description: UMI-grouped BAM
           pattern: "*.bam"
-  - histogram:
-      - meta:
+          ontologies: []
+  histogram:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -57,11 +59,40 @@ output:
           type: file
           description: A text file containing the tag family size counts
           pattern: "*.txt"
-  - versions:
-      - versions.yml:
+          ontologies: []
+  read_metrics:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*read-metrics.txt":
           type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          description: A text file containing the read count metrics from grouping
+          pattern: "*.txt"
+          ontologies: []
+  versions_fgbio:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fgbio:
+          type: string
+          description: The tool name
+      - 'fgbio --version 2>&1 | tr -d "[:cntrl:]" | sed -e "s/^.*Version: //;s/\[.*$//"':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@lescai"
 maintainers:

--- a/modules/nf-core/gawk/environment.yml
+++ b/modules/nf-core/gawk/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::gawk=5.3.0
+  - conda-forge::gawk=5.3.1

--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -3,9 +3,9 @@ process GAWK {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gawk:5.3.0' :
-        'biocontainers/gawk:5.3.0' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a1/a125c778baf3865331101a104b60d249ee15fe1dca13bdafd888926cc5490a34/data' :
+        'community.wave.seqera.io/library/gawk:5.3.1--e09efb5dfc4b8156' }"
 
     input:
     tuple val(meta), path(input, arity: '0..*')
@@ -14,7 +14,7 @@ process GAWK {
 
     output:
     tuple val(meta), path("*.${suffix}"), emit: output
-    path "versions.yml"                 , emit: versions
+    tuple val("${task.process}"), val('gawk'), eval("awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//'"), topic: versions, emit: versions_gawk
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,18 +23,18 @@ process GAWK {
     def args  = task.ext.args  ?: '' // args is used for the main arguments of the tool
     def args2 = task.ext.args2 ?: '' // args2 is used to specify a program when no program file has been given
     prefix    = task.ext.prefix ?: "${meta.id}"
-    suffix    = task.ext.suffix ?: "${input.collect{ it.getExtension()}.get(0)}" // use the first extension of the input files
+    suffix    = task.ext.suffix ?: "${input.collect{ file -> file.getExtension()}.get(0)}" // use the first extension of the input files
 
     program    = program_file ? "-f ${program_file}" : "${args2}"
-    lst_gz     = input.findResults{ it.getExtension().endsWith("gz") ? it.toString() : null }
+    lst_gz     = input.findResults{ file -> file.getExtension().endsWith("gz") ? file.toString() : null }
     unzip      = lst_gz ? "gunzip -q -f ${lst_gz.join(" ")}" : ""
-    input_cmd  = input.collect { it.toString() - ~/\.gz$/ }.join(" ")
+    input_cmd  = input.collect { file -> file.toString() - ~/\.gz$/ }.join(" ")
     output_cmd = suffix.endsWith("gz") ? "| gzip > ${prefix}.${suffix}" : "> ${prefix}.${suffix}"
     output     = disable_redirect_output ? "" : output_cmd
-    cleanup    = lst_gz ? "rm ${lst_gz.collect{ it - ~/\.gz$/ }.join(" ")}" : ""
+    cleanup    = lst_gz ? "rm ${lst_gz.collect{ file -> file - ~/\.gz$/ }.join(" ")}" : ""
 
-    input.collect{
-        assert it.name != "${prefix}.${suffix}" : "Input and output names are the same, set prefix in module configuration to disambiguate!"
+    input.collect{ file ->
+        assert file.name != "${prefix}.${suffix}" : "Input and output names are the same, set prefix in module configuration to disambiguate!"
     }
 
     """
@@ -47,24 +47,14 @@ process GAWK {
         ${output}
 
     ${cleanup}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gawk: \$(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
-    END_VERSIONS
     """
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
-    suffix = task.ext.suffix ?: "${input.getExtension()}"
+    suffix = task.ext.suffix ?: "${input.collect{ file -> file.getExtension()}.get(0)}"
     def create_cmd = suffix.endsWith("gz") ? "echo '' | gzip >" : "touch"
 
     """
     ${create_cmd} ${prefix}.${suffix}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gawk: \$(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/gawk/meta.yml
+++ b/modules/nf-core/gawk/meta.yml
@@ -15,7 +15,8 @@ tools:
       homepage: "https://www.gnu.org/software/gawk/"
       documentation: "https://www.gnu.org/software/gawk/manual/"
       tool_dev_url: "https://www.gnu.org/prep/ftp.html"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: ""
 input:
   - - meta:
@@ -25,38 +26,58 @@ input:
           e.g. [ id:'test', single_end:false ]
     - input:
         type: file
-        description: The input file - Specify the logic that needs to be executed on
-          this file on the `ext.args2` or in the program file.
-          If the files have a `.gz` extension, they will be unzipped using `zcat`.
+        description: The input file - Specify the logic that needs to be executed
+          on this file on the `ext.args2` or in the program file. If the files
+          have a `.gz` extension, they will be unzipped using `zcat`.
         pattern: "*"
-  - - program_file:
-        type: file
-        description: Optional file containing logic for awk to execute. If you don't
-          wish to use a file, you can use `ext.args2` to specify the logic.
-        pattern: "*"
-  - - disable_redirect_output:
-        type: boolean
-        description: Disable the redirection of awk output to a given file. This is
-          useful if you want to use awk's built-in redirect to write files instead
-          of the shell's redirect.
+        ontologies: []
+  - program_file:
+      type: file
+      description: Optional file containing logic for awk to execute. If you don't
+        wish to use a file, you can use `ext.args2` to specify the logic.
+      pattern: "*"
+      ontologies: []
+  - disable_redirect_output:
+      type: boolean
+      description: Disable the redirection of awk output to a given file. This is
+        useful if you want to use awk's built-in redirect to write files instead
+        of the shell's redirect.
 output:
-  - output:
-      - meta:
+  output:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.${suffix}":
           type: file
-          description: The output file - if using shell redirection, specify the name of this
-            file using `ext.prefix` and the extension using `ext.suffix`. Otherwise, ensure
-            the awk program produces files with the extension in `ext.suffix`.
+          description: The output file - if using shell redirection, specify the
+            name of this file using `ext.prefix` and the extension using
+            `ext.suffix`. Otherwise, ensure the awk program produces files with
+            the extension in `ext.suffix`.
           pattern: "*"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_gawk:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gawk:
+          type: string
+          description: The name of the tool
+      - awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gawk:
+          type: string
+          description: The name of the tool
+      - awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@nvnieuwk"
 maintainers:

--- a/modules/nf-core/gunzip/main.nf
+++ b/modules/nf-core/gunzip/main.nf
@@ -3,7 +3,7 @@ process GUNZIP {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
         : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
 
@@ -12,15 +12,16 @@ process GUNZIP {
 
     output:
     tuple val(meta), path("${gunzip}"), emit: gunzip
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('gunzip'), eval('gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//"'), topic: versions, emit: versions_gunzip
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def extension = (archive.toString() - '.gz').tokenize('.')[-1]
-    def name = archive.toString() - '.gz' - ".${extension}"
+    def nameWithoutGz = archive.extension == 'gz' ? archive.baseName : archive.name
+	def extension = file(nameWithoutGz).extension
+	def name = file(nameWithoutGz).baseName
     def prefix = task.ext.prefix ?: name
     gunzip = prefix + ".${extension}"
     """
@@ -32,24 +33,15 @@ process GUNZIP {
         ${args} \\
         ${archive} \\
         > ${gunzip}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
-    def extension = (archive.toString() - '.gz').tokenize('.')[-1]
-    def name = archive.toString() - '.gz' - ".${extension}"
+    def nameWithoutGz = archive.extension == 'gz' ? archive.baseName : archive.name
+	def extension = file(nameWithoutGz).extension
+	def name = file(nameWithoutGz).baseName
     def prefix = task.ext.prefix ?: name
     gunzip = prefix + ".${extension}"
     """
     touch ${gunzip}
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/gunzip/meta.yml
+++ b/modules/nf-core/gunzip/meta.yml
@@ -21,21 +21,42 @@ input:
         type: file
         description: File to be compressed/uncompressed
         pattern: "*.*"
+        ontologies: []
 output:
-  - gunzip:
-      - meta:
+  gunzip:
+    - - meta:
           type: file
           description: Compressed/uncompressed file
           pattern: "*.*"
+          ontologies: []
       - ${gunzip}:
           type: file
           description: Compressed/uncompressed file
           pattern: "*.*"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_gunzip:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gunzip:
+          type: string
+          description: The tool name
+      - gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gunzip:
+          type: string
+          description: The tool name
+      - gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/spring/decompress/main.nf
+++ b/modules/nf-core/spring/decompress/main.nf
@@ -3,9 +3,9 @@ process SPRING_DECOMPRESS {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/spring:1.1.1--h4ac6f70_2' :
-        'biocontainers/spring:1.1.1--h4ac6f70_2' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f6/f67f27c8cb2d1a149564f1a10f5f2b7a6acfa87ef3d3d27d2d8752dbe95e6acf/data' :
+        'community.wave.seqera.io/library/spring:1.1.1--911a17b4ccfb85ee' }"
 
     input:
     tuple val(meta), path(spring)
@@ -13,7 +13,8 @@ process SPRING_DECOMPRESS {
 
     output:
     tuple val(meta), path("*.fastq.gz"), emit: fastq
-    path "versions.yml"                , emit: versions
+    tuple val("${task.process}"), val('spring'), val('1.1.1'), topic: versions, emit: versions_spring
+    // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,9 +22,7 @@ process SPRING_DECOMPRESS {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     def output = write_one_fastq_gz ? "-o ${prefix}.fastq.gz" : "-o ${prefix}_R1.fastq.gz ${prefix}_R2.fastq.gz"
-
     """
     spring \\
         -d \\
@@ -32,23 +31,12 @@ process SPRING_DECOMPRESS {
         $args \\
         -i ${spring} \\
         ${output}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        spring: ${VERSION}
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     def output = write_one_fastq_gz ? "echo '' | gzip > ${prefix}.fastq.gz" : "echo '' | gzip > ${prefix}_R1.fastq.gz; echo '' | gzip > ${prefix}_R2.fastq.gz"
     """
     ${output}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        spring: ${VERSION}
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/spring/decompress/meta.yml
+++ b/modules/nf-core/spring/decompress/meta.yml
@@ -24,14 +24,15 @@ input:
         type: file
         description: Spring file to decompress.
         pattern: "*.{spring}"
-  - - write_one_fastq_gz:
-        type: boolean
-        description: |
-          Controls whether spring should write one fastq.gz file with reads from both directions or two fastq.gz files with reads from distinct directions
-        pattern: "true or false"
+        ontologies: []
+  - write_one_fastq_gz:
+      type: boolean
+      description: |
+        Controls whether spring should write one fastq.gz file with reads from both directions or two fastq.gz files with reads from distinct directions
+      pattern: "true or false"
 output:
-  - fastq:
-      - meta:
+  fastq:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -40,11 +41,28 @@ output:
           type: file
           description: Decompressed FASTQ file(s).
           pattern: "*.{fastq.gz}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_spring:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - spring:
+          type: string
+          description: The name of the tool
+      - 1.1.1:
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - spring:
+          type: string
+          description: The name of the tool
+      - 1.1.1:
+          type: string
+          description: The expression to obtain the version of the tool
 authors:
   - "@xec-cm"
 maintainers:

--- a/modules/nf-core/untar/main.nf
+++ b/modules/nf-core/untar/main.nf
@@ -3,7 +3,7 @@ process UNTAR {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
         : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
 
@@ -12,7 +12,7 @@ process UNTAR {
 
     output:
     tuple val(meta), path("${prefix}"), emit: untar
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('untar'), eval('tar --version 2>&1 | head -1 | sed "s/tar (GNU tar) //; s/ Copyright.*//"'), emit: versions_untar, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -43,10 +43,6 @@ process UNTAR {
             ${args2}
     fi
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        untar: \$(echo \$(tar --version 2>&1) | sed 's/^.*(GNU tar) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 
     stub:
@@ -75,10 +71,5 @@ process UNTAR {
             fi
         done
     fi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        untar: \$(echo \$(tar --version 2>&1) | sed 's/^.*(GNU tar) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/untar/meta.yml
+++ b/modules/nf-core/untar/meta.yml
@@ -1,5 +1,5 @@
 name: untar
-description: Extract files.
+description: Extract files from tar, tar.gz, tar.bz2, tar.xz archives
 keywords:
   - untar
   - uncompress
@@ -7,7 +7,7 @@ keywords:
 tools:
   - untar:
       description: |
-        Extract tar.gz files.
+        Extract tar, tar.gz, tar.bz2, tar.xz files.
       documentation: https://www.gnu.org/software/tar/manual/
       licence: ["GPL-3.0-or-later"]
       identifier: ""
@@ -19,8 +19,8 @@ input:
           e.g. [ id:'test', single_end:false ]
     - archive:
         type: file
-        description: File to be untar
-        pattern: "*.{tar}.{gz}"
+        description: File to be untarred
+        pattern: "*.{tar,tar.gz,tar.bz2,tar.xz}"
         ontologies:
           - edam: http://edamontology.org/format_3981 # TAR format
           - edam: http://edamontology.org/format_3989 # GZIP format
@@ -38,13 +38,29 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
           pattern: "*/"
+  versions_untar:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - untar:
+          type: string
+          description: The name of the tool
+      - tar --version 2>&1 | head -1 | sed "s/tar (GNU tar) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - untar:
+          type: string
+          description: The name of the tool
+      - tar --version 2>&1 | head -1 | sed "s/tar (GNU tar) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/unzip/main.nf
+++ b/modules/nf-core/unzip/main.nf
@@ -3,16 +3,16 @@ process UNZIP {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/p7zip:16.02' :
-        'biocontainers/p7zip:16.02' }"
+        'quay.io/biocontainers/p7zip:16.02' }"
 
     input:
     tuple val(meta), path(archive)
 
     output:
     tuple val(meta), path("${prefix}/"), emit: unzipped_archive
-    path "versions.yml"                , emit: versions
+    tuple val("${task.process}"), val('7za'), eval("7za 2>&1 | sed -n '2s/^.* \\([0-9.]*\\) .*/\\1/p'"), topic: versions, emit: versions_7za
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,23 +27,12 @@ process UNZIP {
         -o"${prefix}"/ \\
         $args \\
         $archive
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        7za: \$(echo \$(7za --help) | sed 's/.*p7zip Version //; s/(.*//')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     if ( archive instanceof List && archive.name.size > 1 ) { error "[UNZIP] error: 7za only accepts a single archive as input. Please check module input." }
     prefix = task.ext.prefix ?: ( meta.id ? "${meta.id}" : archive.baseName)
     """
     mkdir "${prefix}"
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        7za: \$(echo \$(7za --help) | sed 's/.*p7zip Version //; s/(.*//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/unzip/meta.yml
+++ b/modules/nf-core/unzip/meta.yml
@@ -7,12 +7,13 @@ keywords:
   - archiving
 tools:
   - unzip:
-      description: p7zip is a quick port of 7z.exe and 7za.exe (command line version
-        of 7zip, see www.7-zip.org) for Unix.
+      description: p7zip is a quick port of 7z.exe and 7za.exe (command line
+        version of 7zip, see www.7-zip.org) for Unix.
       homepage: https://sourceforge.net/projects/p7zip/
       documentation: https://sourceforge.net/projects/p7zip/
       tool_dev_url: https://sourceforge.net/projects/p7zip"
-      licence: ["LGPL-2.1-or-later"]
+      licence:
+        - "LGPL-2.1-or-later"
       identifier: ""
 input:
   - - meta:
@@ -25,7 +26,7 @@ input:
         description: ZIP file
         pattern: "*.zip"
         ontologies:
-          - edam: http://edamontology.org/format_3987 # ZIP format
+          - edam: http://edamontology.org/format_3987
 output:
   unzipped_archive:
     - - meta:
@@ -37,13 +38,27 @@ output:
           type: directory
           description: Directory contents of the unzipped archive
           pattern: "${archive.baseName}/"
+  versions_7za:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - 7za:
+          type: string
+          description: The name of the tool
+      - 7za 2>&1 | sed -n '2s/^.* \([0-9.]*\) .*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - 7za:
+          type: string
+          description: The name of the tool
+      - 7za 2>&1 | sed -n '2s/^.* \([0-9.]*\) .*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/subworkflows/local/bam_convert_samtools/main.nf
+++ b/subworkflows/local/bam_convert_samtools/main.nf
@@ -60,7 +60,6 @@ workflow BAM_CONVERT_SAMTOOLS {
     reads = CAT_FASTQ.out.reads
 
     // Gather versions of all tools used
-    versions = versions.mix(CAT_FASTQ.out.versions)
     versions = versions.mix(COLLATE_FASTQ_MAP.out.versions)
     versions = versions.mix(COLLATE_FASTQ_UNMAP.out.versions)
     versions = versions.mix(SAMTOOLS_MERGE_UNMAP.out.versions)

--- a/subworkflows/local/bam_variant_calling_mpileup/main.nf
+++ b/subworkflows/local/bam_variant_calling_mpileup/main.nf
@@ -75,7 +75,6 @@ workflow BAM_VARIANT_CALLING_MPILEUP {
         .map { meta, tbi -> [meta - meta.subMap('num_intervals') + [variantcaller: 'bcftools'], tbi] }
 
     versions = versions.mix(SAMTOOLS_MPILEUP.out.versions)
-    versions = versions.mix(CAT_MPILEUP.out.versions)
 
     emit:
     mpileup

--- a/subworkflows/local/fastq_align/main.nf
+++ b/subworkflows/local/fastq_align/main.nf
@@ -19,7 +19,6 @@ workflow FASTQ_ALIGN {
 
     main:
 
-    versions = channel.empty()
     reports = channel.empty()
 
     // Only one of the following should be run
@@ -42,13 +41,8 @@ workflow FASTQ_ALIGN {
     // Gather reports of all tools used
     reports = reports.mix(DRAGMAP_ALIGN.out.log)
 
-    // Gather versions of all tools used
-    versions = versions.mix(BWAMEM1_MEM.out.versions)
-    versions = versions.mix(BWAMEM2_MEM.out.versions)
-    versions = versions.mix(DRAGMAP_ALIGN.out.versions)
     emit:
     bam      // channel: [ [meta], bam ]
     bai      // channel: [ [meta], bai ]
     reports
-    versions // channel: [ versions.yml ]
 }

--- a/subworkflows/local/fastq_create_umi_consensus_fgbio/main.nf
+++ b/subworkflows/local/fastq_create_umi_consensus_fgbio/main.nf
@@ -73,10 +73,6 @@ workflow FASTQ_CREATE_UMI_CONSENSUS_FGBIO {
     CALLUMICONSENSUS(GROUPREADSBYUMI.out.bam, call_min_reads, call_min_baseq)
 
     ch_versions = ch_versions.mix(BAM2FASTQ.out.versions)
-    ch_versions = ch_versions.mix(ALIGN_UMI.out.versions)
-    ch_versions = ch_versions.mix(CALLUMICONSENSUS.out.versions)
-    ch_versions = ch_versions.mix(FASTQTOBAM.out.versions)
-    ch_versions = ch_versions.mix(GROUPREADSBYUMI.out.versions)
     ch_versions = ch_versions.mix(MERGE_CONSENSUS.out.versions)
 
     emit:

--- a/subworkflows/local/fastq_preprocess_gatk/main.nf
+++ b/subworkflows/local/fastq_preprocess_gatk/main.nf
@@ -109,8 +109,7 @@ workflow FASTQ_PREPROCESS_GATK {
             save_trimmed_fail = false
             save_merged = false
             FASTP(
-                reads_for_fastp,
-                [], // we are not using any adapter fastas at the moment
+                reads_for_fastp.map { meta, reads -> [ meta, reads, [] ] }, // adapter_fasta folded into the reads tuple (unused)
                 false, // we don't use discard_trimmed_pass at the moment
                 save_trimmed_fail,
                 save_merged
@@ -126,7 +125,6 @@ workflow FASTQ_PREPROCESS_GATK {
                 }.transpose()
             } else reads_for_bbsplit = FASTP.out.reads
 
-            versions = versions.mix(FASTP.out.versions)
 
         } else {
             reads_for_bbsplit = reads_for_fastp
@@ -182,7 +180,6 @@ workflow FASTQ_PREPROCESS_GATK {
             FGBIO_COPYUMIFROMREADNAME(FASTQ_ALIGN.out.bam.map{meta, bam -> [meta, bam, []]})
             aligned_bam = FGBIO_COPYUMIFROMREADNAME.out.bam
             aligned_bai = FGBIO_COPYUMIFROMREADNAME.out.bai
-            versions = versions.mix(FGBIO_COPYUMIFROMREADNAME.out.versions)
         } else {
             aligned_bam = FASTQ_ALIGN.out.bam
             aligned_bai = FASTQ_ALIGN.out.bai
@@ -250,8 +247,6 @@ workflow FASTQ_PREPROCESS_GATK {
             versions = versions.mix(BAM_TO_CRAM_MAPPING.out.versions)
         }
 
-        // Gather used softwares versions
-        versions = versions.mix(FASTQ_ALIGN.out.versions)
     }
 
     if (params.step in ['mapping', 'markduplicates']) {
@@ -270,7 +265,6 @@ workflow FASTQ_PREPROCESS_GATK {
         if(params.step == 'markduplicates' && params.umi_in_read_header) {
             FGBIO_COPYUMIFROMREADNAME(cram_for_markduplicates.map{ meta, bam -> [ meta, bam, [] ] })
             cram_for_markduplicates = FGBIO_COPYUMIFROMREADNAME.out.bam
-            versions = versions.mix(FGBIO_COPYUMIFROMREADNAME.out.versions)
         }
 
         // if no MD is done, then run QC on mapped & converted CRAM files

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -64,7 +64,6 @@ workflow PREPARE_GENOME {
         if (!bwa_in && (aligner == "bwa-mem" || aligner == "sentieon-bwamem" || aligner == "parabricks")) {
             BWAMEM1_INDEX(fasta)
             index_alignment = BWAMEM1_INDEX.out.index.collect()
-            versions = versions.mix(BWAMEM1_INDEX.out.versions)
         }
         else if (aligner == "bwa-mem" || aligner == "sentieon-bwamem" || aligner == "parabricks") {
             index_alignment = channel.fromPath(bwa_in).map { index -> [[id: 'bwa'], index] }.collect()
@@ -72,7 +71,6 @@ workflow PREPARE_GENOME {
         else if (!bwamem2_in && aligner == 'bwa-mem2') {
             BWAMEM2_INDEX(fasta)
             index_alignment = BWAMEM2_INDEX.out.index.collect()
-            versions = versions.mix(BWAMEM2_INDEX.out.versions)
         }
         else if (aligner == 'bwa-mem2') {
             index_alignment = channel.fromPath(bwamem2_in).map { index -> [[id: 'bwamem2'], index] }.collect()
@@ -80,7 +78,6 @@ workflow PREPARE_GENOME {
         else if (!dragmap_in && aligner == 'dragmap') {
             DRAGMAP_HASHTABLE(fasta)
             index_alignment = DRAGMAP_HASHTABLE.out.hashmap.collect()
-            versions = versions.mix(DRAGMAP_HASHTABLE.out.versions)
         }
         else if (aligner == 'dragmap') {
             index_alignment = channel.fromPath(dragmap_in).map { index -> [[id: 'dragmap'], index] }.collect()
@@ -120,7 +117,6 @@ workflow PREPARE_GENOME {
             // Use user-provided bbsplit index
             if (bbsplit_index_in.endsWith('.tar.gz')) {
                 bbsplit_index = UNTAR_BBSPLIT_INDEX([[id: 'bbsplit_index'], file(bbsplit_index_in, checkIfExists: true)]).untar.map { _meta, index -> index }
-                versions = versions.mix(UNTAR_BBSPLIT_INDEX.out.versions)
             }
             else {
                 bbsplit_index = channel.value(file(bbsplit_index_in, checkIfExists: true))
@@ -210,7 +206,6 @@ workflow PREPARE_GENOME {
     if (msisensor2_models_in && msisensor2_models_in.endsWith(".tar.gz") && tools.split(',').contains('msisensor2')) {
         UNTAR_MSISENSOR2_MODELS(channel.fromPath(file(msisensor2_models_in)).map { archive -> [[id: archive.baseName], archive] })
         msisensor2_models = UNTAR_MSISENSOR2_MODELS.out.untar.collect()
-        versions = versions.mix(UNTAR_MSISENSOR2_MODELS.out.versions)
     }
     else if (msisensor2_models_in && tools.split(',').contains('msisensor2')) {
         msisensor2_models = channel.fromPath(msisensor2_models_in).map { model -> [[id:model.baseName], model] }.collect()
@@ -238,7 +233,6 @@ workflow PREPARE_GENOME {
     else if (ascat_alleles_in.endsWith(".zip") && tools.split(',').contains('ascat')) {
         UNZIP_ALLELES(channel.fromPath(file(ascat_alleles_in)).map { archive -> [[id: archive.baseName], archive] })
         ascat_alleles = UNZIP_ALLELES.out.unzipped_archive.map { _meta, extracted_archive -> extracted_archive }.collect()
-        versions = versions.mix(UNZIP_ALLELES.out.versions)
     }
     else {
         ascat_alleles = channel.fromPath(ascat_alleles_in).collect()
@@ -250,7 +244,6 @@ workflow PREPARE_GENOME {
     else if (ascat_loci_in.endsWith(".zip") && tools.split(',').contains('ascat')) {
         UNZIP_LOCI(channel.fromPath(file(ascat_loci_in)).map { archive -> [[id: archive.baseName], archive] })
         ascat_loci = UNZIP_LOCI.out.unzipped_archive.map { _meta, extracted_archive -> extracted_archive }.collect()
-        versions = versions.mix(UNZIP_LOCI.out.versions)
     }
     else {
         ascat_loci = channel.fromPath(ascat_loci_in).collect()
@@ -262,7 +255,6 @@ workflow PREPARE_GENOME {
     else if (ascat_loci_gc_in.endsWith(".zip") && tools.split(',').contains('ascat')) {
         UNZIP_GC(channel.fromPath(file(ascat_loci_gc_in)).map { archive -> [[id: archive.baseName], archive] })
         ascat_loci_gc = UNZIP_GC.out.unzipped_archive.map { _meta, extracted_archive -> extracted_archive }.collect()
-        versions = versions.mix(UNZIP_GC.out.versions)
     }
     else {
         ascat_loci_gc = channel.fromPath(ascat_loci_gc_in).collect()
@@ -274,7 +266,6 @@ workflow PREPARE_GENOME {
     else if (ascat_loci_rt_in.endsWith(".zip") && tools.split(',').contains('ascat')) {
         UNZIP_RT(channel.fromPath(file(ascat_loci_rt_in)).map { archive -> [[id: archive.baseName], archive] })
         ascat_loci_rt = UNZIP_RT.out.unzipped_archive.map { _meta, extracted_archive -> extracted_archive }.collect()
-        versions = versions.mix(UNZIP_RT.out.versions)
     }
     else {
         ascat_loci_rt = channel.fromPath(ascat_loci_rt_in).collect()
@@ -286,7 +277,6 @@ workflow PREPARE_GENOME {
     else if (chr_dir_in.endsWith(".tar.gz") && tools.split(',').contains('controlfreec')) {
         UNTAR_CHR_DIR(channel.fromPath(file(chr_dir_in)).map { archive -> [[id: archive.baseName], archive] })
         chr_dir = UNTAR_CHR_DIR.out.untar.map { _meta, extracted_archive -> extracted_archive }.collect()
-        versions = versions.mix(UNTAR_CHR_DIR.out.versions)
     }
     else {
         chr_dir = channel.fromPath(chr_dir_in).collect()

--- a/subworkflows/local/prepare_intervals/main.nf
+++ b/subworkflows/local/prepare_intervals/main.nf
@@ -47,7 +47,6 @@ workflow PREPARE_INTERVALS {
 
             intervals_bed = CREATE_INTERVALS_BED.out.bed
 
-            versions = versions.mix(BUILD_INTERVALS.out.versions)
             versions = versions.mix(CREATE_INTERVALS_BED.out.versions)
         } else {
             intervals_combined = channel.fromPath(file(intervals)).map{bed -> [ [ id:bed.baseName ], bed ] }

--- a/tests/aligner-bwa-mem.nf.test.snap
+++ b/tests/aligner-bwa-mem.nf.test.snap
@@ -7,11 +7,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -90,7 +90,7 @@
             5,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -141,7 +141,7 @@
             5,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -207,11 +207,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/aligner-bwa-mem2.nf.test.snap
+++ b/tests/aligner-bwa-mem2.nf.test.snap
@@ -74,7 +74,7 @@
                 },
                 "BWAMEM2_MEM": {
                     "bwamem2": "2.2.1",
-                    "samtools": 1.21
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -211,7 +211,7 @@
                 },
                 "BWAMEM2_MEM": {
                     "bwamem2": "2.2.1",
-                    "samtools": 1.21
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/aligner-parabricks.nf.test.snap
+++ b/tests/aligner-parabricks.nf.test.snap
@@ -4,7 +4,7 @@
             15,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CRAM_TO_BAM": {
                     "samtools": 1.21
@@ -237,7 +237,7 @@
             14,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -476,7 +476,7 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CALCULATECONTAMINATION": {
                     "gatk4": "4.6.2.0"
@@ -797,7 +797,7 @@
             13,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/alignment_from_everything.nf.test.snap
+++ b/tests/alignment_from_everything.nf.test.snap
@@ -4,14 +4,14 @@
             61,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CAT_FASTQ": {
-                    "cat": 9.5
+                    "cat": "9.5"
                 },
                 "COLLATE_FASTQ_MAP": {
                     "samtools": 1.21

--- a/tests/alignment_to_fastq.nf.test.snap
+++ b/tests/alignment_to_fastq.nf.test.snap
@@ -4,14 +4,14 @@
             25,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CAT_FASTQ": {
-                    "cat": 9.5
+                    "cat": "9.5"
                 },
                 "COLLATE_FASTQ_MAP": {
                     "samtools": 1.21

--- a/tests/bbsplit.nf.test.snap
+++ b/tests/bbsplit.nf.test.snap
@@ -13,11 +13,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -377,11 +377,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -601,14 +601,14 @@
                     "bbmap": "39.18"
                 },
                 "BUILD_INTERVALS": {
-                    "gawk": "5.3.0"
+                    "gawk": "5.3.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -7,11 +7,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -334,11 +334,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/fastp.nf.test.snap
+++ b/tests/fastp.nf.test.snap
@@ -4,17 +4,17 @@
             20,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
                 },
                 "FASTP": {
-                    "fastp": "0.24.0"
+                    "fastp": "1.1.0"
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
@@ -235,10 +235,10 @@
                 "preprocessing",
                 "preprocessing/fastp",
                 "preprocessing/fastp/test",
-                "preprocessing/fastp/test/test-test_L1_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/test-test_L1_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/test-test_L2_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/test-test_L2_2.fastp.fastq.gz",
+                "preprocessing/fastp/test/test-test_L1_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/test-test_L1_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/test-test_L2_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/test-test_L2_R2.fastp.fastq.gz",
                 "preprocessing/markduplicates",
                 "preprocessing/markduplicates/test",
                 "preprocessing/markduplicates/test/test.md.cram",
@@ -320,7 +320,7 @@
                 "mosdepth-cumcoverage-dist-id.txt:md5,d97ac04e524b20bf9d261c009ac92b6a",
                 "mosdepth_perchrom.txt:md5,29af8f8744a88e2ec0486292d541559f",
                 "multiqc_citations.txt:md5,0e2971e7a873c92592112775fa99fb02",
-                "multiqc_fastp.txt:md5,2f22f6c961e432974f27a4e56d877cec",
+                "multiqc_fastp.txt:md5,39b27871814457c42ea33aa131b8ecfc",
                 "multiqc_fastqc.txt:md5,bde0d0bffa62228b33fb68b7e25b6ff8",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -329,12 +329,12 @@
                 "samtools-stats-dp.txt:md5,58ea8c88565a359af678aa588e44895c",
                 "samtools_alignment_plot.txt:md5,aac925e42c9da438ab9f0fb7ae77e2fa",
                 "samtools_insert_size.txt:md5,9eccc96ce006c0161497782ed3afc147",
-                "test-test_L1_1.fastp.fastq.gz:md5,f1a5c524cae7be9b5ca9a4138f847cfa",
-                "test-test_L1_2.fastp.fastq.gz:md5,e366994a1db55b5ed3cd12482f33cee7",
-                "test-test_L2_1.fastp.fastq.gz:md5,f1a5c524cae7be9b5ca9a4138f847cfa",
-                "test-test_L2_2.fastp.fastq.gz:md5,e366994a1db55b5ed3cd12482f33cee7",
-                "test-test_L1.fastp.json:md5,fb88c7b5807f6c7478b01baddf8ca4e8",
-                "test-test_L2.fastp.json:md5,708187bd90c12b1c8c3fa7046b69dc35",
+                "test-test_L1_R1.fastp.fastq.gz:md5,f1a5c524cae7be9b5ca9a4138f847cfa",
+                "test-test_L1_R2.fastp.fastq.gz:md5,e366994a1db55b5ed3cd12482f33cee7",
+                "test-test_L2_R1.fastp.fastq.gz:md5,f1a5c524cae7be9b5ca9a4138f847cfa",
+                "test-test_L2_R2.fastp.fastq.gz:md5,e366994a1db55b5ed3cd12482f33cee7",
+                "test-test_L1.fastp.json:md5,80fa7cc86ef9fa02eeb9c9d25c6f2672",
+                "test-test_L2.fastp.json:md5,138a8dbd84d89dcf19c303fdc05754e9",
                 "test.md.mosdepth.global.dist.txt:md5,b1c26e3381f220e65d683048ab6b6e2a",
                 "test.md.mosdepth.region.dist.txt:md5,02d51752367e753a6984c12f059499ba",
                 "test.md.mosdepth.summary.txt:md5,f18e776c3ee8e6947c3a69c136f54860",
@@ -367,17 +367,17 @@
             26,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
                 },
                 "FASTP": {
-                    "fastp": "0.24.0"
+                    "fastp": "1.1.0"
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
@@ -598,22 +598,22 @@
                 "preprocessing",
                 "preprocessing/fastp",
                 "preprocessing/fastp/test",
-                "preprocessing/fastp/test/0001.test-test_L1_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0001.test-test_L1_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/0001.test-test_L2_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0001.test-test_L2_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/0002.test-test_L1_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0002.test-test_L1_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/0002.test-test_L2_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0002.test-test_L2_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/0003.test-test_L1_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0003.test-test_L1_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/0003.test-test_L2_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0003.test-test_L2_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/0004.test-test_L1_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0004.test-test_L1_2.fastp.fastq.gz",
-                "preprocessing/fastp/test/0004.test-test_L2_1.fastp.fastq.gz",
-                "preprocessing/fastp/test/0004.test-test_L2_2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0001.test-test_L1_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0001.test-test_L1_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0001.test-test_L2_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0001.test-test_L2_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0002.test-test_L1_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0002.test-test_L1_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0002.test-test_L2_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0002.test-test_L2_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0003.test-test_L1_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0003.test-test_L1_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0003.test-test_L2_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0003.test-test_L2_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0004.test-test_L1_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0004.test-test_L1_R2.fastp.fastq.gz",
+                "preprocessing/fastp/test/0004.test-test_L2_R1.fastp.fastq.gz",
+                "preprocessing/fastp/test/0004.test-test_L2_R2.fastp.fastq.gz",
                 "preprocessing/markduplicates",
                 "preprocessing/markduplicates/test",
                 "preprocessing/markduplicates/test/test.md.cram",
@@ -695,7 +695,7 @@
                 "mosdepth-cumcoverage-dist-id.txt:md5,722e8c7583dd52b2c8d8bb923718c912",
                 "mosdepth_perchrom.txt:md5,b9304bb6dee33d25255e19693c0a4dd8",
                 "multiqc_citations.txt:md5,0e2971e7a873c92592112775fa99fb02",
-                "multiqc_fastp.txt:md5,758582c0fafe6e69ad8488eb612008de",
+                "multiqc_fastp.txt:md5,e5a4f17bb627d529e829f11fda3bddc3",
                 "multiqc_fastqc.txt:md5,bde0d0bffa62228b33fb68b7e25b6ff8",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -704,24 +704,24 @@
                 "samtools-stats-dp.txt:md5,93ec69f6db74d9de7e4a549491ae2c73",
                 "samtools_alignment_plot.txt:md5,962b7dd27f48ec4bbb668c8c32cbea1b",
                 "samtools_insert_size.txt:md5,555c4ca8aac120c3b23e6cd2457922cd",
-                "0001.test-test_L1_1.fastp.fastq.gz:md5,f379a60cc2a41f39fa0c0d23edf6eb61",
-                "0001.test-test_L1_2.fastp.fastq.gz:md5,e54d912158088d98f8083854079e1f5c",
-                "0001.test-test_L2_1.fastp.fastq.gz:md5,f379a60cc2a41f39fa0c0d23edf6eb61",
-                "0001.test-test_L2_2.fastp.fastq.gz:md5,e54d912158088d98f8083854079e1f5c",
-                "0002.test-test_L1_1.fastp.fastq.gz:md5,366180a220f6b78c55b1b23b35dc7f96",
-                "0002.test-test_L1_2.fastp.fastq.gz:md5,66ca650f883997310858acac94c8d236",
-                "0002.test-test_L2_1.fastp.fastq.gz:md5,366180a220f6b78c55b1b23b35dc7f96",
-                "0002.test-test_L2_2.fastp.fastq.gz:md5,66ca650f883997310858acac94c8d236",
-                "0003.test-test_L1_1.fastp.fastq.gz:md5,46bc09415a26d50230163e613cb1324b",
-                "0003.test-test_L1_2.fastp.fastq.gz:md5,500404ef12d7c6f02eb3b5367f84a978",
-                "0003.test-test_L2_1.fastp.fastq.gz:md5,46bc09415a26d50230163e613cb1324b",
-                "0003.test-test_L2_2.fastp.fastq.gz:md5,500404ef12d7c6f02eb3b5367f84a978",
-                "0004.test-test_L1_1.fastp.fastq.gz:md5,f3b1d77aa32f019f3088810cac2605e9",
-                "0004.test-test_L1_2.fastp.fastq.gz:md5,e38c0529e6ba0abce221ac39c84263b0",
-                "0004.test-test_L2_1.fastp.fastq.gz:md5,f3b1d77aa32f019f3088810cac2605e9",
-                "0004.test-test_L2_2.fastp.fastq.gz:md5,e38c0529e6ba0abce221ac39c84263b0",
-                "test-test_L1.fastp.json:md5,2f72ca9fa3c55cfd4ff67a747f7c2e46",
-                "test-test_L2.fastp.json:md5,f8b183e541878de7b24e555e23e078f1",
+                "0001.test-test_L1_R1.fastp.fastq.gz:md5,f379a60cc2a41f39fa0c0d23edf6eb61",
+                "0001.test-test_L1_R2.fastp.fastq.gz:md5,e54d912158088d98f8083854079e1f5c",
+                "0001.test-test_L2_R1.fastp.fastq.gz:md5,f379a60cc2a41f39fa0c0d23edf6eb61",
+                "0001.test-test_L2_R2.fastp.fastq.gz:md5,e54d912158088d98f8083854079e1f5c",
+                "0002.test-test_L1_R1.fastp.fastq.gz:md5,366180a220f6b78c55b1b23b35dc7f96",
+                "0002.test-test_L1_R2.fastp.fastq.gz:md5,66ca650f883997310858acac94c8d236",
+                "0002.test-test_L2_R1.fastp.fastq.gz:md5,366180a220f6b78c55b1b23b35dc7f96",
+                "0002.test-test_L2_R2.fastp.fastq.gz:md5,66ca650f883997310858acac94c8d236",
+                "0003.test-test_L1_R1.fastp.fastq.gz:md5,46bc09415a26d50230163e613cb1324b",
+                "0003.test-test_L1_R2.fastp.fastq.gz:md5,500404ef12d7c6f02eb3b5367f84a978",
+                "0003.test-test_L2_R1.fastp.fastq.gz:md5,46bc09415a26d50230163e613cb1324b",
+                "0003.test-test_L2_R2.fastp.fastq.gz:md5,500404ef12d7c6f02eb3b5367f84a978",
+                "0004.test-test_L1_R1.fastp.fastq.gz:md5,f3b1d77aa32f019f3088810cac2605e9",
+                "0004.test-test_L1_R2.fastp.fastq.gz:md5,e38c0529e6ba0abce221ac39c84263b0",
+                "0004.test-test_L2_R1.fastp.fastq.gz:md5,f3b1d77aa32f019f3088810cac2605e9",
+                "0004.test-test_L2_R2.fastp.fastq.gz:md5,e38c0529e6ba0abce221ac39c84263b0",
+                "test-test_L1.fastp.json:md5,34c54addc091d14c6c9582ef2ed16a85",
+                "test-test_L2.fastp.json:md5,607e27e248389ec266eecc847c6f9936",
                 "test.md.mosdepth.global.dist.txt:md5,e5d0c6bf323c32f5414bd48b90bb32fa",
                 "test.md.mosdepth.region.dist.txt:md5,5062f8b7bb536c9b77a68f4ccd2315c2",
                 "test.md.mosdepth.summary.txt:md5,455358d5943fd1e5f09853acff3e50b6",
@@ -754,17 +754,17 @@
             20,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
                 },
                 "FASTP": {
-                    "fastp": "0.24.0"
+                    "fastp": "1.1.0"
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
@@ -1064,7 +1064,7 @@
                 "mosdepth-cumcoverage-dist-id.txt:md5,caee7b9e5d1a451970f87d791c3e450b",
                 "mosdepth_perchrom.txt:md5,a0990e98cdd2cd5540d07f504f516ccf",
                 "multiqc_citations.txt:md5,0e2971e7a873c92592112775fa99fb02",
-                "multiqc_fastp.txt:md5,2e4305ae77790e1948c19acc778b508c",
+                "multiqc_fastp.txt:md5,8c270b44aaec9ee1bd7bf19d2150a51e",
                 "multiqc_fastqc.txt:md5,bde0d0bffa62228b33fb68b7e25b6ff8",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -1073,8 +1073,8 @@
                 "samtools-stats-dp.txt:md5,ae7954084b2cd708c5e7369606bf4208",
                 "samtools_alignment_plot.txt:md5,438e719bf574a46726dbd2e0f1442e42",
                 "samtools_insert_size.txt:md5,73b933a27800b86a4012c2d525870796",
-                "test-test_L1.fastp.json:md5,ced0232bc3be313b392a9f59ff970cc2",
-                "test-test_L2.fastp.json:md5,d05b922b85ecd0e087ba05af543f8ff8",
+                "test-test_L1.fastp.json:md5,a7746b05c3ffb374c8f5d204f971879e",
+                "test-test_L2.fastp.json:md5,d896569d921616f61a829b62477c1ffa",
                 "test.md.mosdepth.global.dist.txt:md5,ef7c375ae07aec5540f9892b9b556b73",
                 "test.md.mosdepth.region.dist.txt:md5,212efff2213f6fc1c3204daf68bbb8c8",
                 "test.md.mosdepth.summary.txt:md5,72114393647ff64503522760218b30f0",

--- a/tests/intervals.nf.test.snap
+++ b/tests/intervals.nf.test.snap
@@ -7,14 +7,14 @@
                     "samtools": 1.21
                 },
                 "BUILD_INTERVALS": {
-                    "gawk": "5.3.0"
+                    "gawk": "5.3.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -91,11 +91,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -153,11 +153,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "INDEX_MERGE_BAM": {
                     "samtools": 1.21
@@ -211,11 +211,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "INDEX_MERGE_BAM": {
                     "samtools": 1.21
@@ -264,11 +264,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -321,14 +321,14 @@
                     "samtools": 1.21
                 },
                 "BUILD_INTERVALS": {
-                    "gawk": "5.3.0"
+                    "gawk": "5.3.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/joint_calling_mutect2.nf.test.snap
+++ b/tests/joint_calling_mutect2.nf.test.snap
@@ -238,7 +238,7 @@
                     "bcftools": "1.23.1"
                 },
                 "BUILD_INTERVALS": {
-                    "gawk": "5.3.0"
+                    "gawk": "5.3.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/lane_integer.nf.test.snap
+++ b/tests/lane_integer.nf.test.snap
@@ -7,11 +7,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/multi_lane.nf.test.snap
+++ b/tests/multi_lane.nf.test.snap
@@ -7,11 +7,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -125,17 +125,17 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CALLUMICONSENSUS": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "CAT_FASTQ": {
-                    "cat": 9.5
+                    "cat": "9.5"
                 },
                 "COLLATE_FASTQ_MAP": {
                     "samtools": 1.21
@@ -147,13 +147,13 @@
                     "gawk": "5.3.0"
                 },
                 "FASTQTOBAM": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_INTERVALLISTTOBED": {
                     "gatk4": "4.6.2.0"
                 },
                 "GROUPREADSBYUMI": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "INDEX_MERGE_BAM": {
                     "samtools": 1.21
@@ -203,16 +203,18 @@
                 "reference",
                 "reports",
                 "reports/umi",
-                "reports/umi/test_umi-grouped_histogram.txt"
+                "reports/umi/test_umi-grouped_histogram.txt",
+                "reports/umi/test_umi-grouped_read-metrics.txt"
             ],
             [
-                "test_umi-grouped_histogram.txt:md5,47440eca0cc1e70be22fe2a2ce81dfbf"
+                "test_umi-grouped_histogram.txt:md5,4e3bc8b3ed89ddf32ee3543af98f1033",
+                "test_umi-grouped_read-metrics.txt:md5,c0319b6e16385163f66b647091a48550"
             ],
             [
-                "test_umi-consensus.bam:md5,122d60b069b76a217b6fe91d1765dae3"
+                "test_umi-consensus.bam:md5,d77fca0cc9d628d9966556d64be72460"
             ],
             [
-                "test.sorted.cram:md5,450f711661b0222e8496ea3140fe7fff"
+                "test.sorted.cram:md5,d07bc9529dff41207c4cac3ecbd47071"
             ],
             "No VCF files",
             [

--- a/tests/save_mapped.nf.test.snap
+++ b/tests/save_mapped.nf.test.snap
@@ -7,11 +7,11 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/save_output_as_bam.nf.test.snap
+++ b/tests/save_output_as_bam.nf.test.snap
@@ -7,11 +7,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CNVKIT_ANTITARGET": {
                     "cnvkit": "0.9.11"
@@ -377,11 +377,11 @@
             9,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/sentieon.nf.test.snap
+++ b/tests/sentieon.nf.test.snap
@@ -4,7 +4,7 @@
             18,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/sentieon_aligner_bwamem.nf.test.snap
+++ b/tests/sentieon_aligner_bwamem.nf.test.snap
@@ -7,7 +7,7 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -90,16 +90,16 @@
             9,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
                 },
                 "FASTP": {
-                    "fastp": "0.24.0"
+                    "fastp": "1.1.0"
                 },
                 "FGBIO_COPYUMIFROMREADNAME": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_INTERVALLISTTOBED": {
                     "gatk4": "4.6.2.0"
@@ -145,7 +145,7 @@
                 "reports/sentieon_dedup/test/test.dedup.cram.metrics.multiqc.tsv"
             ],
             [
-                "test-test_L1.fastp.json:md5,d9107ec414e44408d0698b167cc445f9"
+                "test-test_L1.fastp.json:md5,5146ada16c3aae0e55e3e993b9d587af"
             ],
             "No BAM files",
             [
@@ -167,7 +167,7 @@
             5,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/sentieon_dedup.nf.test.snap
+++ b/tests/sentieon_dedup.nf.test.snap
@@ -583,7 +583,7 @@
                     "gawk": "5.3.0"
                 },
                 "FGBIO_COPYUMIFROMREADNAME": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_APPLYBQSR": {
                     "gatk4": "4.6.2.0"
@@ -778,7 +778,7 @@
                     "gawk": "5.3.0"
                 },
                 "FGBIO_COPYUMIFROMREADNAME": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_APPLYBQSR": {
                     "gatk4": "4.6.2.0"

--- a/tests/spark.nf.test.snap
+++ b/tests/spark.nf.test.snap
@@ -4,11 +4,11 @@
             18,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -253,11 +253,11 @@
             11,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/tumor-normal-pair.nf.test.snap
+++ b/tests/tumor-normal-pair.nf.test.snap
@@ -7,11 +7,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/umi_fastp.nf.test.snap
+++ b/tests/umi_fastp.nf.test.snap
@@ -4,23 +4,23 @@
             18,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
                 },
                 "FASTP": {
-                    "fastp": "0.24.0"
+                    "fastp": "1.1.0"
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
                 "FGBIO_COPYUMIFROMREADNAME": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_APPLYBQSR": {
                     "gatk4": "4.6.2.0"
@@ -318,7 +318,7 @@
                 "mosdepth-cumcoverage-dist-id.txt:md5,5e049e05573f1afd0bb893f2cb4076c6",
                 "mosdepth_perchrom.txt:md5,45bca136491a7675ebba87def2534f26",
                 "multiqc_citations.txt:md5,0e2971e7a873c92592112775fa99fb02",
-                "multiqc_fastp.txt:md5,8e11d751e997877e4ffc487c52756f62",
+                "multiqc_fastp.txt:md5,542e41a81f66bd647eff0e741a377b04",
                 "multiqc_fastqc.txt:md5,0ca2cba4204d9076a1eb17596379d10c",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -327,7 +327,7 @@
                 "samtools-stats-dp.txt:md5,a6f11f838a72299e4913a54dd327f2e6",
                 "samtools_alignment_plot.txt:md5,111d8b457e8c34dc919a527f12f27d4a",
                 "samtools_insert_size.txt:md5,5dbef29f8a260b9aa05de422676ab81a",
-                "test-test_L1.fastp.json:md5,d9107ec414e44408d0698b167cc445f9",
+                "test-test_L1.fastp.json:md5,5146ada16c3aae0e55e3e993b9d587af",
                 "test.md.mosdepth.global.dist.txt:md5,40bf266b2080717f92b405cb42fab4a7",
                 "test.md.mosdepth.region.dist.txt:md5,94b080042f51f484fa178339cc9324bc",
                 "test.md.mosdepth.summary.txt:md5,7958c5422bb4b5181afe9782e38a735a",

--- a/tests/umi_fgbio.nf.test.snap
+++ b/tests/umi_fgbio.nf.test.snap
@@ -27,17 +27,17 @@
                     "samtools": 1.21
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CALLUMICONSENSUS": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "CAT_FASTQ": {
-                    "cat": 9.5
+                    "cat": "9.5"
                 },
                 "COLLATE_FASTQ_MAP": {
                     "samtools": 1.21
@@ -52,7 +52,7 @@
                     "fastqc": "0.12.1"
                 },
                 "FASTQTOBAM": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_APPLYBQSR": {
                     "gatk4": "4.6.2.0"
@@ -68,7 +68,7 @@
                     "samtools": "1.21"
                 },
                 "GROUPREADSBYUMI": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "INDEX_CRAM": {
                     "samtools": 1.21
@@ -276,7 +276,8 @@
                 "reports/samtools/test/test.md.cram.stats",
                 "reports/samtools/test/test.recal.cram.stats",
                 "reports/umi",
-                "reports/umi/test_umi-grouped_histogram.txt"
+                "reports/umi/test_umi-grouped_histogram.txt",
+                "reports/umi/test_umi-grouped_read-metrics.txt"
             ],
             [
                 "fastqc-status-check-heatmap.txt:md5,92fcedba625d8394492d1ef6e2eb64f0",
@@ -290,36 +291,37 @@
                 "fastqc_sequence_counts_plot.txt:md5,1a4aab87f1bd4fd9f69cabef40f5e5ed",
                 "fastqc_sequence_duplication_levels_plot.txt:md5,72e6366160d000a2990b2bbd321300a7",
                 "fastqc_sequence_length_distribution_plot.txt:md5,7c07faf0c0b90613cdc82a9f09bc1f19",
-                "mosdepth-coverage-per-contig-single.txt:md5,800ad271050c46d24bf53c0f8bdf7b6e",
-                "mosdepth-cumcoverage-dist-id.txt:md5,3c526ec6da433233b419bdbdd19a1b56",
-                "mosdepth_perchrom.txt:md5,800ad271050c46d24bf53c0f8bdf7b6e",
+                "mosdepth-coverage-per-contig-single.txt:md5,fc8d90478e230b3cbad16ef68ede3a62",
+                "mosdepth-cumcoverage-dist-id.txt:md5,7985d3196b234be9907f6c417c4fe0df",
+                "mosdepth_perchrom.txt:md5,fc8d90478e230b3cbad16ef68ede3a62",
                 "multiqc_citations.txt:md5,7d0b4b866fa577272c48a1f3ad72e75d",
                 "multiqc_fastqc.txt:md5,0ca2cba4204d9076a1eb17596379d10c",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram_1.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_QualityScoreDistribution_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "samtools-stats-dp.txt:md5,4d27768d75a69a61daf23bf5efe17687",
-                "samtools_alignment_plot.txt:md5,3c2a882852a7ffe06610c9027f0a312a",
-                "samtools_insert_size.txt:md5,728c8cd8979768e4912f608f59fe1222",
-                "test.md.mosdepth.global.dist.txt:md5,09d22913aa50a0207f97a3f85b182c6e",
-                "test.md.mosdepth.region.dist.txt:md5,61676a4a3668c0e84eb0f56dc6bda1ae",
-                "test.md.mosdepth.summary.txt:md5,9bbea5e4d213a51f501c2aadff8d4526",
-                "test.md.regions.bed.gz:md5,e24c18ad56e54376c41fdaacec372f9e",
-                "test.md.regions.bed.gz.csi:md5,d0713716f63ac573f4a3385733e9a537",
-                "test.recal.mosdepth.global.dist.txt:md5,09d22913aa50a0207f97a3f85b182c6e",
-                "test.recal.mosdepth.region.dist.txt:md5,61676a4a3668c0e84eb0f56dc6bda1ae",
-                "test.recal.mosdepth.summary.txt:md5,9bbea5e4d213a51f501c2aadff8d4526",
-                "test.recal.regions.bed.gz:md5,e24c18ad56e54376c41fdaacec372f9e",
-                "test.recal.regions.bed.gz.csi:md5,d0713716f63ac573f4a3385733e9a537",
-                "test_umi-grouped_histogram.txt:md5,85292e9acb83edf17110dce17be27f44"
+                "samtools-stats-dp.txt:md5,49a0910af4cea91b46a1df076c08c5b5",
+                "samtools_alignment_plot.txt:md5,60b8f1d48124a8f28b06dc0d15ca4d59",
+                "samtools_insert_size.txt:md5,ef2a81138667814cda3e5c8c2628c549",
+                "test.md.mosdepth.global.dist.txt:md5,bb51e76c9cf2f3929cb5ce560f559dd6",
+                "test.md.mosdepth.region.dist.txt:md5,11dc4683f9038de1938b4874e02974d6",
+                "test.md.mosdepth.summary.txt:md5,d6cda5af0f2bf21973e256cf198aa47a",
+                "test.md.regions.bed.gz:md5,b420210d41279bbc93f211491f7d4f02",
+                "test.md.regions.bed.gz.csi:md5,b3716e5cd1744610e69c29bd4ffad259",
+                "test.recal.mosdepth.global.dist.txt:md5,bb51e76c9cf2f3929cb5ce560f559dd6",
+                "test.recal.mosdepth.region.dist.txt:md5,11dc4683f9038de1938b4874e02974d6",
+                "test.recal.mosdepth.summary.txt:md5,d6cda5af0f2bf21973e256cf198aa47a",
+                "test.recal.regions.bed.gz:md5,b420210d41279bbc93f211491f7d4f02",
+                "test.recal.regions.bed.gz.csi:md5,b3716e5cd1744610e69c29bd4ffad259",
+                "test_umi-grouped_histogram.txt:md5,85292e9acb83edf17110dce17be27f44",
+                "test_umi-grouped_read-metrics.txt:md5,cb2aecfe82357aa06e091d69b4606b9e"
             ],
             [
-                "test_umi-consensus.bam:md5,18d420720f72366289d3a324f4552522"
+                "test_umi-consensus.bam:md5,86ddd035aced3a9e7b6e618794824050"
             ],
             [
-                "test.md.cram:md5,2d0c176fed158d84a061b69e1947994c",
-                "test.recal.cram:md5,6927569ca52dbba512d27f8742bc6aae"
+                "test.md.cram:md5,a8f60b321cc24e782dcf6470fd310b08",
+                "test.recal.cram:md5,a8f60b321cc24e782dcf6470fd310b08"
             ],
             "No VCF files",
             [

--- a/tests/umi_in_read_names.nf.test.snap
+++ b/tests/umi_in_read_names.nf.test.snap
@@ -10,7 +10,7 @@
                     "gawk": "5.3.0"
                 },
                 "FGBIO_COPYUMIFROMREADNAME": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_APPLYBQSR": {
                     "gatk4": "4.6.2.0"
@@ -269,14 +269,14 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CAT_FASTQ": {
-                    "cat": 9.5
+                    "cat": "9.5"
                 },
                 "COLLATE_FASTQ_MAP": {
                     "samtools": 1.21
@@ -291,7 +291,7 @@
                     "fastqc": "0.12.1"
                 },
                 "FGBIO_COPYUMIFROMREADNAME": {
-                    "fgbio": "2.4.0"
+                    "fgbio": "3.1.2"
                 },
                 "GATK4_APPLYBQSR": {
                     "gatk4": "4.6.2.0"

--- a/tests/variant_calling_all.nf.test.snap
+++ b/tests/variant_calling_all.nf.test.snap
@@ -13,11 +13,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CNVKIT_ANTITARGET": {
                     "cnvkit": "0.9.11"
@@ -654,11 +654,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CNVKIT_ANTITARGET": {
                     "cnvkit": "0.9.11"
@@ -1148,11 +1148,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CALCULATECONTAMINATION": {
                     "gatk4": "4.6.2.0"

--- a/tests/variant_calling_controlfreec.nf.test.snap
+++ b/tests/variant_calling_controlfreec.nf.test.snap
@@ -32,7 +32,7 @@
                     "tabix": "1.21"
                 },
                 "UNTAR_CHR_DIR": {
-                    "untar": 1.34
+                    "untar": "1.34"
                 }
             },
             [
@@ -189,7 +189,7 @@
                     "tabix": "1.21"
                 },
                 "UNTAR_CHR_DIR": {
-                    "untar": 1.34
+                    "untar": "1.34"
                 }
             },
             [
@@ -361,7 +361,7 @@
                     "tabix": "1.21"
                 },
                 "UNTAR_CHR_DIR": {
-                    "untar": 1.34
+                    "untar": "1.34"
                 }
             },
             [
@@ -480,7 +480,7 @@
                     "tabix": "1.21"
                 },
                 "UNTAR_CHR_DIR": {
-                    "untar": 1.34
+                    "untar": "1.34"
                 }
             },
             [

--- a/tests/variant_calling_freebayes.nf.test.snap
+++ b/tests/variant_calling_freebayes.nf.test.snap
@@ -221,11 +221,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
@@ -626,11 +626,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -995,11 +995,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "FASTQC": {
                     "fastqc": "0.12.1"
@@ -1547,11 +1547,11 @@
                     "bcftools": "1.23.1"
                 },
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "BWAMEM1_MEM": {
-                    "bwa": "0.7.18-r1243-dirty",
-                    "samtools": 1.21
+                    "bwa": "0.7.19-r1273",
+                    "samtools": "1.22.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/variant_calling_msisensor2.nf.test.snap
+++ b/tests/variant_calling_msisensor2.nf.test.snap
@@ -11,7 +11,7 @@
                     "tabix": "1.21"
                 },
                 "UNTAR_MSISENSOR2_MODELS": {
-                    "untar": 1.34
+                    "untar": "1.34"
                 }
             },
             [
@@ -104,7 +104,7 @@
                     "tabix": "1.21"
                 },
                 "UNTAR_MSISENSOR2_MODELS": {
-                    "untar": 1.34
+                    "untar": "1.34"
                 }
             },
             [
@@ -184,7 +184,7 @@
                     "tabix": "1.21"
                 },
                 "UNTAR_MSISENSOR2_MODELS": {
-                    "untar": 1.34
+                    "untar": "1.34"
                 }
             },
             [

--- a/tests/variant_calling_mutect2.nf.test.snap
+++ b/tests/variant_calling_mutect2.nf.test.snap
@@ -606,7 +606,7 @@
                     "bcftools": "1.23.1"
                 },
                 "BUILD_INTERVALS": {
-                    "gawk": "5.3.0"
+                    "gawk": "5.3.1"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/tests/variant_calling_sentieon_tnscope.nf.test.snap
+++ b/tests/variant_calling_sentieon_tnscope.nf.test.snap
@@ -4,7 +4,7 @@
             11,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -91,7 +91,7 @@
             19,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"
@@ -204,7 +204,7 @@
             10,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "SENTIEON_BWAMEM": {
                     "bwa": "0.7.17-r1188",
@@ -292,7 +292,7 @@
             13,
             {
                 "BWAMEM1_INDEX": {
-                    "bwa": "0.7.18-r1243-dirty"
+                    "bwa": "0.7.19-r1273"
                 },
                 "CREATE_INTERVALS_BED": {
                     "gawk": "5.3.0"

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -168,9 +168,6 @@ workflow SAREK {
             true,
         )
 
-        versions = versions.mix(SPRING_DECOMPRESS_TO_R1_FQ.out.versions)
-        versions = versions.mix(SPRING_DECOMPRESS_TO_R2_FQ.out.versions)
-        versions = versions.mix(SPRING_DECOMPRESS_TO_FQ_PAIR.out.versions)
 
         two_fastq_gz_from_spring = r1_fastq_gz_from_spring.fastq.join(r2_fastq_gz_from_spring.fastq).map { meta, fastq_1, fastq_2 -> [meta, [fastq_1, fastq_2]] }
 


### PR DESCRIPTION
Migrates alignment, UMI and utility modules to the `versions` topic channel. **Stacked on #2238** (base: `topic/gatk`).

### Changes
- Updates `bwa`, `bwamem2`, `dragmap`, `fgbio`, `fastp`, `cat`, `gawk`, `gunzip`, `untar`, `unzip`, `tabix`, `spring` to their topic-channel versions.
- Removes the corresponding `.out.versions` wiring from subworkflows.
- Fixes the `FASTP` call site for the new input signature (adapter fasta folded into the reads tuple).
- Tool bumps ride along (see changelog) — notably **fastp 0.24.0 → 1.1.0** (major) and **fgbio 2.4.0 → 3.1.2**.

Test snapshots need regenerating in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)