### PR TITLE
avoid misleading sample-sheet errors on unrelated pipeline abort (#1629)

### DIFF
--- a/subworkflows/local/samplesheet_to_channel/main.nf
+++ b/subworkflows/local/samplesheet_to_channel/main.nf
@@ -240,37 +240,45 @@ workflow SAMPLESHEET_TO_CHANNEL {
         // Two checks for ensuring that the pipeline stops with a meaningful error message if
         // 1. the sample-sheet only contains normal-samples, but some of the requested tools require tumor-samples, and
         // 2. the sample-sheet only contains tumor-samples, but some of the requested tools require normal-samples.
+        // Collect the statuses first and validate once. The `if (statuses)` guard means that when the
+        // channel emits nothing - e.g. the run is aborting for an unrelated reason such as an invalid
+        // snpeff_cache/vep_cache path - we skip the check instead of firing spurious "only contains
+        // tumor/normal-samples" errors from the operators' afterStop teardown.
         input_sample
-            .filter { sample -> sample[0].status == 1 }
-            .ifEmpty {
-                // In this case, the sample-sheet contains no tumor-samples
-                if (!build_only_index) {
-                    def tools_tumor = ['ascat', 'controlfreec', 'mutect2', 'msisensorpro']
-                    def tools_tumor_asked = []
-                    tools_tumor.each { tool ->
-                        if (tools && tools.split(',').contains(tool)) {
-                            tools_tumor_asked.add(tool)
+            .map { it[0].status }
+            .toList()
+            .subscribe { statuses ->
+                if (statuses) {
+                    def has_normal = statuses.contains(0)
+                    def has_tumor  = statuses.contains(1)
+
+                    // 1. the sample-sheet contains no tumor-samples
+                    if (!has_tumor) {
+                        def tools_tumor = ['ascat', 'controlfreec', 'mutect2', 'msisensorpro']
+                        def tools_tumor_asked = []
+                        tools_tumor.each { tool ->
+                            if (tools && tools.split(',').contains(tool)) {
+                                tools_tumor_asked.add(tool)
+                            }
+                        }
+                        if (!tools_tumor_asked.isEmpty()) {
+                            error('The sample-sheet only contains normal-samples, but the following tools, which were requested with "--tools", expect at least one tumor-sample : ' + tools_tumor_asked.join(", "))
                         }
                     }
-                    if (!tools_tumor_asked.isEmpty()) {
-                        error('The sample-sheet only contains normal-samples, but the following tools, which were requested with "--tools", expect at least one tumor-sample : ' + tools_tumor_asked.join(", "))
-                    }
-                }
-            }
 
-        input_sample
-            .filter { sample -> sample[0].status == 0 }
-            .ifEmpty {
-                // In this case, the sample-sheet contains no normal/germline-samples
-                def tools_requiring_normal_samples = ['ascat', 'deepvariant', 'haplotypecaller', 'msisensorpro']
-                def requested_tools_requiring_normal_samples = []
-                tools_requiring_normal_samples.each { tool_requiring_normal_samples ->
-                    if (tools && tools.split(',').contains(tool_requiring_normal_samples)) {
-                        requested_tools_requiring_normal_samples.add(tool_requiring_normal_samples)
+                    // 2. the sample-sheet contains no normal/germline-samples
+                    if (!has_normal) {
+                        def tools_requiring_normal_samples = ['ascat', 'deepvariant', 'haplotypecaller', 'msisensorpro']
+                        def requested_tools_requiring_normal_samples = []
+                        tools_requiring_normal_samples.each { tool_requiring_normal_samples ->
+                            if (tools && tools.split(',').contains(tool_requiring_normal_samples)) {
+                                requested_tools_requiring_normal_samples.add(tool_requiring_normal_samples)
+                            }
+                        }
+                        if (!requested_tools_requiring_normal_samples.isEmpty()) {
+                            error('The sample-sheet only contains tumor-samples, but the following tools, which were requested by the option "tools", expect at least one normal-sample : ' + requested_tools_requiring_normal_samples.join(", "))
+                        }
                     }
-                }
-                if (!requested_tools_requiring_normal_samples.isEmpty()) {
-                    error('The sample-sheet only contains tumor-samples, but the following tools, which were requested by the option "tools", expect at least one normal-sample : ' + requested_tools_requiring_normal_samples.join(", "))
                 }
             }
     }


### PR DESCRIPTION
Some code from Claude to fix #1629 

I checked that the fix works in Sarek v3.9.0. (For reasons, I can't easily check that the fix works with dev.)

My tests:
```
$ sarek -profile test_full --snpeff_cache /ngc/people/andped/test_sarek
```
and that gave me the following on stdout:
```
[-        ] NFCORE_SAREK:PREPARE_GENOME:UNZIP_ALLELES                         -
[-        ] NFCORE_SAREK:PREPARE_GENOME:UNZIP_LOCI                            -
[-        ] NFCORE_SAREK:PREPARE_GENOME:UNZIP_GC                              -
[-        ] NFCORE_SAREK:PREPARE_GENOME:UNZIP_RT                              -
[-        ] NFCORE_SAREK:PREPARE_INTERVALS:CREATE_INTERVALS_BED               -
[-        ] NFCORE_SAREK:PREPARE_INTERVALS:TABIX_BGZIPTABIX_INTERVAL_SPLIT    -
[-        ] NFCORE_SAREK:PREPARE_INTERVALS:TABIX_BGZIPTABIX_INTERVAL_COMBINED -
[-        ] NFCORE_SAREK:PREPARE_REFERENCE_CNVKIT:CNVKIT_ANTITARGET           -
[-        ] NFCORE_SAREK:PREPARE_REFERENCE_CNVKIT:CNVKIT_REFERENCE            -
Path provided with SnpEff cache is invalid.
Make sure there is a directory named GRCh38.115 in /ngc/people/andped/test_sarek.
Please refer to https://nf-co.re/sarek/docs/usage/#how-to-customise-snpeff-and-vep-annotation for more information.
$ 
```
The log-file `.nextflow.log`also looks fine:
```
$ grep "Path provided with SnpEff cache is invalid" .nextflow.log
Jul-22 10:33:57.488 [main] DEBUG nextflow.Session - Session aborted -- Cause: Path provided with SnpEff cache is invalid.
nextflow.exception.WorkflowScriptErrorException: Path provided with SnpEff cache is invalid.
$ grep "The sample-sheet only contains" .nextflow.log
$
```

Next, I checked that the samplesheet-error-message is still given when needed, that is, I ran
```
$ sarek -profile test_full --input only_normal.csv --tools ascat
```
and I got
```
The sample-sheet only contains normal-samples, but the following tools, which were requested with "--tools", expect at least one tumor-sample : ascat
```
Those tests were done with the fix in Sarek v3.9.0. I expect the same results with the fix on `dev`.