### PR TITLE
Collect nf-test runtime reports

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -91,10 +91,20 @@ runs:
           $UPDATE_SNAPSHOT \
           --verbose \
           --tap=test.tap \
+          --csv=test-results.csv \
           --shard ${{ inputs.shard }}/${{ inputs.total_shards }}
 
           # Save the absolute path of the test.tap file to the output
           echo "tap_file_path=$(realpath test.tap)" >> $GITHUB_OUTPUT
+
+    - name: Upload nf-test runtime report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: nf-test-results-${{ inputs.profile }}-${{ env.NXF_VERSION }}-${{ inputs.shard }}
+        path: test-results.csv
+        if-no-files-found: warn
+        retention-days: 14
 
     # ---- update-snapshot mode: collect & upload regenerated snapshots ----
     # Only the canonical docker + pinned-Nextflow leg uploads, to avoid

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -178,6 +178,33 @@ jobs:
           path: pr-comment-fragments
           merge-multiple: true
 
+      - name: Download nf-test runtime reports
+        if: ${{ always() && needs.nf-test.result != 'skipped' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: nf-test-results-*
+          path: nf-test-runtime-reports
+
+      - name: Summarise nf-test runtimes
+        if: ${{ always() && needs.nf-test.result != 'skipped' }}
+        run: |
+          python tests/ci/summarise_runtimes.py \
+            nf-test-runtime-reports \
+            --csv nf-test-runtimes.csv \
+            --markdown nf-test-runtimes.md
+          cat nf-test-runtimes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload merged nf-test runtime report
+        if: ${{ always() && needs.nf-test.result != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: nf-test-runtimes
+          path: |
+            nf-test-runtimes.csv
+            nf-test-runtimes.md
+          if-no-files-found: warn
+          retention-days: 30
+
       # Build a comment for the shared pr-comment.yml poster to publish on the PR.
       # Based on the fragments above (not needs.*.result) so non-blocking failures are still reported.
       - name: Prepare PR comment

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -149,6 +149,9 @@ jobs:
       - runs-on=${{ github.run_id }}-confirm-pass
       - runner=2cpu-linux-x64
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - name: One or more tests failed (excluding latest-everything)
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1

--- a/tests/ci/summarise_runtimes.py
+++ b/tests/ci/summarise_runtimes.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+
+def read_reports(report_dir):
+    observations = defaultdict(list)
+    for report in sorted(Path(report_dir).rglob("*.csv")):
+        with report.open(newline="") as handle:
+            for row in csv.DictReader(handle):
+                if row.get("result") != "PASSED":
+                    continue
+                filename = Path(row["filename"])
+                try:
+                    filename = filename.relative_to(Path.cwd())
+                except ValueError:
+                    parts = filename.parts
+                    if "tests" in parts:
+                        filename = Path(*parts[parts.index("tests") :])
+                key = f"{filename}::{row['test']}"
+                observations[key].append(float(row["time"]))
+    return observations
+
+
+def summarise(observations):
+    rows = []
+    for key, durations in observations.items():
+        ordered = sorted(durations)
+        p75_index = max(0, int(0.75 * len(ordered) + 0.999999) - 1)
+        rows.append(
+            {
+                "test": key,
+                "observations": len(ordered),
+                "median_seconds": round(statistics.median(ordered), 3),
+                "p75_seconds": round(ordered[p75_index], 3),
+                "max_seconds": round(max(ordered), 3),
+            }
+        )
+    return sorted(rows, key=lambda row: (-row["p75_seconds"], row["test"]))
+
+
+def write_csv(rows, output):
+    fields = ["test", "observations", "median_seconds", "p75_seconds", "max_seconds"]
+    with Path(output).open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_markdown(rows, output):
+    total_seconds = sum(row["median_seconds"] for row in rows)
+    lines = [
+        "## nf-test runtime summary",
+        "",
+        f"Collected **{sum(row['observations'] for row in rows)}** observations for **{len(rows)}** tests ",
+        f"with **{total_seconds / 3600:.1f} runner-hours** of median execution time.",
+        "",
+        "| Test | Observations | Median | P75 | Maximum |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for row in rows[:20]:
+        test = row["test"].replace("|", "\\|")
+        lines.append(
+            f"| `{test}` | {row['observations']} | {row['median_seconds'] / 60:.1f} min | "
+            f"{row['p75_seconds'] / 60:.1f} min | {row['max_seconds'] / 60:.1f} min |"
+        )
+    Path(output).write_text("\n".join(lines) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Summarise nf-test CSV runtime reports")
+    parser.add_argument("report_dir")
+    parser.add_argument("--csv", required=True, dest="csv_output")
+    parser.add_argument("--markdown", required=True)
+    args = parser.parse_args()
+
+    rows = summarise(read_reports(args.report_dir))
+    if not rows:
+        parser.error(f"no passing nf-test observations found in {args.report_dir}")
+    write_csv(rows, args.csv_output)
+    write_markdown(rows, args.markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/test_summarise_runtimes.py
+++ b/tests/ci/test_summarise_runtimes.py
@@ -1,0 +1,69 @@
+import csv
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("summarise_runtimes.py")
+SPEC = importlib.util.spec_from_file_location("summarise_runtimes", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class SummariseRuntimesTest(unittest.TestCase):
+    def test_summarises_passing_observations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "results.csv"
+            with report.open("w", newline="") as handle:
+                writer = csv.DictWriter(
+                    handle,
+                    fieldnames=["filename", "testsuite", "type", "test", "result", "start", "end", "time"],
+                )
+                writer.writeheader()
+                writer.writerows(
+                    [
+                        {
+                            "filename": "/workspace/tests/example.nf.test",
+                            "testsuite": "Test pipeline",
+                            "type": "PipelineTestSuite",
+                            "test": "example",
+                            "result": "PASSED",
+                            "start": "0",
+                            "end": "1000",
+                            "time": "1.0",
+                        },
+                        {
+                            "filename": "/workspace/tests/example.nf.test",
+                            "testsuite": "Test pipeline",
+                            "type": "PipelineTestSuite",
+                            "test": "example",
+                            "result": "PASSED",
+                            "start": "0",
+                            "end": "3000",
+                            "time": "3.0",
+                        },
+                        {
+                            "filename": "/workspace/tests/example.nf.test",
+                            "testsuite": "Test pipeline",
+                            "type": "PipelineTestSuite",
+                            "test": "ignored failure",
+                            "result": "FAILED",
+                            "start": "0",
+                            "end": "9000",
+                            "time": "9.0",
+                        },
+                    ]
+                )
+
+            rows = MODULE.summarise(MODULE.read_reports(directory))
+
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["test"], "tests/example.nf.test::example")
+            self.assertEqual(rows[0]["observations"], 2)
+            self.assertEqual(rows[0]["median_seconds"], 2.0)
+            self.assertEqual(rows[0]["p75_seconds"], 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Collect each nf-test job's CSV report as a short-lived artifact.
- Merge successful observations into stable per-test median, P75 and maximum runtimes.
- Publish a concise slow-test table in the workflow summary and a machine-readable artifact for later shard planning.

## Why

The current suite has a long and uneven tail, but the workflow does not retain enough timing data to tune it safely. This PR adds measurement only; it does not remove tests or change required coverage.

## Impact

This is the first PR in a stack. The next PR consumes the generated timing format to balance CPU shards by expected runtime.

Generated by Codex

## Checks

- `python -m unittest tests/ci/test_summarise_runtimes.py`
- `python -m py_compile tests/ci/summarise_runtimes.py tests/ci/test_summarise_runtimes.py`
- `prek run`
- `nf-core pipelines lint`
- Full nf-test execution is intentionally delegated to this draft PR's matrix because the local all-tests run did not complete in a useful time window.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
