### PR TITLE
Balance nf-test shards by runtime

### DIFF
--- a/.github/actions/get-shards/action.yml
+++ b/.github/actions/get-shards/action.yml
@@ -21,6 +21,9 @@ outputs:
   total_shards:
     description: "Total number of shards"
     value: ${{ steps.shards.outputs.total_shards }}
+  weighted_shard:
+    description: "Weighted shard assignments with explicit nf-test selectors"
+    value: ${{ steps.shards.outputs.weighted_shard }}
 runs:
   using: "composite"
   steps:
@@ -37,32 +40,42 @@ runs:
         # not just those changed since HEAD^.
         CHANGED_SINCE="--changed-since HEAD^"
         if [ "${{ inputs.all_tests }}" = "true" ]; then CHANGED_SINCE=""; fi
-        nftest_output=$(nf-test test \
+        set +e
+        nf-test test \
           --profile +docker \
           $(if [ -n "${{ inputs.tags }}" ]; then echo "--tag ${{ inputs.tags }}"; fi) \
           --dry-run \
+          --csv nf-test-discovery.csv \
           --ci \
-          $CHANGED_SINCE) || {
-            echo "nf-test command failed with exit code $?"
-            echo "Full output: $nftest_output"
+          $CHANGED_SINCE > nf-test-dry-run.log 2>&1
+        nftest_status=$?
+        set -e
+        cat nf-test-dry-run.log
+        if [ "$nftest_status" -ne 0 ]; then
+            echo "nf-test command failed with exit code $nftest_status"
             exit 1
-        }
-        echo "nf-test dry-run output: $nftest_output"
+        fi
 
         # Default values for shard and total_shards
         shard="[]"
+        weighted_shard="[]"
         total_shards=0
 
         # Check if there are related tests
-        if echo "$nftest_output" | grep -q 'No tests to execute'; then
+        if grep -q 'No tests to execute' nf-test-dry-run.log; then
           echo "No related tests found."
         else
           # Extract the number of related tests
-          number_of_shards=$(echo "$nftest_output" | sed -n 's|.*Executed \([0-9]*\) tests.*|\1|p')
+          number_of_shards=$(sed -n 's|.*Executed \([0-9]*\) tests.*|\1|p' nf-test-dry-run.log)
           if [[ -n "$number_of_shards" && "$number_of_shards" -gt 0 ]]; then
             shards_to_run=$(( $number_of_shards < ${{ inputs.max_shards }} ? $number_of_shards : ${{ inputs.max_shards }} ))
             shard=$(seq 1 "$shards_to_run" | jq -R . | jq -c -s .)
             total_shards="$shards_to_run"
+            weighted_shard=$(python tests/ci/plan_weighted_shards.py \
+              --discovery-csv nf-test-discovery.csv \
+              --dry-run-log nf-test-dry-run.log \
+              --weights tests/ci/runtime-weights.csv \
+              --shards "$shards_to_run")
           else
             echo "Unexpected output format. Falling back to default values."
           fi
@@ -71,7 +84,9 @@ runs:
         # Write to GitHub Actions outputs
         echo "shard=$shard" >> $GITHUB_OUTPUT
         echo "total_shards=$total_shards" >> $GITHUB_OUTPUT
+        echo "weighted_shard=$weighted_shard" >> $GITHUB_OUTPUT
 
         # Debugging output
         echo "Final shard array: $shard"
+        echo "Final weighted shard assignments: $weighted_shard"
         echo "Total number of shards: $total_shards"

--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: "Run with --update-snapshot over all tagged tests and upload regenerated snapshots as artifacts"
     required: false
     default: "false"
+  selectors:
+    description: "Space-separated explicit nf-test path@hash selectors"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -74,11 +77,17 @@ runs:
         NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
         SENTIEON_LICSRVR_IP: ${{ env.SENTIEON_LICSRVR_IP }}
         SENTIEON_AUTH_MECH: "GitHub Actions - token"
+        TEST_SELECTORS: ${{ inputs.selectors }}
       run: |
         # In update-snapshot mode, regenerate snapshots over ALL tagged tests
         # (drop --changed-since, which is only meaningful for PR/push diffs).
         CHANGED_SINCE="--changed-since HEAD^"
         UPDATE_SNAPSHOT=""
