### PR TITLE
Require CPU stub topology tests

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -23,6 +23,18 @@ inputs:
   selectors:
     description: "Space-separated explicit nf-test path@hash selectors"
     required: false
+  all_tests:
+    description: "Run all tagged tests instead of filtering against HEAD^"
+    required: false
+    default: "false"
+  minimum_tests:
+    description: "Fail if fewer tests than this value are reported"
+    required: false
+    default: "0"
+  artifact_suffix:
+    description: "Suffix used to keep runtime-report artifact names unique"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -88,6 +100,9 @@ runs:
           CHANGED_SINCE=""
           SHARD_OPTION=""
         fi
+        if [ "${{ inputs.all_tests }}" = "true" ]; then
+          CHANGED_SINCE=""
+        fi
         if [ "${{ inputs.update_snapshots }}" = "true" ]; then
           CHANGED_SINCE=""
           UPDATE_SNAPSHOT="--update-snapshot"
@@ -104,6 +119,13 @@ runs:
           $SHARD_OPTION \
           $TEST_SELECTORS
 
+          test_count=$(python -c "import csv; print(sum(1 for _ in csv.DictReader(open('test-results.csv'))))")
+          echo "nf-test reported $test_count tests"
+          if [ "$test_count" -lt "${{ inputs.minimum_tests }}" ]; then
+            echo "Expected at least ${{ inputs.minimum_tests }} tests, but nf-test reported $test_count"
+            exit 1
+          fi
+
           # Save the absolute path of the test.tap file to the output
           echo "tap_file_path=$(realpath test.tap)" >> $GITHUB_OUTPUT
 
@@ -111,7 +133,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: nf-test-results-${{ inputs.profile }}-${{ env.NXF_VERSION }}-${{ inputs.shard }}
+        name: nf-test-results-${{ inputs.profile }}-${{ env.NXF_VERSION }}-${{ inputs.shard }}${{ inputs.artifact_suffix }}
         path: test-results.csv
         if-no-files-found: warn
         retention-days: 14

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -144,8 +144,33 @@ jobs:
           name: pr-comment-fragment-${{ strategy.job-index }}
           path: pr-comment-fragment/
 
+  nf-test-stub:
+    name: "Stub topology | docker | 25.10.4"
+    runs-on:
+      - runs-on=${{ github.run_id }}-nf-test-stub
+      - runner=4cpu-linux-x64
+      - volume=80gb
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Run all CPU stub scenarios
+        uses: ./.github/actions/nf-test
+        env:
+          NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
+          NXF_VERSION: "25.10.4"
+        with:
+          profile: docker
+          shard: 1
+          total_shards: 1
+          tags: "cpu_stub,cpu_conda_stub"
+          all_tests: true
+          minimum_tests: 22
+          artifact_suffix: "-stub"
+
   confirm-pass:
-    needs: [nf-test]
+    needs: [nf-test, nf-test-stub]
     if: always()
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-confirm-pass
@@ -184,14 +209,14 @@ jobs:
           merge-multiple: true
 
       - name: Download nf-test runtime reports
-        if: ${{ always() && needs.nf-test.result != 'skipped' }}
+        if: ${{ always() && (needs.nf-test.result != 'skipped' || needs.nf-test-stub.result != 'skipped') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: nf-test-results-*
           path: nf-test-runtime-reports
 
       - name: Summarise nf-test runtimes
-        if: ${{ always() && needs.nf-test.result != 'skipped' }}
+        if: ${{ always() && (needs.nf-test.result != 'skipped' || needs.nf-test-stub.result != 'skipped') }}
         run: |
           python tests/ci/summarise_runtimes.py \
             nf-test-runtime-reports \
@@ -200,7 +225,7 @@ jobs:
           cat nf-test-runtimes.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload merged nf-test runtime report
-        if: ${{ always() && needs.nf-test.result != 'skipped' }}
+        if: ${{ always() && (needs.nf-test.result != 'skipped' || needs.nf-test-stub.result != 'skipped') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nf-test-runtimes


### PR DESCRIPTION
## What changed

- Add one required Docker job that runs every existing CPU stub scenario on pinned Nextflow 25.10.4.
- Bypass changed-test filtering for this lane so pipeline topology is checked on every relevant workflow run.
- Require at least 22 reported stub tests to prevent the lane silently losing coverage.
- Give the stub runtime artifact a unique name and include its timings in the merged report.

## Why

Stub execution provides a comparatively cheap integration check for pipeline composition, module loading and channel wiring. It can catch issues such as deprecated or missing modules without adding another full data-processing matrix. The regular nf-tests remain unchanged, so this adds coverage rather than replacing it.

## Stack

- Base: #2266
- Parent: #2265
- This PR contains only the required stub-lane layer when reviewed against `codex/ci-weighted-sharding`.

Generated by Codex

## Checks

- Stub dry-run discovered 22 scenarios across 13 test files.
- The minimum-count guard was exercised against the generated CSV.
- `prek run`
- `nf-core pipelines lint`
- Full local Docker execution was attempted, but this ARM host failed while launching an amd64 container (`bash: .command.run: No such file or directory`). The draft PR's x64 runner is the authoritative execution check.

## Trade-offs

- This adds one pinned-Docker runner rather than multiplying stubs across profiles and Nextflow versions.
- It validates only paths with existing stub scenarios. Scatter/gather expansion remains follow-up work because realistic fan-out and fan-in channels need purpose-built fixtures.
- The count guard must be raised when new stub scenarios are added intentionally.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the full stub lane passes on this draft PR's x64 runner.