+        SHARD_OPTION="--shard ${{ inputs.shard }}/${{ inputs.total_shards }}"
+        if [ -n "$TEST_SELECTORS" ]; then
+          CHANGED_SINCE=""
+          SHARD_OPTION=""
+        fi
         if [ "${{ inputs.update_snapshots }}" = "true" ]; then
           CHANGED_SINCE=""
           UPDATE_SNAPSHOT="--update-snapshot"
@@ -92,7 +101,8 @@ runs:
           --verbose \
           --tap=test.tap \
           --csv=test-results.csv \
-          --shard ${{ inputs.shard }}/${{ inputs.total_shards }}
+          $SHARD_OPTION \
+          $TEST_SELECTORS
 
           # Save the absolute path of the test.tap file to the output
           echo "tap_file_path=$(realpath test.tap)" >> $GITHUB_OUTPUT

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -37,6 +37,7 @@ jobs:
       - runner=4cpu-linux-x64
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
+      weighted_shard: ${{ steps.set-shards.outputs.weighted_shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
     steps:
       - name: Clean Workspace # Purge the workspace in case it's running on a self-hosted runner
@@ -65,7 +66,7 @@ jobs:
           echo ${{ steps.set-shards.outputs.total_shards }}
 
   nf-test:
-    name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.shard }}/${{ needs.nf-test-changes.outputs.total_shards }}"
+    name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.assignment.index }}/${{ needs.nf-test-changes.outputs.total_shards }}"
     needs: [nf-test-changes]
     if: ${{ needs.nf-test-changes.outputs.total_shards != '0' }}
     runs-on: # use self-hosted runners
@@ -75,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
+        assignment: ${{ fromJson(needs.nf-test-changes.outputs.weighted_shard) }}
         profile: [conda, docker, singularity]
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
@@ -106,8 +107,9 @@ jobs:
           NXF_VERSION: ${{ matrix.NXF_VER }}
         with:
           profile: ${{ matrix.profile }}
-          shard: ${{ matrix.shard }}
+          shard: ${{ matrix.assignment.index }}
           total_shards: ${{ env.TOTAL_SHARDS }}
+          selectors: ${{ join(matrix.assignment.selectors, ' ') }}
           tags: ${{ matrix.profile == 'conda' && 'cpu_conda' || 'cpu,cpu_conda' }}
           update_snapshots: ${{ github.event.inputs.update_snapshots || 'false' }}
 
@@ -117,7 +119,7 @@ jobs:
           if [[ "${{ steps.run_nf_test.outcome }}" == "failure" ]]; then
             echo "::error::Test with ${{ matrix.NXF_VER }} failed"
             # Add to workflow summary
-            echo "## ❌ Test failed: ${{ matrix.profile }} | ${{ matrix.NXF_VER }} | Shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}" >> $GITHUB_STEP_SUMMARY
+            echo "## ❌ Test failed: ${{ matrix.profile }} | ${{ matrix.NXF_VER }} | Shard ${{ matrix.assignment.index }}/${{ env.TOTAL_SHARDS }}" >> $GITHUB_STEP_SUMMARY
             if [[ "${{ matrix.NXF_VER }}" == "latest-everything" ]]; then
               echo "::warning::Test with latest-everything failed but will not cause workflow failure. Please check if the error is expected or if it needs fixing."
             fi
@@ -133,7 +135,7 @@ jobs:
         if: ${{ always() && steps.run_nf_test.outcome == 'failure' && matrix.NXF_VER == 'latest-everything' }}
         run: |
           mkdir -p pr-comment-fragment
-          echo "* ❌ \`${{ matrix.profile }}\` | \`${{ matrix.NXF_VER }}\` | Shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}" > pr-comment-fragment/fragment.md
+          echo "* ❌ \`${{ matrix.profile }}\` | \`${{ matrix.NXF_VER }}\` | Shard ${{ matrix.assignment.index }}/${{ env.TOTAL_SHARDS }}" > pr-comment-fragment/fragment.md
 
       - name: Upload PR comment fragment
         if: ${{ always() && steps.run_nf_test.outcome == 'failure' && matrix.NXF_VER == 'latest-everything' }}
@@ -149,6 +151,9 @@ jobs:
       - runs-on=${{ github.run_id }}-confirm-pass
       - runner=2cpu-linux-x64
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - name: One or more tests failed (excluding latest-everything)
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1

--- a/tests/ci/plan_weighted_shards.py
+++ b/tests/ci/plan_weighted_shards.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+HASH_PATTERN = re.compile(r"\bTest\b.*\[([0-9a-f]{8})\]")
+
+
+def normalise_path(filename):
+    path = Path(filename)
+    parts = path.parts
+    if "tests" in parts:
+        return Path(*parts[parts.index("tests") :]).as_posix()
+    return path.as_posix()
+
+
+def read_discovery(discovery_csv, dry_run_log):
+    with Path(discovery_csv).open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    hashes = []
+    for line in Path(dry_run_log).read_text().splitlines():
+        match = HASH_PATTERN.search(ANSI_ESCAPE.sub("", line))
+        if match:
+            hashes.append(match.group(1))
+
+    if len(rows) != len(hashes):
+        raise ValueError(f"discovery CSV contains {len(rows)} tests but dry-run log contains {len(hashes)} hashes")
+
+    tests = []
+    for row, test_hash in zip(rows, hashes, strict=True):
+        path = normalise_path(row["filename"])
+        tests.append(
+            {
+                "key": f"{path}::{row['test']}",
+                "selector": f"{path}@{test_hash}",
+            }
+        )
+    return tests
+
+
+def read_weights(weights_csv):
+    with Path(weights_csv).open(newline="") as handle:
+        return {row["test"]: float(row["p75_seconds"]) for row in csv.DictReader(handle)}
+
+
+def assign_shards(tests, weights, shard_count, default_weight=None):
+    known_weights = sorted(weights.values())
+    if default_weight is None:
+        default_weight = known_weights[len(known_weights) * 3 // 4] if known_weights else 120.0
+
+    weighted_tests = [
+        (weights.get(test["key"], default_weight), test["selector"])
+        for test in tests
+    ]
+    weighted_tests.sort(key=lambda item: (-item[0], item[1]))
+
+    shards = [{"index": index + 1, "estimated_seconds": 0.0, "selectors": []} for index in range(shard_count)]
+    for weight, selector in weighted_tests:
+        shard = min(shards, key=lambda item: (item["estimated_seconds"], item["index"]))
+        shard["selectors"].append(selector)
+        shard["estimated_seconds"] += weight
+
+    for shard in shards:
+        shard["estimated_seconds"] = round(shard["estimated_seconds"], 3)
+    return shards
+
+
+def validate_assignments(tests, shards):
+    expected = sorted(test["selector"] for test in tests)
+    assigned = sorted(selector for shard in shards for selector in shard["selectors"])
+    if assigned != expected:
+        raise ValueError("weighted shard assignments do not match discovered tests")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create duration-weighted nf-test shards")
+    parser.add_argument("--discovery-csv", required=True)
+    parser.add_argument("--dry-run-log", required=True)
+    parser.add_argument("--weights", required=True)
+    parser.add_argument("--shards", required=True, type=int)
+    args = parser.parse_args()
+
+    tests = read_discovery(args.discovery_csv, args.dry_run_log)
+    shards = assign_shards(tests, read_weights(args.weights), args.shards)
+    validate_assignments(tests, shards)
+    print(json.dumps(shards, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/runtime-weights.csv
+++ b/tests/ci/runtime-weights.csv
@@ -1,0 +1,9 @@
+test,p75_seconds
+tests/joint_calling_mutect2.nf.test::-profile test --input tests/csv/3.0/recalibrated_tumoronly_joint.csv --tools mutect2 --joint_mutect2,1331.545
+tests/variant_calling_mutect2.nf.test::-profile test --tools mutect2 somatic --no_intervals,266.769
+tests/aligner-bwa-mem2.nf.test::-profile test --aligner bwa-mem2 --save_reference skip QC/recal/md,245.675
+tests/umi_in_read_names.nf.test::-profile test --input tests/csv/3.0/bam_umi_header.csv --umi_in_read_header --tools markduplicates --step markduplicates,171.250
+tests/variant_calling_deepvariant.nf.test::-profile test --tools deepvariant --input tests/csv/3.0/mapped_single_cram.csv --no_intervals,115.644
+tests/qc_ngscheckmate.nf.test::-profile test --tools ngscheckmate,73.883
+tests/variant_calling_manta.nf.test::-profile test --tools manta --no_intervals germline,66.014
+tests/start_from_preparerecalibration.nf.test::-profile test --input tests/csv/3.0/mapped_single_bam.csv --step prepare_recalibration --tools null,65.047

--- a/tests/ci/test_plan_weighted_shards.py
+++ b/tests/ci/test_plan_weighted_shards.py
@@ -1,0 +1,56 @@
+import csv
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("plan_weighted_shards.py")
+SPEC = importlib.util.spec_from_file_location("plan_weighted_shards", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class PlanWeightedShardsTest(unittest.TestCase):
+    def test_pairs_discovery_rows_with_hashes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            discovery = Path(directory) / "discovery.csv"
+            log = Path(directory) / "dry-run.log"
+            with discovery.open("w", newline="") as handle:
+                writer = csv.DictWriter(handle, fieldnames=["filename", "test"])
+                writer.writeheader()
+                writer.writerow({"filename": "/workspace/tests/example.nf.test", "test": "first test"})
+                writer.writerow({"filename": "/workspace/tests/example.nf.test", "test": "second test"})
+            log.write_text("Test [1234abcd] 'first test' PASSED\nTest [9876fedc] 'second test' PASSED\n")
+
+            tests = MODULE.read_discovery(discovery, log)
+
+            self.assertEqual(tests[0]["selector"], "tests/example.nf.test@1234abcd")
+            self.assertEqual(tests[1]["key"], "tests/example.nf.test::second test")
+
+    def test_assigns_longest_tests_to_different_shards(self):
+        tests = [
+            {"key": "slow", "selector": "tests/a.nf.test@11111111"},
+            {"key": "medium", "selector": "tests/b.nf.test@22222222"},
+            {"key": "fast", "selector": "tests/c.nf.test@33333333"},
+        ]
+
+        shards = MODULE.assign_shards(tests, {"slow": 10, "medium": 6, "fast": 4}, 2)
+
+        MODULE.validate_assignments(tests, shards)
+        self.assertEqual(shards[0]["estimated_seconds"], 10)
+        self.assertEqual(shards[1]["estimated_seconds"], 10)
+
+    def test_rejects_mismatched_discovery_sources(self):
+        with tempfile.TemporaryDirectory() as directory:
+            discovery = Path(directory) / "discovery.csv"
+            log = Path(directory) / "dry-run.log"
+            discovery.write_text("filename,test\n/workspace/tests/example.nf.test,example\n")
+            log.write_text("")
+
+            with self.assertRaisesRegex(ValueError, "1 tests.*0 hashes"):
+                MODULE.read_discovery(discovery, log)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Discover concrete nf-test `path@hash` selectors before building the CPU matrix.
- Use a longest-processing-time-first planner to assign slower tests to the currently lightest shard.
- Seed the planner with representative P75 runtimes and use a conservative fallback for unknown tests.
- Preserve the existing numeric shard output for GPU and Sentieon jobs.

## Why

Equal test counts do not produce equal wall times. A few long tests dominate the tail, leaving most runners idle while the slowest shard finishes. Runtime weighting shortens that tail without skipping tests or reducing the profile and Nextflow-version matrix.

## Stack

- Base: #2265
- This PR contains only the weighted-sharding layer when reviewed against `codex/ci-test-observability`.

Generated by Codex

## Checks

- Full dry-run discovery found 136 CPU tests; the planner assigned all 136 exactly once across 15 shards.
- Seed-data estimates ranged from 2,401 to 2,551 seconds per shard.
- An explicit `path@hash` selector executed exactly one test successfully with Docker and Nextflow 25.10.4.
- `python -m unittest tests/ci/test_plan_weighted_shards.py tests/ci/test_summarise_runtimes.py`
- `python -m py_compile tests/ci/plan_weighted_shards.py tests/ci/test_plan_weighted_shards.py`
- `prek run`
- `nf-core pipelines lint`

## Trade-offs

- Historical data can drift. Unknown tests therefore receive a conservative P75 fallback, and #2265 publishes fresh timings for periodic updates.
- Explicit selector lists increase matrix JSON size, but the current 136-test suite remains comfortably within GitHub output limits.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the full test suite passes in this draft PR's matrix.
